### PR TITLE
Fix Few-Shot WavLM WebGPU errors + missing Start button

### DIFF
--- a/docs/modules/kws.md
+++ b/docs/modules/kws.md
@@ -277,6 +277,15 @@ All parameters are surfaced in the **Studio config panel** with the defaults bel
   rejects; UI shows "KWS inference unavailable in this browser."
 - **WebGPU unavailable:** automatic fallback to WASM execution provider; UI shows
   a "performance" indicator (WASM is slower).
+- **WavLM embedder (Few-Shot / Phase 3):** the WavLM ONNX graph contains ops
+  (notably `Concat` with int64 shape tensors) that onnxruntime-web's WebGPU EP
+  fails to compile, raising a cascade of `Invalid ComputePipeline "Concat"`
+  WebGPU validation errors at `run()` time. The `WavLMEmbedProvider` is
+  therefore pinned to the **WASM** execution provider regardless of the
+  configured `executionProvider`. The reported EP is `wasm` whenever only the
+  WavLM embedder is loaded; OpenWakeWord detection backends still use WebGPU
+  where available. (Fix: force WASM for the embedder, report `wasm` as the
+  effective EP in the few-shot-only case.)
 - **Inference slower than realtime** (frame underrun): drop the oldest frames,
   log a warning, surface via the score-curve (gaps); never block the audio thread.
 - **WavLM too large for browser memory** (Phase 3 concern): `embed()` rejects with

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,13 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      // Allow intentionally-unused params prefixed with '_' (e.g. interface-
+      // mandated params that are deliberately ignored, like the WavLM
+      // embedder's 'provider' arg it pins to WASM).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
     },
   },
   {

--- a/src/components/FewShotPanel.tsx
+++ b/src/components/FewShotPanel.tsx
@@ -239,13 +239,20 @@ export const FewShotPanel = memo(function FewShotPanel({
             {building ? 'Building…' : `Build prototype (${samples.length} samples)`}
           </button>
         )}
-        {encoderReady && prototype && !detecting && afeRunning && (
-          <button
-            onClick={handleStartDetection}
-            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
-          >
-            Start Few-Shot detection
-          </button>
+        {encoderReady && prototype && !detecting && (
+          <>
+            <button
+              onClick={handleStartDetection}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+            >
+              Start Few-Shot detection
+            </button>
+            {!afeRunning && (
+              <span className="text-sm text-amber-400">
+                Start the AFE microphone (top panel) first, then click above.
+              </span>
+            )}
+          </>
         )}
         {detecting && (
           <button

--- a/src/kws/backends/wavlm-embed.ts
+++ b/src/kws/backends/wavlm-embed.ts
@@ -14,7 +14,15 @@
  * Input normalization: the Wav2Vec2FeatureExtractor normalizes per-utterance
  * (zero-mean, unit-variance). We apply the same so embeddings match training.
  *
+ * Execution provider: WavLM is **always run on WASM (CPU)**, not WebGPU. Its
+ * ONNX graph contains ops (notably `Concat` with int64 shape tensors) that
+ * onnxruntime-web's WebGPU EP fails to compile, raising a cascade of
+ * "Invalid ComputePipeline \"Concat\"" validation errors at `run()` time.
+ * WASM executes the same graph correctly. The OpenWakeWord detection backends
+ * still use WebGPU where supported; only the WavLM embedder is pinned to WASM.
+ *
  * @see docs/modules/kws.md §4 (EmbedProvider), §5 (Few-Shot scaffold)
+ * @see docs/modules/kws.md §7 (error model / WebGPU fallback)
  */
 
 import * as ort from 'onnxruntime-web'
@@ -48,7 +56,7 @@ export class WavLMEmbedProvider implements EmbedProvider {
     return this._session !== null
   }
 
-  async load(url: string, provider: 'webgpu' | 'wasm'): Promise<void> {
+  async load(url: string, _provider: 'webgpu' | 'wasm'): Promise<void> {
     const response = await fetch(url)
     if (!response.ok) {
       throw new Error(
@@ -56,8 +64,12 @@ export class WavLMEmbedProvider implements EmbedProvider {
       )
     }
     const buffer = await response.arrayBuffer()
+    // Force WASM only. The `provider` arg is intentionally ignored (see the
+    // class docstring): this model's graph is incompatible with ORT-Web's
+    // WebGPU EP and would otherwise fail with "Invalid ComputePipeline
+    // 'Concat'" validation errors during run().
     this._session = await ort.InferenceSession.create(buffer, {
-      executionProviders: provider === 'webgpu' ? ['webgpu', 'wasm'] : ['wasm'],
+      executionProviders: ['wasm'],
     })
   }
 

--- a/src/kws/worker.ts
+++ b/src/kws/worker.ts
@@ -104,6 +104,13 @@ async function handleLoad(
       }
     }
 
+    // Tracks whether a GPU-capable detection backend was actually loaded. The
+    // WavLM embedder is always pinned to WASM (its ONNX graph is incompatible
+    // with ORT-Web's WebGPU EP - see WavLMEmbedProvider). So the EP reported
+    // to the UI is only 'webgpu' when a WebGPU-feasible detection backend is
+    // loaded; otherwise it is 'wasm' even if WebGPU is available.
+    let gpuBackendLoaded = false
+
     if (backendId === 'wavlm-few-shot') {
       // Few-Shot backend: reuse the shared WavLM embedProvider + the prototype.
       if (!embedProvider || !embedProvider.ready) {
@@ -138,10 +145,16 @@ async function handleLoad(
       if (hasDetectionUrls) {
         backend = createBackend(backendId)
         await backend.load(urls, actualExecutionProvider)
+        // OpenWakeWord (and similar) actually exercise the WebGPU EP.
+        gpuBackendLoaded = true
       }
     }
 
-    post({ type: 'loaded', executionProvider: actualExecutionProvider })
+    const reportedEp: 'webgpu' | 'wasm' =
+      actualExecutionProvider === 'webgpu' && gpuBackendLoaded
+        ? 'webgpu'
+        : 'wasm'
+    post({ type: 'loaded', executionProvider: reportedEp })
   } catch (err) {
     postError(
       `Model load failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

Two Few-Shot fixes:

1. **WavLM WebGPU "Invalid ComputePipeline Concat" errors.** The WavLM ONNX graph (`Xenova/wavlm-base-plus-sv`) contains ops (notably `Concat` with int64 shape tensors) that onnxruntime-web's WebGPU EP fails to compile, raising a cascade of `Invalid ComputePipeline "Concat"` WebGPU validation errors at `run()` time (these are uncaptured async errors, so they silently broke inference). `WavLMEmbedProvider` is now pinned to the **WASM** execution provider regardless of the configured `executionProvider`. OpenWakeWord detection backends keep using WebGPU where available. The worker reports `wasm` as the effective EP when only the WavLM embedder is loaded, so the UI indicator stays accurate.

2. **Missing "Start Few-Shot detection" button.** The button's render condition required `afeRunning` (the AFE mic must already be running), so after building a prototype with the mic stopped the Start button never appeared. The condition now shows the button once a prototype is built (independent of AFE state) and adds a hint to start the mic first.

## Changes

- `src/kws/backends/wavlm-embed.ts` — force WASM EP for WavLM; document why.
- `src/kws/worker.ts` — report effective EP as `wasm` in the few-shot-only case.
- `src/components/FewShotPanel.tsx` — show Start button when prototype ready; add AFE-not-running hint.
- `docs/modules/kws.md` — document the WavLM/WebGPU incompatibility (§7).

## Test plan

- [ ] Embed/enroll a sample and build a prototype (no WebGPU errors in console).
- [ ] Start detection with AFE running — score curve renders.
- [ ] Build prototype with AFE stopped — Start button is visible with the hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)