### PR TITLE
PLiX transformers: external-data load + gen HF-dir script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:e2e": "playwright install chromium && playwright test",
     "test:unit": "vitest run",
     "test": "vitest run && pnpm test:e2e",
-    "gen-icons": "node scripts/gen-icons.mjs"
+    "gen-icons": "node scripts/gen-icons.mjs",
+    "gen-plix-hf-dir": "node scripts/gen-plix-hf-dir.mjs"
   },
   "dependencies": {
     "onnxruntime-web": "^1.27.0",

--- a/scripts/gen-plix-hf-dir.mjs
+++ b/scripts/gen-plix-hf-dir.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Generate a locally-served Hugging Face-style directory for the PLiX Few-Shot
+ * encoder, so the `transformers` runtime can load it fully offline.
+ *
+ * The PLiX repo on the Hub (aaqibsaeed/plixkws) only ships `.pt` PyTorch
+ * weights + config.json - it has NO ONNX graph - so the transformers runtime
+ * cannot fetch it from the Hub. Instead it loads the ONNX graph from a
+ * locally-built HF-style dir:
+ *
+ *   prebuilts/plixkws/hf/plixkws/
+ *   ├── config.json
+ *   └── onnx/
+ *       ├── model.onnx            (== plixkws-small.onnx, renamed)
+ *       └── plixkws-small.onnx.data (external weights; 'small' only)
+ *
+ * Transformers.js looks for `onnx/model.onnx` by default, so the exported
+ * graph is copied (not moved) and renamed; the external weights stay
+ * co-located so onnxruntime-web can resolve them (the protobuf `location`
+ * `plixkws-small.onnx.data` resolves relative to the graph dir).
+ *
+ * This folder is gitignored (ADR-011) - a generated, dev-only artifact. Run:
+ *
+ *   node scripts/gen-plix-hf-dir.mjs            # defaults to 'small'
+ *   node scripts/gen-plix-hf-dir.mjs --variant base
+ *
+ * or via the npm script:
+ *
+ *   npm run gen-plix-hf-dir -- --variant base
+ */
+
+import { existsSync } from 'node:fs'
+import { copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+
+/** Variants and the source ONNX (relative to prebuilts/plixkws). */
+const VARIANTS = {
+  base: { onnx: 'plixkws-base.onnx', external: null },
+  small: { onnx: 'plixkws-small.onnx', external: 'plixkws-small.onnx.data' },
+}
+
+const EMBEDDING_DIM = 1280
+const NUM_MELS = 64
+const NUM_FRAMES = 100
+
+function parseArgs(argv) {
+  const args = { variant: 'small' }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--variant') {
+      args.variant = argv[++i]
+    } else if (a.startsWith('--variant=')) {
+      args.variant = a.slice('--variant='.length)
+    } else if (a === '--help' || a === '-h') {
+      args.help = true
+    }
+  }
+  return args
+}
+
+function usage() {
+  return `usage: node scripts/gen-plix-hf-dir.mjs [--variant base|small]
+
+Generate a locally-served HF-style dir for the PLiX Few-Shot encoder so the
+'transers' runtime can load it offline (prebuilts/plixkws/hf/plixkws).
+Default variant: small.`
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    console.log(usage())
+    return
+  }
+
+  const variant = args.variant
+  const src = VARIANTS[variant]
+  if (!src) {
+    console.error(`Unknown variant '${variant}'. Choose one of: ${Object.keys(VARIANTS).join(', ')}.`)
+    process.exit(2)
+  }
+
+  const baseDir = join(repoRoot, 'prebuilts', 'plixkws')
+  const srcOnnx = join(baseDir, src.onnx)
+  const hfDir = join(baseDir, 'hf', 'plixkws')
+  const onnxDir = join(hfDir, 'onnx')
+
+  if (!existsSync(srcOnnx)) {
+    console.error(
+      `Missing source ONNX: ${srcOnnx}\n` +
+        `Export it first (see prebuilts/plixkws/README.md), then re-run this script.`,
+    )
+    process.exit(1)
+  }
+
+  await mkdir(onnxDir, { recursive: true })
+
+  // Copy + rename the graph to the name Transformers.js expects.
+  const destOnnx = join(onnxDir, 'model.onnx')
+  await copyFile(srcOnnx, destOnnx)
+  console.log(`copied ${src.onnx} -> hf/plixkws/onnx/model.onnx`)
+
+  // Copy external weights (small only) so they stay co-located.
+  if (src.external) {
+    const srcExternal = join(baseDir, src.external)
+    if (!existsSync(srcExternal)) {
+      console.error(
+        `Missing external weights: ${srcExternal}\n` +
+          `The '${variant}' export needs its .onnx.data sidecar. Export it and re-run.`,
+      )
+      process.exit(1)
+    }
+    const destExternal = join(onnxDir, src.external)
+    await copyFile(srcExternal, destExternal)
+    console.log(`copied ${src.external} -> hf/plixkws/onnx/${src.external}`)
+  }
+
+  // Write a minimal config.json describing the backbone.
+  const config = {
+    _name_or_path: 'plixkws',
+    architectures: ['PlixBackbone'],
+    model_type: 'plixkws',
+    num_channels: 1,
+    num_mels: NUM_MELS,
+    num_frames: NUM_FRAMES,
+    embedding_dim: EMBEDDING_DIM,
+    onnx: { model: 'onnx/model.onnx' },
+  }
+  await writeFile(join(hfDir, 'config.json'), JSON.stringify(config, null, 2) + '\n')
+  console.log('wrote hf/plixkws/config.json')
+
+  console.log(`\nDone. The 'transformers' runtime now loads from:\n  ${hfDir}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/components/FewShotPanel.tsx
+++ b/src/components/FewShotPanel.tsx
@@ -116,18 +116,21 @@ export const FewShotPanel = memo(function FewShotPanel({
       // load. Surface that clearly instead of a raw fetch/404 error.
       const variant = getPlixEncoderVariant(encoderVariant)
       const expected = variant?.onnxUrl ?? '/prebuilts/plixkws/plixkws-base.onnx'
-      if (runtime === 'transformers') {
+      if (
+        runtime === 'transformers' &&
+        /config\.json|model\.onnx|could not locate|404|not found/i.test(msg)
+      ) {
         // The transformers runtime loads the ONNX graph from a locally-exported
         // HF-style dir (config.json + onnx/model.onnx). The Hugging Face repo
-        // only ships .pt weights, so it cannot be fetched from the Hub.
+        // only ships .pt weights, so it cannot be fetched from the Hub. Only
+        // show this hint when the failure is actually a missing dir/file.
         setError(
           `PLiX (${encoderVariant}) 'transformers' runtime needs a locally-exported ` +
             `HF-style dir at ${variant?.transformersLocalDir ?? '/prebuilts/plixkws/hf/plixkws'} ` +
-            `(config.json + onnx/model.onnx). Export it with: ` +
-            'python scripts/export-plixkws-onnx.py --encoder ' +
+            `(config.json + onnx/model.onnx). Generate it with: ` +
+            'npm run gen-plix-hf-dir -- --variant ' +
             encoderVariant +
-            ' --hf-dir prebuilts/plixkws/hf/plixkws. ' +
-            'Alternatively, use the default ONNX runtime.',
+            '. Alternatively, use the default ONNX runtime.',
         )
       } else if (/fetch|404|load failed|not loaded/i.test(msg)) {
         setError(

--- a/src/kws/backends/plix-transformers.ts
+++ b/src/kws/backends/plix-transformers.ts
@@ -106,11 +106,21 @@ export class PlixTransformersEncoder implements PlixEncoder {
       mod.env.localModelPath = base
       this._TensorCtor = mod.Tensor
       // The 'small' export stores its large weight tensor as ONNX external
-      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx),
-      // so tell the wrapped onnxruntime-web to resolve the external sidecar.
+      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx).
+      // The browser build of onnxruntime-web cannot read the filesystem, so
+      // the external weights must be passed explicitly (same mechanism as the
+      // ONNX runtime's `_externalDataOptions`). Transformers.js maps each
+      // externalData entry to ORT-web's `mountExternalData`, which is the only
+      // reliable way to resolve the sidecar in the browser. The protobuf
+      // `location` is `plixkws-small.onnx.data`, resolved relative to the
+      // graph, so the path here must match exactly.
+      const externalDataUrl = `${this._modelId}/onnx/plixkws-small.onnx.data`
       this._model = await mod.AutoModel.from_pretrained(id, {
         dtype: 'fp32',
         use_external_data_format: true,
+        externalData: [
+          { path: 'plixkws-small.onnx.data', data: externalDataUrl },
+        ],
       })
       return
     }

--- a/src/kws/backends/plix-transformers.ts
+++ b/src/kws/backends/plix-transformers.ts
@@ -105,7 +105,13 @@ export class PlixTransformersEncoder implements PlixEncoder {
       mod.env.allowRemoteModels = false
       mod.env.localModelPath = base
       this._TensorCtor = mod.Tensor
-      this._model = await mod.AutoModel.from_pretrained(id, { dtype: 'fp32' })
+      // The 'small' export stores its large weight tensor as ONNX external
+      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx),
+      // so tell the wrapped onnxruntime-web to resolve the external sidecar.
+      this._model = await mod.AutoModel.from_pretrained(id, {
+        dtype: 'fp32',
+        use_external_data_format: true,
+      })
       return
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #7 (which already merged the core fix: the transformers runtime now loads from a local HF-style dir instead of the Hub). This PR carries the two commits that landed on the branch *after* #7 was merged, so they aren't lost:

1. **`feat(plix): generate HF-style dir for transformers runtime from local ONNX`** — `plix-transformers.ts` now passes `use_external_data_format: true` when loading the local HF-style dir, so the wrapped onnxruntime-web fetches the `.data` external-weights sidecar. Without this, the `small` variant's external data would not resolve. (The HF-style dir itself is gitignored per ADR-011; generated locally from the committed-free weights.)

2. **`feat(scripts): add gen-plix-hf-dir`** — new `scripts/gen-plix-hf-dir.mjs` (npm: `gen-plix-hf-dir`, also `--variant base|small`) that copies the local PLiX ONNX weights into the locally-served HF-style directory the transformers runtime loads offline:
   ```
   prebuilts/plixkws/hf/plixkws/
   ├── config.json
   └── onnx/{model.onnx, plixkws-small.onnx.data}
   ```
   The graph is renamed to `onnx/model.onnx` (what Transformers.js expects) and the external weights stay co-located. Verified the script-generated dir loads via onnxruntime-web and emits the expected 1280-dim embedding. Missing source / unknown variant exit with a clear message.

## Test plan

- `tsc --noEmit` clean, ESLint clean, `vitest` 26/26 pass.
- `node scripts/gen-plix-hf-dir.mjs --variant small` regenerates the dir; loaded in Node via onnxruntime-web -> `[1,1280]` embedding.
- `--variant base` and unknown variant error paths verified.

Generated with Claude (https://claude.com/)
