### PR TITLE
Fix PLiX transformers runtime: load from local HF-style dir, not the Hub

### DIFF
--- a/public/model-registry.json
+++ b/public/model-registry.json
@@ -81,7 +81,7 @@
       "class": "redistributable",
       "sha256": "TODO-phase3",
       "sizeBytes": null,
-      "notes": "PLiX 'small' encoder variant (TinyNet-E) - lighter than 'base', for low-RAM / end-side devices. Still outputs a 1280-dim embedding from the same 1x64x100 log-Mel front-end, so prototype-distance scoring is identical to 'base'. Exported with external data: plixkws-small.onnx references plixkws-small.onnx.data (co-located, served from /prebuilts/plixkws/). Select this variant via the encoder selector in the Few-Shot panel (ADR-002). Same two runtimes as 'base' (onnx / transformers)."
+      "notes": "PLiX 'small' encoder variant (TinyNet-E) - lighter than 'base', for low-RAM / end-side devices. Still outputs a 1280-dim embedding from the same 1x64x100 log-Mel front-end, so prototype-distance scoring is identical to 'base'. Exported with external data: plixkws-small.onnx references plixkws-small.onnx.data (co-located, served from /prebuilts/plixkws/). Select this variant via the encoder selector in the Few-Shot panel (ADR-002). Same two runtimes as 'base' (onnx / transformers). The 'transformers' runtime loads from a LOCALLY-EXPORTED HF-style dir (prebuilts/plixkws/hf/plixkws); the Hugging Face repo only ships .pt weights, not ONNX."
     },
     {
       "id": "silero-vad",

--- a/src/components/FewShotPanel.tsx
+++ b/src/components/FewShotPanel.tsx
@@ -74,7 +74,7 @@ export const FewShotPanel = memo(function FewShotPanel({
     const rt = runtime
     const url =
       rt === 'transformers'
-        ? variant.transformersModel
+        ? variant.transformersLocalDir
         : variant.onnxUrl
     return { url, runtime: rt }
   }, [encoderVariant, runtime])
@@ -116,7 +116,20 @@ export const FewShotPanel = memo(function FewShotPanel({
       // load. Surface that clearly instead of a raw fetch/404 error.
       const variant = getPlixEncoderVariant(encoderVariant)
       const expected = variant?.onnxUrl ?? '/prebuilts/plixkws/plixkws-base.onnx'
-      if (/fetch|404|load failed|not loaded/i.test(msg)) {
+      if (runtime === 'transformers') {
+        // The transformers runtime loads the ONNX graph from a locally-exported
+        // HF-style dir (config.json + onnx/model.onnx). The Hugging Face repo
+        // only ships .pt weights, so it cannot be fetched from the Hub.
+        setError(
+          `PLiX (${encoderVariant}) 'transformers' runtime needs a locally-exported ` +
+            `HF-style dir at ${variant?.transformersLocalDir ?? '/prebuilts/plixkws/hf/plixkws'} ` +
+            `(config.json + onnx/model.onnx). Export it with: ` +
+            'python scripts/export-plixkws-onnx.py --encoder ' +
+            encoderVariant +
+            ' --hf-dir prebuilts/plixkws/hf/plixkws. ' +
+            'Alternatively, use the default ONNX runtime.',
+        )
+      } else if (/fetch|404|load failed|not loaded/i.test(msg)) {
         setError(
           `PLiX (${encoderVariant}) encoder model not found. Export the PLiX ` +
             `ONNX (see prebuilts/plixkws/README.md) and place it at ` +
@@ -130,7 +143,7 @@ export const FewShotPanel = memo(function FewShotPanel({
       }
       setStatus('error')
     }
-  }, [ensureEngines, resolvePlixLocator, encoderVariant])
+  }, [ensureEngines, resolvePlixLocator, encoderVariant, runtime])
 
   /** Record a 1.5 s sample from the mic at 16 kHz. */
   const handleRecord = useCallback(async () => {

--- a/src/kws/__tests__/backend.test.ts
+++ b/src/kws/__tests__/backend.test.ts
@@ -283,11 +283,13 @@ describe('PLIX_ENCODER_VARIANTS', () => {
     expect(PLIX_ENCODER_VARIANTS.map((v) => v.id)).toEqual(['base', 'small'])
   })
 
-  it('every variant has a label, onnx URL, and transformers model', () => {
+  it('every variant has a label, onnx URL, and transformers local dir', () => {
     for (const v of PLIX_ENCODER_VARIANTS) {
       expect(v.label.length).toBeGreaterThan(0)
       expect(v.onnxUrl.startsWith('/prebuilts/plixkws/')).toBe(true)
-      expect(v.transformersModel.length).toBeGreaterThan(0)
+      expect(v.transformersLocalDir.startsWith('/prebuilts/plixkws/')).toBe(
+        true,
+      )
       expect(v.note.length).toBeGreaterThan(0)
     }
   })

--- a/src/kws/backends/plix-encoder.ts
+++ b/src/kws/backends/plix-encoder.ts
@@ -55,8 +55,16 @@ export interface PlixEncoderVariant {
   label: string
   /** Local ONNX URL served from /prebuilts/plixkws/ (onnx runtime). */
   onnxUrl: string
-  /** Hugging Face repo id for the transformers runtime (zero-Python). */
-  transformersModel: string
+  /**
+   * Local HF-style directory URL for the transformers runtime. The PLiX ONNX
+   * graph is NOT hosted on the Hub (the `aaqibsaeed/plixkws` repo only ships
+   * `.pt` weights + config.json), so the transformers runtime must load the
+   * graph from a locally-exported HF-style dir produced by
+   * `scripts/export-plixkws-onnx.py --hf-dir prebuilts/plixkws/hf/plixkws`
+   * (config.json + onnx/model.onnx). This path starts with '/' so the
+   * encoder serves it from the dev server (no remote fetch).
+   */
+  transformersLocalDir: string
   /** One-line note shown in the encoder selector. */
   note: string
 }
@@ -71,14 +79,14 @@ export const PLIX_ENCODER_VARIANTS: ReadonlyArray<PlixEncoderVariant> = [
     id: 'base',
     label: 'PLiX base (EfficientNet-v2-M, 1280-d)',
     onnxUrl: '/prebuilts/plixkws/plixkws-base.onnx',
-    transformersModel: 'aaqibsaeed/plixkws',
+    transformersLocalDir: '/prebuilts/plixkws/hf/plixkws',
     note: 'Heavier CNN; default. Needs plixkws-base.onnx (exported ONNX).',
   },
   {
     id: 'small',
     label: 'PLiX small (TinyNet-E, 1280-d)',
     onnxUrl: '/prebuilts/plixkws/plixkws-small.onnx',
-    transformersModel: 'aaqibsaeed/plixkws',
+    transformersLocalDir: '/prebuilts/plixkws/hf/plixkws',
     note: 'Lighter / low-RAM. Needs plixkws-small.onnx + plixkws-small.onnx.data (external weights).',
   },
 ]


### PR DESCRIPTION
## Summary

Fixes the next error when the PLiX **transformers** runtime is selected:

> Could not locate file: "https://huggingface.co/aaqibsaeed/plixkws/resolve/main/onnx/model.onnx"

**Root cause:** the encoders used the HF repo id `aaqibsaeed/plixkws` as the transformers load target. That repo only ships `.pt` weights + `config.json` — it has **no ONNX graph** and no `onnx/` folder — so `AutoModel.from_pretrained()` can never resolve `onnx/model.onnx` from the Hub.

**Fix:** the transformers runtime now loads the ONNX graph from the **locally-exported HF-style directory** (`prebuilts/plixkws/hf/plixkws`, i.e. `config.json` + `onnx/model.onnx`) produced by `scripts/export-plixkws-onnx.py --hf-dir prebuilts/plixkws/hf/plixkws`. Added `PlixEncoderVariant.transformersLocalDir` and pointed `FewShotPanel`'s selector at it; the path starts with `/` so the encoder serves it locally (no remote fetch). The worker already surfaces load failures loudly.

Also:
- `FewShotPanel` shows an actionable error for the transformers runtime telling the user to export the HF-style dir (with the exact command) or use the default ONNX runtime.
- Updated `model-registry.json` notes to state the Hub repo has no ONNX.
- Updated the variant unit test (`transformersModel` -> `transformersLocalDir`).

The default ONNX runtime path is unchanged and unaffected.

## Test plan

- `tsc --noEmit` clean, ESLint clean, `vitest` 26/26 pass.
- Verified the HF repo `aaqibsaeed/plixkws` contains only `.pt` + `config.json` (no ONNX), confirming the Hub id was never a valid ONNX source.
- Verified the dev-server-transformed code resolves the transformers runtime to `/prebuilts/plixkws/hf/plixkws`.
- The `onnx` runtime (default, with the files already present) is unaffected.

Generated with Claude (https://claude.com/)
