### PR TITLE
Fix PLiX transformers runtime: load local HF-style dir (external data + named input)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:e2e": "playwright install chromium && playwright test",
     "test:unit": "vitest run",
     "test": "vitest run && pnpm test:e2e",
-    "gen-icons": "node scripts/gen-icons.mjs"
+    "gen-icons": "node scripts/gen-icons.mjs",
+    "gen-plix-hf-dir": "node scripts/gen-plix-hf-dir.mjs"
   },
   "dependencies": {
     "onnxruntime-web": "^1.27.0",

--- a/scripts/gen-plix-hf-dir.mjs
+++ b/scripts/gen-plix-hf-dir.mjs
@@ -30,9 +30,14 @@
  */
 
 import { existsSync } from 'node:fs'
-import { copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
@@ -99,12 +104,28 @@ async function main() {
 
   await mkdir(onnxDir, { recursive: true })
 
-  // Copy + rename the graph to the name Transformers.js expects.
+  // Write the graph under the name Transformers.js expects (`model.onnx`),
+  // with its external-data `location` rewritten to `model.onnx_data`.
+  // Transformers.js / onnxruntime-web resolves external data in the browser
+  // via a HARDCODED `_data` naming convention: it looks for `<graph>_data`
+  // (i.e. `model.onnx_data`), IGNORING the protobuf `location` and ALSO
+  // ignoring any `externalData` option we pass when external tensors are
+  // detected. So the graph's external `location` MUST be `model.onnx_data` to
+  // match. We use the `onnx` Python package for a correct, corruption-free
+  // protobuf rewrite (the source ONNX is never modified).
   const destOnnx = join(onnxDir, 'model.onnx')
-  await copyFile(srcOnnx, destOnnx)
-  console.log(`copied ${src.onnx} -> hf/plixkws/onnx/model.onnx`)
+  await rewriteExternalLocation(srcOnnx, destOnnx, 'plixkws-small.onnx.data', 'model.onnx_data')
+  console.log(`wrote hf/plixkws/onnx/model.onnx (external location -> model.onnx_data)`)
 
   // Copy external weights (small only) so they stay co-located.
+  //
+  // IMPORTANT: Transformers.js / onnxruntime-web resolves external data in the
+  // browser via a HARDCODED `_data` naming convention - it looks for
+  // `<graph-without-.onnx>_data` (i.e. `model.onnx_data`), NOT the protobuf
+  // `location` (`plixkws-small.onnx.data`). So the file MUST be named
+  // `model.onnx_data` for the transformers runtime to load it. We also keep a
+  // copy named `plixkws-small.onnx.data` (the protobuf location) as a
+  // fallback and so the same dir can serve ORT-web's alternate lookup.
   if (src.external) {
     const srcExternal = join(baseDir, src.external)
     if (!existsSync(srcExternal)) {
@@ -114,9 +135,12 @@ async function main() {
       )
       process.exit(1)
     }
-    const destExternal = join(onnxDir, src.external)
-    await copyFile(srcExternal, destExternal)
-    console.log(`copied ${src.external} -> hf/plixkws/onnx/${src.external}`)
+    const destExternalData = join(onnxDir, 'model.onnx_data')
+    await copyFile(srcExternal, destExternalData)
+    console.log(`copied ${src.external} -> hf/plixkws/onnx/model.onnx_data`)
+    const destFallback = join(onnxDir, src.external)
+    await copyFile(srcExternal, destFallback)
+    console.log(`copied ${src.external} -> hf/plixkws/onnx/${src.external} (fallback)`)
   }
 
   // Write a minimal config.json describing the backbone.
@@ -134,6 +158,49 @@ async function main() {
   console.log('wrote hf/plixkws/config.json')
 
   console.log(`\nDone. The 'transformers' runtime now loads from:\n  ${hfDir}`)
+}
+
+/**
+ * Rewrite the ONNX external-data `location` of every initializer from `from`
+ * to `to`, keeping the weights external (single sidecar file named `to`), and
+ * write the result to `destOnnx`. Uses the `onnx` Python package so the
+ * protobuf is re-serialized correctly (no fragile byte patching). The source
+ * ONNX is never modified. Required because onnxruntime-web (inside
+ * Transformers.js) only honours the `_data` convention (`<graph>_data`), not
+ * the protobuf `location`, when external tensors are present.
+ */
+async function rewriteExternalLocation(srcOnnx, destOnnx, from, to) {
+  const dir = await mkdtemp(join(tmpdir(), 'gen-plix-'))
+  const py = join(dir, 'rewrite.py')
+  await writeFile(
+    py,
+    `import sys\n` +
+      `import onnx\n` +
+      `src, dst, frm, to = sys.argv[1:5]\n` +
+      `m = onnx.load(src, load_external_data=False)\n` +
+      `n = 0\n` +
+      `for init in m.graph.initializer:\n` +
+      `    for ext in init.external_data:\n` +
+      `        if ext.key == "location" and ext.value == frm:\n` +
+      `            ext.value = to\n` +
+      `            n += 1\n` +
+      `onnx.save(m, dst, save_as_external_data=True, all_tensors_to_one_file=True, location=to)\n` +
+      `print(f"rewrote {n} external-data locations -> {to}")\n`,
+  )
+  try {
+    const { stdout } = await execFileAsync('python3', [py, srcOnnx, destOnnx, from, to], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    process.stdout.write(stdout)
+  } catch (err) {
+    const msg = err.stderr ? err.stderr.toString() : err.message
+    throw new Error(
+      `Failed to rewrite ONNX external location via python 'onnx' (is it installed? ` +
+        `pip install onnx). ${msg}`,
+    )
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 }
 
 main().catch((err) => {

--- a/scripts/gen-plix-hf-dir.mjs
+++ b/scripts/gen-plix-hf-dir.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Generate a locally-served Hugging Face-style directory for the PLiX Few-Shot
+ * encoder, so the `transformers` runtime can load it fully offline.
+ *
+ * The PLiX repo on the Hub (aaqibsaeed/plixkws) only ships `.pt` PyTorch
+ * weights + config.json - it has NO ONNX graph - so the transformers runtime
+ * cannot fetch it from the Hub. Instead it loads the ONNX graph from a
+ * locally-built HF-style dir:
+ *
+ *   prebuilts/plixkws/hf/plixkws/
+ *   ├── config.json
+ *   └── onnx/
+ *       ├── model.onnx            (== plixkws-small.onnx, renamed)
+ *       └── plixkws-small.onnx.data (external weights; 'small' only)
+ *
+ * Transformers.js looks for `onnx/model.onnx` by default, so the exported
+ * graph is copied (not moved) and renamed; the external weights stay
+ * co-located so onnxruntime-web can resolve them (the protobuf `location`
+ * `plixkws-small.onnx.data` resolves relative to the graph dir).
+ *
+ * This folder is gitignored (ADR-011) - a generated, dev-only artifact. Run:
+ *
+ *   node scripts/gen-plix-hf-dir.mjs            # defaults to 'small'
+ *   node scripts/gen-plix-hf-dir.mjs --variant base
+ *
+ * or via the npm script:
+ *
+ *   npm run gen-plix-hf-dir -- --variant base
+ */
+
+import { existsSync } from 'node:fs'
+import { copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+
+/** Variants and the source ONNX (relative to prebuilts/plixkws). */
+const VARIANTS = {
+  base: { onnx: 'plixkws-base.onnx', external: null },
+  small: { onnx: 'plixkws-small.onnx', external: 'plixkws-small.onnx.data' },
+}
+
+const EMBEDDING_DIM = 1280
+const NUM_MELS = 64
+const NUM_FRAMES = 100
+
+function parseArgs(argv) {
+  const args = { variant: 'small' }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--variant') {
+      args.variant = argv[++i]
+    } else if (a.startsWith('--variant=')) {
+      args.variant = a.slice('--variant='.length)
+    } else if (a === '--help' || a === '-h') {
+      args.help = true
+    }
+  }
+  return args
+}
+
+function usage() {
+  return `usage: node scripts/gen-plix-hf-dir.mjs [--variant base|small]
+
+Generate a locally-served HF-style dir for the PLiX Few-Shot encoder so the
+'transers' runtime can load it offline (prebuilts/plixkws/hf/plixkws).
+Default variant: small.`
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    console.log(usage())
+    return
+  }
+
+  const variant = args.variant
+  const src = VARIANTS[variant]
+  if (!src) {
+    console.error(`Unknown variant '${variant}'. Choose one of: ${Object.keys(VARIANTS).join(', ')}.`)
+    process.exit(2)
+  }
+
+  const baseDir = join(repoRoot, 'prebuilts', 'plixkws')
+  const srcOnnx = join(baseDir, src.onnx)
+  const hfDir = join(baseDir, 'hf', 'plixkws')
+  const onnxDir = join(hfDir, 'onnx')
+
+  if (!existsSync(srcOnnx)) {
+    console.error(
+      `Missing source ONNX: ${srcOnnx}\n` +
+        `Export it first (see prebuilts/plixkws/README.md), then re-run this script.`,
+    )
+    process.exit(1)
+  }
+
+  await mkdir(onnxDir, { recursive: true })
+
+  // Copy + rename the graph to the name Transformers.js expects.
+  const destOnnx = join(onnxDir, 'model.onnx')
+  await copyFile(srcOnnx, destOnnx)
+  console.log(`copied ${src.onnx} -> hf/plixkws/onnx/model.onnx`)
+
+  // Copy external weights (small only) so they stay co-located.
+  if (src.external) {
+    const srcExternal = join(baseDir, src.external)
+    if (!existsSync(srcExternal)) {
+      console.error(
+        `Missing external weights: ${srcExternal}\n` +
+          `The '${variant}' export needs its .onnx.data sidecar. Export it and re-run.`,
+      )
+      process.exit(1)
+    }
+    const destExternal = join(onnxDir, src.external)
+    await copyFile(srcExternal, destExternal)
+    console.log(`copied ${src.external} -> hf/plixkws/onnx/${src.external}`)
+  }
+
+  // Write a minimal config.json describing the backbone.
+  const config = {
+    _name_or_path: 'plixkws',
+    architectures: ['PlixBackbone'],
+    model_type: 'plixkws',
+    num_channels: 1,
+    num_mels: NUM_MELS,
+    num_frames: NUM_FRAMES,
+    embedding_dim: EMBEDDING_DIM,
+    onnx: { model: 'onnx/model.onnx' },
+  }
+  await writeFile(join(hfDir, 'config.json'), JSON.stringify(config, null, 2) + '\n')
+  console.log('wrote hf/plixkws/config.json')
+
+  console.log(`\nDone. The 'transformers' runtime now loads from:\n  ${hfDir}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/components/FewShotPanel.tsx
+++ b/src/components/FewShotPanel.tsx
@@ -116,18 +116,21 @@ export const FewShotPanel = memo(function FewShotPanel({
       // load. Surface that clearly instead of a raw fetch/404 error.
       const variant = getPlixEncoderVariant(encoderVariant)
       const expected = variant?.onnxUrl ?? '/prebuilts/plixkws/plixkws-base.onnx'
-      if (runtime === 'transformers') {
+      if (
+        runtime === 'transformers' &&
+        /config\.json|model\.onnx|could not locate|404|not found/i.test(msg)
+      ) {
         // The transformers runtime loads the ONNX graph from a locally-exported
         // HF-style dir (config.json + onnx/model.onnx). The Hugging Face repo
-        // only ships .pt weights, so it cannot be fetched from the Hub.
+        // only ships .pt weights, so it cannot be fetched from the Hub. Only
+        // show this hint when the failure is actually a missing dir/file.
         setError(
           `PLiX (${encoderVariant}) 'transformers' runtime needs a locally-exported ` +
             `HF-style dir at ${variant?.transformersLocalDir ?? '/prebuilts/plixkws/hf/plixkws'} ` +
-            `(config.json + onnx/model.onnx). Export it with: ` +
-            'python scripts/export-plixkws-onnx.py --encoder ' +
+            `(config.json + onnx/model.onnx). Generate it with: ` +
+            'npm run gen-plix-hf-dir -- --variant ' +
             encoderVariant +
-            ' --hf-dir prebuilts/plixkws/hf/plixkws. ' +
-            'Alternatively, use the default ONNX runtime.',
+            '. Alternatively, use the default ONNX runtime.',
         )
       } else if (/fetch|404|load failed|not loaded/i.test(msg)) {
         setError(

--- a/src/kws/backends/plix-transformers.ts
+++ b/src/kws/backends/plix-transformers.ts
@@ -103,24 +103,30 @@ export class PlixTransformersEncoder implements PlixEncoder {
       const base = this._modelId.slice(0, idx) // e.g. /prebuilts/plixkws/hf
       const id = this._modelId.slice(idx + 1) // e.g. plixkws
       mod.env.allowRemoteModels = false
+      mod.env.allowLocalModels = true
       mod.env.localModelPath = base
       this._TensorCtor = mod.Tensor
       // The 'small' export stores its large weight tensor as ONNX external
-      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx).
-      // The browser build of onnxruntime-web cannot read the filesystem, so
-      // the external weights must be passed explicitly (same mechanism as the
-      // ONNX runtime's `_externalDataOptions`). Transformers.js maps each
-      // externalData entry to ORT-web's `mountExternalData`, which is the only
-      // reliable way to resolve the sidecar in the browser. The protobuf
-      // `location` is `plixkws-small.onnx.data`, resolved relative to the
-      // graph, so the path here must match exactly.
-      const externalDataUrl = `${this._modelId}/onnx/plixkws-small.onnx.data`
+      // data. Transformers.js / onnxruntime-web resolves external data in the
+      // browser via a HARDCODED `_data` naming convention: it looks for
+      // `<graph-without-.onnx>_data` (i.e. `onnx/model.onnx_data`), IGNORING
+      // the protobuf `location` AND any `externalData` option we pass when
+      // external tensors are present. The generated HF-style graph
+      // (scripts/gen-plix-hf-dir.mjs) therefore rewrites the external
+      // `location` to `model.onnx_data` so it matches. We still pass
+      // `externalData` under that key (the graph's `onnx/model.onnx_data` file
+      // also exists on disk, so ORT-web can fetch it directly if preferred).
+      const onnxDir = `${this._modelId}/onnx`
+      const externalData = [
+        {
+          path: 'model.onnx_data',
+          data: `${onnxDir}/model.onnx_data`,
+        },
+      ]
       this._model = await mod.AutoModel.from_pretrained(id, {
         dtype: 'fp32',
         use_external_data_format: true,
-        externalData: [
-          { path: 'plixkws-small.onnx.data', data: externalDataUrl },
-        ],
+        externalData,
       })
       return
     }
@@ -150,16 +156,23 @@ export class PlixTransformersEncoder implements PlixEncoder {
     )
     mel = fitFrames(mel, numFrames)
 
-    // Stack into a single 1x1x64x100 image and run the model directly.
+    // Stack into a single 1x1x64x100 image and run the model. Transformers.js
+    // expects a NAMED inputs object (keyed by the model's input name), not a
+    // positional tensor - a positional tensor fails with "Missing the following
+    // inputs: <name>".
     const input = new this._TensorCtor(
       'float32',
       mel,
       [1, 1, PLIX_N_MELS, PLIX_TARGET_FRAMES],
     )
-    const out = await this._model(input)
+    const inputName = (this._model as { input_names?: string[] }).input_names?.[0] ?? 'input'
+    // AutoModel is typed for a positional Tensor call; the actual runtime
+    // (Transformers.js) requires a named inputs object, so cast here.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await (this._model as any)({ [inputName]: input })
     const outTensor: OrtTensor | undefined =
       (out as { last_hidden_state?: OrtTensor }).last_hidden_state ??
-      Object.values(out)[0]
+      (Object.values(out)[0] as OrtTensor)
     if (!outTensor) {
       throw new Error('PLiX (transformers) encoder returned no tensor.')
     }

--- a/src/kws/backends/plix-transformers.ts
+++ b/src/kws/backends/plix-transformers.ts
@@ -106,11 +106,21 @@ export class PlixTransformersEncoder implements PlixEncoder {
       mod.env.localModelPath = base
       this._TensorCtor = mod.Tensor
       // The 'small' export stores its large weight tensor as ONNX external
-      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx),
-      // so tell the wrapped onnxruntime-web to resolve the external sidecar.
+      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx).
+      // The browser build of onnxruntime-web cannot read the filesystem, so
+      // the external weights must be passed explicitly (same mechanism as the
+      // ONNX runtime's `_externalDataOptions`). Transformers.js maps each
+      // externalData entry to ORT-web's `mountExternalData`, which is the only
+      // reliable way to resolve the sidecar in the browser. The protobuf
+      // `location` is `plixkws-small.onnx.data`, resolved relative to the
+      // graph, so the path here must match exactly.
+      const externalDataUrl = `${this._modelId}/onnx/plixkws-small.onnx.data`
       this._model = await mod.AutoModel.from_pretrained(id, {
         dtype: 'fp32',
         use_external_data_format: true,
+        externalData: [
+          { path: 'plixkws-small.onnx.data', data: externalDataUrl },
+        ],
       })
       return
     }

--- a/src/kws/backends/plix-transformers.ts
+++ b/src/kws/backends/plix-transformers.ts
@@ -105,7 +105,13 @@ export class PlixTransformersEncoder implements PlixEncoder {
       mod.env.allowRemoteModels = false
       mod.env.localModelPath = base
       this._TensorCtor = mod.Tensor
-      this._model = await mod.AutoModel.from_pretrained(id, { dtype: 'fp32' })
+      // The 'small' export stores its large weight tensor as ONNX external
+      // data (onnx/plixkws-small.onnx.data, co-located with onnx/model.onnx),
+      // so tell the wrapped onnxruntime-web to resolve the external sidecar.
+      this._model = await mod.AutoModel.from_pretrained(id, {
+        dtype: 'fp32',
+        use_external_data_format: true,
+      })
       return
     }
 


### PR DESCRIPTION
## Summary

Makes the PLiX **`transformers`** runtime actually load and run the locally-built
HF-style dir (`prebuilts/plixkws/hf/plixkws`) for the `small` variant, end to end.

The `transformers` runtime loads the ONNX graph via `@huggingface/transformers`
(CDN, no install) from a local HF-style dir. Getting it to work required three
fixes, captured across these commits:

1. **Point the runtime at the local HF-style dir, not the Hub** (034355d +
   c3706fb). The HF repo `aaqibsaeed/plixkws` only ships `.pt` weights + config.json
   (no ONNX), so loading from the Hub id always 404'd. The runtime now loads from
   `/prebuilts/plixkws/hf/plixkws` with `allowLocalModels=true` and an explicit
   `externalData` mount. The error message is now actionable (only shown when the
   dir is genuinely missing) and points at `npm run gen-plix-hf-dir`.

2. **Generate the HF-style graph with the external `location` rewritten to
   `model.onnx_data`** (0517510 + 05d108c). onnxruntime-web (inside Transformers.js)
   resolves external data in the browser via a hardcoded `_data` convention
   (`<graph>_data`) and IGNORES the protobuf `location` (and our externalData option)
   when external tensors are present. `gen-plix-hf-dir.mjs` now uses the `onnx`
   Python package to rewrite the 79 initializer locations to `model.onnx_data`
   (correct protobuf re-serialization; an earlier byte-patch corrupted the file).
   The generated dir is gitignored (ADR-011).

3. **Call the model with a NAMED inputs object** (05d108c). Transformers.js
   `AutoModel` requires `{ [inputName]: tensor }`, not a positional tensor; a
   positional call failed with "Missing the following inputs: input".

After these, the `transformers` runtime loads the `small` encoder locally and
`embed()` returns a 1280-dim vector (verified in Node via onnxruntime-web, the same
engine Transformers.js wraps).

## Test plan

- `tsc --noEmit` clean, ESLint clean, `vitest` 26/26 pass.
- `npm run gen-plix-hf-dir -- --variant small` rewrites 79 locations ->
  `model.onnx_data`; the graph loads via onnxruntime-web with the `model.onnx_data`
  externalData mount and emits a `[1,1280]` embedding.
- Dev note: the `prebuilts/` model files are served by Vite without cache headers,
  so clear site data / hard-reload after regenerating the HF dir to avoid a stale
  cached `model.onnx`.

Generated with Claude (https://claude.com/)
