### PR TITLE
Fix PLiX transformers runtime: import @huggingface/transformers from CDN

### DIFF
--- a/src/kws/backends/plix-transformers.ts
+++ b/src/kws/backends/plix-transformers.ts
@@ -48,6 +48,18 @@ import {
   melSpectrogram,
   fitFrames,
 } from './plix-frontend'
+
+// `@huggingface/transformers` is an OPTIONAL dependency (not installed by
+// default). The 'transformers' runtime loads it from the jsDelivr CDN at
+// runtime - no npm install required. We import the package's browser ESM
+// build by full URL (not the bare specifier) because a bare specifier cannot
+// be resolved in the browser and would throw
+// "Failed to resolve module specifier '@huggingface/transformers'". The
+// version is pinned to match package.json's optionalDependencies range.
+const HF_TRANSFORMERS_CDN =
+  'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0'
+
+// Type-only imports (erased at build time; do not affect runtime resolution).
 import type {
   AutoModelStatic,
   TransformersEnv,
@@ -71,14 +83,12 @@ export class PlixTransformersEncoder implements PlixEncoder {
 
   async load(_locator: string): Promise<void> {
     // Dynamic import: @huggingface/transformers is only fetched when this
-    // runtime is actually selected (keeps the default ONNX path light). The
-    // specifier is held in a variable so the bundler does NOT statically
-    // resolve it (it is an optional dep declared external in vite.config.ts).
-    const spec = '@huggingface/transformers'
-    // @vite-ignore: this specifier is an OPTIONAL dependency declared external
-    // in vite.config.ts - it is fetched at runtime (CDN) only when this runtime
-    // is selected, so Vite must not try to statically analyze/bundle it.
-    const mod = (await import(/* @vite-ignore */ spec)) as unknown as {
+    // runtime is actually selected (keeps the default ONNX path light). We
+    // import the full CDN ESM URL (HF_TRANSFORMERS_CDN) rather than the bare
+    // package specifier, because a bare specifier cannot be resolved in the
+    // browser. The @vite-ignore tells Vite not to rewrite/analyze this remote
+    // URL at build time - it is fetched at runtime when this runtime is used.
+    const mod = (await import(/* @vite-ignore */ HF_TRANSFORMERS_CDN)) as unknown as {
       AutoModel: AutoModelStatic
       env: TransformersEnv
       Tensor: typeof import('@huggingface/transformers').Tensor

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,17 +70,18 @@ const base = process.env.VITE_BASE_PATH ?? '/'
 
 export default defineConfig({
   base,
-  // Optional, dynamically-imported dependencies are kept external so the
-  // default ONNX path does not require them to be installed/bundled. Each is
-  // only fetched at runtime when its runtime is selected (see ModelRuntime in
-  // src/runtime.ts and the per-runtime encoder backends).
-  //   - @xenova/transformers : PLiX 'transformers' runtime (no ONNX file)
-  //   - @huggingface/transformers : PLiX 'transformers' runtime (v4 browser build)
-  //   - executorch           : PLiX 'executorch' runtime (WASM, deferred impl)
-  // In a deployed build these routes need the dep available at runtime.
+  // Optional, dynamically-imported dependencies. The 'transformers' runtime
+  // loads @huggingface/transformers from the jsDelivr CDN at runtime (full URL
+  // import in plix-transformers.ts), so it is NOT bundled and does not need to
+  // be installed. 'executorch' is a deferred runtime. These are listed as
+  // external so any stray static reference is left as a bare specifier rather
+  // than failing the build (see ModelRuntime in src/runtime.ts and the
+  // per-runtime encoder backends).
+  //   - @huggingface/transformers : PLiX 'transformers' runtime (v4 browser build, CDN)
+  //   - executorch               : PLiX 'executorch' runtime (WASM, deferred impl)
   build: {
     rollupOptions: {
-      external: ['@xenova/transformers', '@huggingface/transformers', 'executorch'],
+      external: ['@huggingface/transformers', 'executorch'],
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

Fixes the runtime error when the PLiX transformers runtime is selected:

> [KWS worker] Model load failed: Failed to resolve module specifier '@huggingface/transformers'

Root cause: the transformers encoder did import('@huggingface/transformers') with a bare specifier. @huggingface/transformers is an OPTIONAL dependency that is not installed, and with @vite-ignore Vite leaves the specifier untouched, so the browser cannot resolve it.

Fix: import the package's browser ESM build from the jsDelivr CDN at runtime via the full URL (https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0), pinned to the version in package.json. This matches the documented zero-Python design (no install required). Verified the CDN URL returns the ESM build exporting AutoModel / env / Tensor. The @vite-ignore is kept so Vite does not try to bundle the remote URL.

Also removed the stale @xenova/transformers note from vite.config.ts external list (that package was never used; the real optional dep is @huggingface/transformers).

## Test plan

- tsc --noEmit clean, ESLint clean, vitest 26/26 pass.
- Verified the CDN URL serves the browser ESM build with the expected named exports.
- The onnx runtime path is unchanged.

Generated with Claude (https://claude.com/)
