### PR TITLE
fix(ci): bump emsdk to 4.0.23 for sherpa-onnx KWS WASM build

### DIFF
--- a/.github/workflows/build-sherpa-onnx-kws-wasm.yml
+++ b/.github/workflows/build-sherpa-onnx-kws-wasm.yml
@@ -46,7 +46,12 @@ on:
       emsdk_version:
         description: 'emsdk (Emscripten) version'
         required: false
-        default: '3.1.53'
+        # NOTE: emsdk 3.1.x produces an undefined `std::filesystem` symbol error
+        # at link time (wasm-ld: undefined symbol std::__2::filesystem::... in
+        # libonnxruntime.a) for the v1.13.4 wasm onnxruntime. The fix pairs
+        # sherpa-onnx >= v1.13.4 WASM with emsdk 4.0.x (see k2-fsa/sherpa-onnx
+        # PR #3582 / issue #3592). Bump this if you change sherpa_version.
+        default: '4.0.23'
         type: string
       kws_model:
         description: 'KWS model release archive (from sherpa-onnx kws-models)'
@@ -72,9 +77,8 @@ jobs:
       # ----------------------------------------------------------------------
       # 1. Emscripten toolchain
       #    mymindstorm/setup-emsdk caches the install in actions-cache-folder
-      #    so rebuilds are fast. The version is pinned because the sherpa-onnx
-      #    build script expects a specific emsdk; 3.1.53 is what v1.13.4 ships
-      #    with and is known-good for the KWS wasm build.
+      #    so rebuilds are fast. The version is pinned: sherpa-onnx >= v1.13.4
+      #    WASM requires emsdk 4.0.x (3.1.x fails to link `std::filesystem`).
       # ----------------------------------------------------------------------
       - name: Install emsdk
         uses: mymindstorm/setup-emsdk@v14


### PR DESCRIPTION
## Summary

Fixes the `Build sherpa-onnx KWS WASM` workflow, which failed at the link step on the first run (run #30419432538, exit code 2).

**Root cause:** the v1.13.4 wasm onnxruntime (`libonnxruntime.a`) references `std::filesystem` symbols (`std::__2::filesystem::__weakly_canonical`, `__absolute`, `path::__filename`, `path::__parent_path`, `__file_size`, `__status`). Under **emsdk 3.1.53** those symbols are undefined and `wasm-ld` aborts:

```
wasm-ld: error: ../../_deps/onnxruntime-src/lib/libonnxruntime.a(env.cc.o): undefined symbol: std::__2::filesystem::__weakly_canonical(...)
```

**Fix:** bump the pinned `emsdk_version` default from `3.1.53` -> `4.0.23`. emsdk 4.0.x provides the `std::filesystem` implementation for wasm, matching the upstream WASM-fix effort (k2-fsa/sherpa-onnx PR #3582 / issue #3592, which moved WASM to emsdk 4.0.23 after the ORT v1.24.4 change introduced these filesystem calls). `sherpa_version` stays at `v1.13.4`.

## Test plan

- [ ] Merge and re-run **Actions -> Build sherpa-onnx KWS WASM** (accept defaults -- now uses emsdk 4.0.23).
- [ ] Confirm the `sherpa-onnx-kws-wasm` artifact is produced (`.js`/`.wasm`/`.data` + demo html).
