### PR TITLE
Fix PLiX ONNX export workflow (opset, deps, release step)

### DIFF
--- a/.github/workflows/export-plixkws.yml
+++ b/.github/workflows/export-plixkws.yml
@@ -5,8 +5,8 @@ name: Export PLiX ONNX
 # Why a workflow (not local conversion): per AGENTS.md, Python dependencies
 # (torch / torchaudio / timm) must not be installed on the developer machine,
 # and `main` is protected (no auto-push). This workflow runs the conversion in
-# CI and publishes the result as a **downloadable artifact** (and optionally a
-# GitHub Release asset) - it never commits or pushes to the repo.
+# CI and publishes the result as a **downloadable artifact** - it never commits
+# or pushes to the repo.
 #
 # The exported weights are intentionally NOT committed: `prebuilts/` is
 # gitignored (ADR-011 - dev-only / model artifacts are never bundled). The
@@ -41,11 +41,6 @@ on:
         required: false
         default: '18'
         type: string
-      upload_release:
-        description: 'Also attach artifacts to a GitHub Release (plixkws-models)'
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: export-plixkws-${{ github.actor }}-${{ github.event.inputs.encoder }}-${{ github.event.inputs.language }}
@@ -112,16 +107,3 @@ jobs:
           name: plixkws-${{ github.event.inputs.encoder }}-${{ github.event.inputs.language }}
           path: prebuilts/plixkws/**
           retention-days: 30
-
-      - name: Attach to Release (optional)
-        if: ${{ github.event.inputs.upload_release == 'true' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: plixkws-models
-          name: PLiX ONNX models
-          files: |
-            prebuilts/plixkws/plixkws-${{ github.event.inputs.encoder }}.onnx
-            prebuilts/plixkws/hf/plixkws/config.json
-            prebuilts/plixkws/hf/plixkws/onnx/model.onnx
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/export-plixkws.yml
+++ b/.github/workflows/export-plixkws.yml
@@ -68,12 +68,13 @@ jobs:
           python-version: '3.11'
 
       - name: Install conversion toolchain
-        # `plixkws` pulls torch, torchaudio, timm. `wget` is used by the script
-        # to fetch config.json + the Dropbox .pt weights. CPU torch is enough
-        # for tracing the export graph.
+        # `plixkws` pulls torch, torchaudio, timm. `wget` fetches the Dropbox
+        # .pt weights. `onnx` + `onnxscript` are required by torch's modern
+        # (torch.export-based) ONNX exporter used by the export script.
+        # CPU torch is enough for tracing the export graph.
         run: |
           python -m pip install --no-cache-dir --upgrade pip
-          python -m pip install --no-cache-dir plixkws wget
+          python -m pip install --no-cache-dir plixkws wget onnx onnxscript
 
       - name: Download PLiX config manifest
         # Fetch the published PLiX config.json (Dropbox) into

--- a/.github/workflows/export-plixkws.yml
+++ b/.github/workflows/export-plixkws.yml
@@ -37,9 +37,9 @@ on:
         default: 'en'
         type: string
       opset:
-        description: 'ONNX opset version'
+        description: 'ONNX opset version (must be >= 18 for the modern exporter)'
         required: false
-        default: '17'
+        default: '18'
         type: string
       upload_release:
         description: 'Also attach artifacts to a GitHub Release (plixkws-models)'
@@ -117,7 +117,8 @@ jobs:
         if: ${{ github.event.inputs.upload_release == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
-          tag: plixkws-models
+          tag_name: plixkws-models
+          name: PLiX ONNX models
           files: |
             prebuilts/plixkws/plixkws-${{ github.event.inputs.encoder }}.onnx
             prebuilts/plixkws/hf/plixkws/config.json

--- a/scripts/export-plixkws-onnx.py
+++ b/scripts/export-plixkws-onnx.py
@@ -169,6 +169,10 @@ def main() -> None:
     dummy = torch.randn(1, 1, 64, 100, device=device)
 
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    # Use the TorchScript (legacy) ONNX exporter: it does not require the
+    # `onnxscript` package that the newer dynamo exporter needs, and it handles
+    # a traced CNN trunk like PLiX cleanly. The dummy input is a concrete
+    # 1x1x64x100 tensor, so tracing is exact.
     torch.onnx.export(
         trunk,
         dummy,
@@ -177,6 +181,7 @@ def main() -> None:
         output_names=["embeddings"],
         dynamic_axes={"input": {0: "batch"}},
         opset_version=args.opset,
+        dynamo=False,
     )
     print(f"Exported {args.encoder}/{language} encoder -> {args.out}")
 

--- a/scripts/export-plixkws-onnx.py
+++ b/scripts/export-plixkws-onnx.py
@@ -174,14 +174,20 @@ def main() -> None:
     # Use the modern torch.export-based ONNX exporter (torch >= 2.9 default).
     # It requires the `onnx` and `onnxscript` packages, which the CI workflow
     # installs. The dummy input is a concrete 1x1x64x100 tensor, so the export
-    # is exact. (The legacy TorchScript exporter is deprecated.)
+    # is exact.
+    #
+    # Opset must be >= 18: the modern exporter only has implementations for
+    # opset 18+, and exporting at 17 then down-converting fails on some ops
+    # (e.g. Pad). The browser onnxruntime-web supports opset 18.
+    # `dynamic_axes` is intentionally omitted: with dynamo=True it is not
+    # recommended and can raise; the browser always runs a single clip
+    # (batch=1), so a fixed batch is fine.
     torch.onnx.export(
         trunk,
         dummy,
         args.out,
         input_names=["input"],
         output_names=["embeddings"],
-        dynamic_axes={"input": {0: "batch"}},
         opset_version=args.opset,
     )
     print(f"Exported {args.encoder}/{language} encoder -> {args.out}")

--- a/scripts/export-plixkws-onnx.py
+++ b/scripts/export-plixkws-onnx.py
@@ -112,11 +112,13 @@ class EncoderTrunk(torch.nn.Module):
 
     def forward(self, mel: torch.Tensor) -> torch.Tensor:
         # mirroring Backbone.forward after the melspectrogram step:
-        #   x = log(mel + 1e-6); x = encoder(x); x = mean(2,3); squeeze
+        #   x = log(mel + 1e-6); x = encoder(x); x = mean(2,3)
+        # After mean(dim=(2,3)) the tensor is already [B, 1280] (2-D), so no
+        # squeeze is needed (a squeeze(-1) on a size-1280 dim is a no-op and
+        # triggers an exporter warning).
         x = torch.log(mel + 1e-6)
         x = self.backbone.encoder(x)
         x = x.mean(dim=(2, 3))
-        x = x.squeeze(-1)
         return x
 
 
@@ -169,10 +171,10 @@ def main() -> None:
     dummy = torch.randn(1, 1, 64, 100, device=device)
 
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
-    # Use the TorchScript (legacy) ONNX exporter: it does not require the
-    # `onnxscript` package that the newer dynamo exporter needs, and it handles
-    # a traced CNN trunk like PLiX cleanly. The dummy input is a concrete
-    # 1x1x64x100 tensor, so tracing is exact.
+    # Use the modern torch.export-based ONNX exporter (torch >= 2.9 default).
+    # It requires the `onnx` and `onnxscript` packages, which the CI workflow
+    # installs. The dummy input is a concrete 1x1x64x100 tensor, so the export
+    # is exact. (The legacy TorchScript exporter is deprecated.)
     torch.onnx.export(
         trunk,
         dummy,
@@ -181,7 +183,6 @@ def main() -> None:
         output_names=["embeddings"],
         dynamic_axes={"input": {0: "batch"}},
         opset_version=args.opset,
-        dynamo=False,
     )
     print(f"Exported {args.encoder}/{language} encoder -> {args.out}")
 


### PR DESCRIPTION
## Summary

Follow-up fixes to the PLiX export workflow after the initial runtime PR was merged. The export job failed in CI; these commits make it run cleanly.

- **ONNX export deps**: install `onnx` + `onnxscript` (required by torch's modern `torch.export`-based ONNX exporter). Earlier the job failed with `ModuleNotFoundError: No module named 'onnx'`.
- **No-op squeeze removed**: `EncoderTrunk.forward` no longer calls `squeeze(-1)` after `mean(dim=(2,3))` (tensor is already [B,1280]); that only triggered an exporter warning about dropping a node.
- **Opset >= 18**: the modern exporter only has implementations for opset >= 18; exporting at 17 then down-converting crashed on `Pad` ("No Adapter To Version 17 for Pad"). Default bumped to 18. Also dropped `dynamic_axes` (not recommended with dynamo=True; the browser runs a single clip, batch=1).
- **Removed optional "Attach to Release" step**: conversion output is delivered as a downloadable workflow artifact only — keeps the flow push-free per AGENTS.md.

The branch was force-updated (`git push -f`) after the prior PR (#3) was merged, so this PR carries the final corrected state.

## Test plan
- [x] `python -m py_compile scripts/export-plixkws-onnx.py` passes locally
- [ ] Re-run **Export PLiX ONNX** workflow (base/en) and confirm a clean export + artifact upload (no onnx/onnxscript import errors, no opset-17 conversion crash).
- [ ] Download the artifact, drop into `prebuilts/plixkws/`, and verify the .onnx loads in `FewShotPanel` with `PLIX_RUNTIME='onnx'`.

## Notes
- `prebuilts/` stays gitignored (ADR-011); weights are never committed.
- The `transformers` runtime (browser-native via `@huggingface/transformers` v4) is unchanged by this PR; only the export tooling/workflow is.
