### PR TITLE
feat(module-kit): spec-driven UI + panel generator + local-service skeleton (ADR-025/005/028)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ apps/web/public/sherpa-onnx-kws/
 # never committed (ADR-011).
 packages/modules/*/*/assets/*
 !packages/modules/*/*/assets/README.md
+
+# uv train environments + runtime outputs (ADR-028)
+packages/modules/*/*/train/.venv/
+packages/modules/*/*/train/out/
+packages/modules/*/*/train/*.egg-info/

--- a/apps/local-service/package.json
+++ b/apps/local-service/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@wake-studio/local-service",
+  "version": "0.1.0",
+  "private": true,
+  "description": "WakeStudio local service - the Self-hosted backend (ADR-005): module registry, train-runner (uv, ADR-028), artifact sync (ADR-027).",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/server.ts",
+  "types": "./src/server.ts",
+  "exports": {
+    ".": "./src/server.ts"
+  },
+  "scripts": {
+    "dev": "tsx src/server.ts",
+    "start": "tsx src/server.ts",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run",
+    "fetch:all": "echo 'no artifacts'"
+  },
+  "dependencies": {
+    "@wake-studio/contracts": "workspace:*",
+    "@wake-studio/module-kit": "workspace:*",
+    "@wake-studio/module-rnnoise": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.6",
+    "tsx": "^4.19.2",
+    "typescript": "~5.6.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/apps/local-service/src/module-registry.ts
+++ b/apps/local-service/src/module-registry.ts
@@ -1,0 +1,90 @@
+/**
+ * local-service - module registry (ADR-025).
+ *
+ * Discovers every module in the monorepo (packages/modules/.../spec/
+ * module.spec.json), validates its spec with module-kit, and exposes the
+ * catalog for route mounting + train/artifact operations.
+ *
+ * The registry is the single source of truth for "what modules exist" in the
+ * local world - mirroring how the web panel registry consumes the same specs.
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { ModuleSpec } from '@wake-studio/contracts'
+import { validateModuleSpec } from '@wake-studio/module-kit/validator'
+
+const here = dirname(fileURLToPath(import.meta.url))
+/** Monorepo modules root (packages/modules/<category>/<module>/). */
+const modulesRoot = resolve(here, '../../../packages/modules')
+
+function dirname(p: string): string {
+  return p.split('/').slice(0, -1).join('/')
+}
+
+export interface RegisteredModule {
+  /** Package directory (packages/modules/<category>/<module>). */
+  dir: string
+  /** Category directory name (afe, kws, ...). */
+  category: string
+  /** Module id (spec.meta.id). */
+  id: string
+  spec: ModuleSpec
+  /** Node target present? (node/index.ts) */
+  hasNodeTarget: boolean
+  /** Train target present? (train/) */
+  hasTrainTarget: boolean
+  /** Device target present? (device/) */
+  hasDeviceTarget: boolean
+}
+
+/** Scan the modules tree for specs. Returns modules sorted by category+id. */
+export function discoverModules(root: string = modulesRoot): RegisteredModule[] {
+  const out: RegisteredModule[] = []
+  for (const category of safeReaddir(root)) {
+    const catDir = join(root, category)
+    for (const mod of safeReaddir(catDir)) {
+      const dir = join(catDir, mod)
+      const specPath = join(dir, 'spec', 'module.spec.json')
+      if (!existsSync(specPath)) continue
+      try {
+        const raw = JSON.parse(readFileSync(specPath, 'utf8'))
+        const validation = validateModuleSpec(raw)
+        if (!validation.ok) {
+          // Fail loud: a malformed spec should surface at startup, not at use.
+          console.error(
+            `[module-registry] invalid spec ${category}/${mod}: ${validation.errors.join('; ')}`,
+          )
+          continue
+        }
+        const spec = raw as ModuleSpec
+        out.push({
+          dir,
+          category,
+          id: spec.meta.id,
+          spec,
+          hasNodeTarget: existsSync(join(dir, 'node', 'index.ts')) || existsSync(join(dir, 'node', 'index.js')),
+          hasTrainTarget: existsSync(join(dir, 'train')),
+          hasDeviceTarget: existsSync(join(dir, 'device')),
+        })
+      } catch (err) {
+        console.error(`[module-registry] failed to read spec ${category}/${mod}:`, err)
+      }
+    }
+  }
+  return out.sort((a, b) => a.category.localeCompare(b.category) || a.id.localeCompare(b.id))
+}
+
+/** Find one module by id. */
+export function findModule(id: string, root?: string): RegisteredModule | undefined {
+  return discoverModules(root).find((m) => m.id === id)
+}
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+  } catch {
+    return []
+  }
+}

--- a/apps/local-service/src/server.ts
+++ b/apps/local-service/src/server.ts
@@ -1,0 +1,137 @@
+/**
+ * local-service - HTTP server (ADR-005 Self-hosted backend, skeleton).
+ *
+ * Zero-dependency Node http server exposing the module platform:
+ *
+ *   GET  /health                    -> liveness + module count
+ *   GET  /modules                   -> catalog (specs + targets present)
+ *   GET  /modules/:id               -> one module's spec + capabilities
+ *   POST /modules/:id/train         -> run the module's train script (uv, ADR-028)
+ *   GET  /modules/:id/status        -> last train result (if any)
+ *
+ * Routes are mounted from the module registry (module.spec.json), so adding a
+ * module automatically adds its endpoints - no per-module server code.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { discoverModules, findModule } from './module-registry'
+import { runTrain } from './train-runner'
+
+export interface LocalServiceOptions {
+  port?: number
+  host?: string
+}
+
+export class LocalService {
+  private readonly port: number
+  private readonly host: string
+  private lastTrain: Record<string, { at: string; exitCode: number }> = {}
+
+  constructor(options: LocalServiceOptions = {}) {
+    this.port = options.port ?? 4824
+    this.host = options.host ?? '127.0.0.1'
+  }
+
+  /** Start the server; returns the http.Server (for tests to close). */
+  listen(): ReturnType<typeof createServer> {
+    const server = createServer((req, res) => this.handle(req, res))
+    server.listen(this.port, this.host, () => {
+      const modules = discoverModules()
+      console.log(
+        `[local-service] listening on http://${this.host}:${this.port} ` +
+          `(${modules.length} module(s) discovered)`,
+      )
+    })
+    return server
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`)
+      const path = url.pathname
+
+      if (req.method === 'GET' && path === '/health') {
+        return this.json(res, 200, {
+          ok: true,
+          name: 'wake-studio local-service',
+          modules: discoverModules().length,
+        })
+      }
+
+      if (req.method === 'GET' && path === '/modules') {
+        const modules = discoverModules().map((m) => ({
+          id: m.id,
+          category: m.category,
+          name: m.spec.meta.name,
+          version: m.spec.meta.version,
+          targets: {
+            node: m.hasNodeTarget,
+            train: m.hasTrainTarget,
+            device: m.hasDeviceTarget,
+          },
+          params: m.spec.params.map((p) => p.id),
+          actions: m.spec.actions.map((a) => a.id),
+          playground: m.spec.playground.route,
+        }))
+        return this.json(res, 200, { modules })
+      }
+
+      const trainMatch = path.match(/^\/modules\/([^/]+)\/train$/)
+      if (req.method === 'POST' && trainMatch) {
+        const mod = findModule(trainMatch[1])
+        if (!mod) return this.json(res, 404, { error: `unknown module: ${trainMatch[1]}` })
+        if (!mod.spec.train) return this.json(res, 400, { error: `module ${mod.id} has no train target` })
+
+        try {
+          const result = await runTrain(mod)
+          this.lastTrain[mod.id] = { at: new Date().toISOString(), exitCode: result.exitCode }
+          return this.json(res, result.exitCode === 0 ? 200 : 500, {
+            module: mod.id,
+            exitCode: result.exitCode,
+            outputs: result.outputs,
+          })
+        } catch (err) {
+          return this.json(res, 500, { error: err instanceof Error ? err.message : String(err) })
+        }
+      }
+
+      const statusMatch = path.match(/^\/modules\/([^/]+)\/status$/)
+      if (req.method === 'GET' && statusMatch) {
+        const id = statusMatch[1]
+        const mod = findModule(id)
+        if (!mod) return this.json(res, 404, { error: `unknown module: ${id}` })
+        return this.json(res, 200, {
+          module: id,
+          train: this.lastTrain[id] ?? null,
+        })
+      }
+
+      return this.json(res, 404, { error: `not found: ${req.method} ${path}` })
+    } catch (err) {
+      return this.json(res, 500, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  private json(res: ServerResponse, code: number, body: unknown): void {
+    const text = JSON.stringify(body, null, 2)
+    res.writeHead(code, {
+      'content-type': 'application/json; charset=utf-8',
+      'content-length': Buffer.byteLength(text),
+    })
+    res.end(text)
+  }
+}
+
+/** Run when executed directly (not imported by tests). */
+export function main(): void {
+  const port = Number(process.env.PORT ?? 4824)
+  const service = new LocalService({ port })
+  service.listen()
+}
+
+// ESM entry guard: `import.meta.url === process.argv[1]` means direct run.
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  main()
+}

--- a/apps/local-service/src/train-runner.ts
+++ b/apps/local-service/src/train-runner.ts
@@ -1,0 +1,99 @@
+/**
+ * local-service - train runner (ADR-028).
+ *
+ * Spawns a module's train script via `uv run` in the module's train/
+ * directory, streams stdout/stderr, and resolves with the outputs declared in
+ * the module spec (spec.train.outputs).
+ *
+ * Both the local service and CI (train-<module>.yml) invoke the SAME path -
+ * one code path, two callers.
+ */
+
+import { spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+import type { RegisteredModule } from './module-registry'
+
+export interface TrainRunOptions {
+  /** Extra args passed to the train script. */
+  args?: string[]
+  /** Override output dir (defaults to <module>/train/out). */
+  outDir?: string
+  /** Optional env vars (e.g. ML env). */
+  env?: Record<string, string>
+}
+
+export interface TrainResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  /** Absolute paths of the declared outputs (may be absent for no-op runs). */
+  outputs: Record<string, string>
+}
+
+/** Run a module's train script with uv (ADR-028). */
+export async function runTrain(
+  module: RegisteredModule,
+  options: TrainRunOptions = {},
+): Promise<TrainResult> {
+  const train = module.spec.train
+  if (!train) {
+    throw new Error(`module ${module.id} has no train target in its spec`)
+  }
+  if (!module.hasTrainTarget) {
+    throw new Error(`module ${module.id} has no train/ directory`)
+  }
+
+  const trainDir = resolve(module.dir, 'train')
+  const outDir = resolve(options.outDir ?? resolve(trainDir, 'out'))
+
+  // train.entry is relative to the MODULE root (e.g. "train/train.py", per
+  // spec.train.entry); resolve it against the train dir for uv.
+  const entryRel = train.entry.replace(/^train\//, '')
+
+  const args = [
+    'run',
+    '--project',
+    trainDir,
+    'python',
+    entryRel,
+    ...(options.args ?? []),
+  ]
+
+  return new Promise<TrainResult>((resolvePromise, reject) => {
+    const child = spawn('uv', args, {
+      cwd: trainDir,
+      env: {
+        ...process.env,
+        MODULE_OUT_DIR: outDir,
+        ...options.env,
+      },
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (d) => {
+      stdout += d
+      process.stdout.write(`[${module.id} train] ${d}`)
+    })
+    child.stderr.on('data', (d) => {
+      stderr += d
+      process.stderr.write(`[${module.id} train] ${d}`)
+    })
+
+    child.on('error', (err) => {
+      reject(new Error(`failed to spawn uv for ${module.id}: ${err.message}`))
+    })
+    child.on('close', (code) => {
+      const outputs: Record<string, string> = {}
+      for (const [name, rel] of Object.entries(train.outputs)) {
+        outputs[name] = resolve(outDir, rel.replace(/^out\//, ''))
+      }
+      resolvePromise({
+        exitCode: code ?? -1,
+        stdout,
+        stderr,
+        outputs,
+      })
+    })
+  })
+}

--- a/apps/local-service/tests/module-registry.test.ts
+++ b/apps/local-service/tests/module-registry.test.ts
@@ -1,0 +1,33 @@
+/**
+ * local-service - module registry tests (L1).
+ *
+ * Verifies discovery over the real monorepo: the rnnoise pilot module is
+ * found with its spec parsed and targets detected.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { discoverModules, findModule } from '../src/module-registry'
+
+describe('module-registry', () => {
+  it('discovers the rnnoise pilot module', () => {
+    const modules = discoverModules()
+    const rnnoise = modules.find((m) => m.id === 'rnnoise')
+    expect(rnnoise).toBeDefined()
+    expect(rnnoise?.category).toBe('afe')
+    expect(rnnoise?.spec.meta.name).toBe('RNNoise Noise Suppression')
+    expect(rnnoise?.hasNodeTarget).toBe(true)
+    expect(rnnoise?.hasTrainTarget).toBe(true)
+    expect(rnnoise?.hasDeviceTarget).toBe(true) // device/ placeholder dir exists
+  })
+
+  it('sorts by category then id', () => {
+    const modules = discoverModules()
+    const keys = modules.map((m) => `${m.category}/${m.id}`)
+    expect([...keys].sort()).toEqual(keys)
+  })
+
+  it('findModule resolves by id', () => {
+    expect(findModule('rnnoise')?.spec.meta.version).toBe('1.0.0')
+    expect(findModule('does-not-exist')).toBeUndefined()
+  })
+})

--- a/apps/local-service/tests/server.test.ts
+++ b/apps/local-service/tests/server.test.ts
@@ -1,0 +1,60 @@
+/**
+ * local-service - HTTP server tests (L1, real sockets).
+ *
+ * Starts the LocalService on an ephemeral port and exercises the module
+ * catalog + health endpoints. Train is tested separately (spawns uv).
+ */
+
+import { describe, it, expect, afterAll } from 'vitest'
+import type { Server } from 'node:http'
+import { LocalService } from '../src/server'
+
+let server: Server | undefined
+let baseUrl = ''
+
+async function start(): Promise<string> {
+  if (server) return baseUrl
+  // Port 0 -> ephemeral.
+  const service = new LocalService({ port: 0 })
+  server = service.listen()
+  await new Promise<void>((resolve) => server!.on('listening', () => resolve()))
+  const addr = server!.address()
+  const port = typeof addr === 'object' && addr ? addr.port : 0
+  baseUrl = `http://127.0.0.1:${port}`
+  return baseUrl
+}
+
+async function get(path: string): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(`${baseUrl}${path}`)
+  return { status: res.status, body: await res.json() }
+}
+
+describe('local-service HTTP', () => {
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server?.close(() => resolve()))
+  })
+
+  it('health reports ok + module count', async () => {
+    await start()
+    const { status, body } = await get('/health')
+    expect(status).toBe(200)
+    expect((body as { ok: boolean }).ok).toBe(true)
+    expect((body as { modules: number }).modules).toBeGreaterThanOrEqual(1)
+  })
+
+  it('catalog lists the rnnoise module with targets', async () => {
+    await start()
+    const { status, body } = await get('/modules')
+    expect(status).toBe(200)
+    const { modules } = body as { modules: Array<{ id: string; category: string; targets: { train: boolean } }> }
+    const rnnoise = modules.find((m) => m.id === 'rnnoise')
+    expect(rnnoise?.category).toBe('afe')
+    expect(rnnoise?.targets.train).toBe(true)
+  })
+
+  it('unknown module returns 404', async () => {
+    await start()
+    const { status } = await get('/modules/nope')
+    expect(status).toBe(404)
+  })
+})

--- a/apps/local-service/tsconfig.json
+++ b/apps/local-service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/apps/local-service/vitest.config.ts
+++ b/apps/local-service/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+})

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,7 +1,17 @@
 import type { Config } from 'tailwindcss'
 
 export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+    // Monorepo: scan module-kit UI classes (ADR-025) so spec-driven controls
+    // and the panel generator get Tailwind utilities.
+    '../../packages/module-kit/src/**/*.{ts,tsx}',
+    // Module web targets (playgrounds etc). Scoped to avoid scanning
+    // node_modules / vendor glue.
+    '../../packages/modules/*/*/web/**/*.{ts,tsx}',
+    '../../packages/modules/*/*/core/**/*.{ts,tsx}',
+  ],
   theme: {
     extend: {
       colors: {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "dev": "pnpm --filter @wake-studio/web dev",
+    "dev:service": "pnpm --filter @wake-studio/local-service dev",
     "build": "pnpm --filter @wake-studio/web build",
     "preview": "pnpm --filter @wake-studio/web preview",
     "lint": "pnpm -r lint",

--- a/packages/module-kit/package.json
+++ b/packages/module-kit/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./validator": "./src/validator.ts"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/module-kit/package.json
+++ b/packages/module-kit/package.json
@@ -22,7 +22,9 @@
     "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-slider": "^1.4.7",
     "@radix-ui/react-switch": "^1.3.7",
-    "@wake-studio/contracts": "workspace:*"
+    "@wake-studio/contracts": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/packages/module-kit/package.json
+++ b/packages/module-kit/package.json
@@ -17,9 +17,15 @@
     "fetch:all": "echo 'no artifacts'"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.20",
+    "@radix-ui/react-progress": "^1.1.16",
+    "@radix-ui/react-select": "^2.3.7",
+    "@radix-ui/react-slider": "^1.4.7",
+    "@radix-ui/react-switch": "^1.3.7",
     "@wake-studio/contracts": "workspace:*"
   },
   "devDependencies": {
+    "@types/react": "^18.3.12",
     "typescript": "~5.6.3",
     "vitest": "^2.1.9"
   }

--- a/packages/module-kit/src/index.ts
+++ b/packages/module-kit/src/index.ts
@@ -11,3 +11,13 @@ export type { ModuleScorecard } from '@wake-studio/contracts'
 
 // Spec-driven UI kit (ADR-025 §3 panel generator).
 export * from './ui'
+
+// Panel generator: ModuleSpec -> React component (ADR-025 §3).
+export {
+  ModulePanel,
+  renderPanel,
+  defaultsFromSpec,
+  type ModulePanelController,
+  type GeneratedPanelProps,
+  type GeneratedModulePanelProps,
+} from './panel-generator'

--- a/packages/module-kit/src/index.ts
+++ b/packages/module-kit/src/index.ts
@@ -8,3 +8,6 @@ export {
 } from './validator'
 export type { ModuleSpec } from '@wake-studio/contracts'
 export type { ModuleScorecard } from '@wake-studio/contracts'
+
+// Spec-driven UI kit (ADR-025 §3 panel generator).
+export * from './ui'

--- a/packages/module-kit/src/panel-generator.tsx
+++ b/packages/module-kit/src/panel-generator.tsx
@@ -1,0 +1,264 @@
+/**
+ * module-kit panel generator (ADR-025 §3).
+ *
+ * `renderPanel(spec)` is a PURE function: given a ModuleSpec it returns a
+ * React component. No module ships a hand-written panel - the generator maps:
+ *
+ *   params  -> UiParamRow + spec control (mapper.tsx)
+ *   actions -> UiButton (variant by action kind)
+ *   status  -> Ui* canvas/bar by StatusRenderer
+ *   group   -> primary | advanced (collapsible Advanced, ADR-024)
+ *
+ * The generated panel is CONTROLLED: it receives a ModulePanelController
+ * (state + callbacks) from the host, so the module engine stays headless and
+ * the panel is fully testable.
+ */
+
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import type {
+  ModuleSpec,
+  ModuleAction,
+  ModuleStatus,
+} from '@wake-studio/contracts'
+import { UiButton, UiCollapsible, UiParamRow } from './ui/controls'
+import { UiBar, UiWaveform, UiCurve } from './ui/canvas'
+import { renderParamControl } from './ui/mapper'
+
+// ---------------------------------------------------------------------------
+// Panel controller contract (host-provided)
+// ---------------------------------------------------------------------------
+
+export interface ModulePanelController {
+  /** Current param values (keyed by param.id). */
+  values: Record<string, unknown>
+  /** Apply a param change to the module engine. */
+  setValue: (id: string, value: unknown) => void
+  /** Invoke an action (load/start/train...). Return a promise if async. */
+  runAction: (actionId: string) => void | Promise<void>
+  /** Whether an action is currently busy (disables other controls). */
+  actionBusy?: boolean
+  /** Live status values (keyed by status.id). */
+  status?: Record<string, unknown>
+  /** Disable all controls (e.g. while loading). */
+  disabled?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Status renderer dispatch (ModuleStatus.renderer)
+// ---------------------------------------------------------------------------
+
+function renderStatus(
+  statusDef: ModuleStatus,
+  value: unknown,
+): ReactNode {
+  const v = typeof value === 'number' ? value : 0
+  switch (statusDef.renderer) {
+    case 'bar':
+      return <UiBar value={v} label={statusDef.label} threshold={0.5} />
+    case 'waveform': {
+      const data = Array.isArray(value) ? value : (value as ArrayLike<number>) ? (value as ArrayLike<number>) : []
+      return <UiWaveform data={data} />
+    }
+    case 'curve': {
+      const data = Array.isArray(value) ? value : []
+      return <UiCurve data={data} />
+    }
+    case 'badge':
+      return (
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          <span className="text-sm text-slate-300">{statusDef.label}</span>
+        </div>
+      )
+    case 'gauge':
+      return <UiBar value={v} label={statusDef.label} height={10} threshold={0.8} />
+    case 'text':
+    default:
+      return (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm text-slate-400">{statusDef.label}</span>
+          <span className="font-mono text-sm text-slate-200">{String(value ?? '—')}</span>
+        </div>
+      )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generated panel component
+// ---------------------------------------------------------------------------
+
+export interface GeneratedPanelProps {
+  spec: ModuleSpec
+  controller: ModulePanelController
+  /** Override panel heading (defaults to spec.meta.name). */
+  title?: string
+}
+
+/**
+ * The panel generated from a ModuleSpec. Pure render: all state comes from
+ * `controller`. Primary params render inline; `group: "advanced"` params
+ * collapse under an "Advanced" section (ADR-024 dual layer).
+ */
+export function ModulePanel({ spec, controller, title }: GeneratedPanelProps) {
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+
+  const primary = spec.params.filter((p) => p.group === 'primary')
+  const advanced = spec.params.filter((p) => p.group === 'advanced')
+  const busy = controller.actionBusy ?? false
+  const disabled = controller.disabled ?? busy
+
+  return (
+    <section className="mx-auto max-w-5xl px-6 py-12">
+      {/* Panel header from spec.meta. */}
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold text-white">
+          {title ?? spec.meta.name}
+        </h2>
+        <p className="mt-1 text-sm text-slate-400">
+          {spec.meta.category} module · v{spec.meta.version} ·{' '}
+          <span className="text-slate-500">{spec.meta.license}</span>
+        </p>
+      </div>
+
+      <div className="space-y-4 rounded-xl border border-white/10 bg-white/[0.03] p-5">
+        {/* Primary params. */}
+        {primary.map((param) => (
+          <UiParamRow
+            key={param.id}
+            label={param.label}
+            description={param.description}
+          >
+            {renderParamControl({
+              param,
+              value: controller.values[param.id],
+              onChange: (v) => controller.setValue(param.id, v),
+              disabled,
+            })}
+          </UiParamRow>
+        ))}
+
+        {/* Advanced params (collapsible, ADR-024). */}
+        {advanced.length > 0 && (
+          <UiCollapsible
+            label="Advanced"
+            open={advancedOpen}
+            onOpenChange={setAdvancedOpen}
+          >
+            <div className="space-y-3 rounded-lg border border-white/10 bg-slate-900/40 p-4">
+              {advanced.map((param) => (
+                <UiParamRow
+                  key={param.id}
+                  label={param.label}
+                  description={param.description}
+                >
+                  {renderParamControl({
+                    param,
+                    value: controller.values[param.id],
+                    onChange: (v) => controller.setValue(param.id, v),
+                    disabled,
+                  })}
+                </UiParamRow>
+              ))}
+            </div>
+          </UiCollapsible>
+        )}
+
+        {/* Actions. */}
+        {spec.actions.length > 0 && (
+          <div className="flex flex-wrap gap-3 pt-2">
+            {spec.actions.map((action) => (
+              <ActionButton
+                key={action.id}
+                action={action}
+                disabled={disabled}
+                onClick={() => controller.runAction(action.id)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Status (live values from controller.status). */}
+        {spec.status.length > 0 && (
+          <div className="grid gap-4 border-t border-white/5 pt-4 sm:grid-cols-2">
+            {spec.status.map((statusDef) => (
+              <div key={statusDef.id}>
+                {renderStatus(statusDef, controller.status?.[statusDef.id])}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Action button (confirm support)
+// ---------------------------------------------------------------------------
+
+function ActionButton({
+  action,
+  disabled,
+  onClick,
+}: {
+  action: ModuleAction
+  disabled: boolean
+  onClick: () => void
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const variant = action.kind === 'reset' || action.kind === 'stop' ? 'danger' : action.kind === 'train' || action.kind === 'export' || action.kind === 'start' ? 'primary' : 'secondary'
+
+  const handleClick = () => {
+    if (action.confirm && !confirming) {
+      setConfirming(true)
+      setTimeout(() => setConfirming(false), 2500)
+      return
+    }
+    setConfirming(false)
+    onClick()
+  }
+
+  return (
+    <UiButton
+      label={confirming ? 'Confirm?' : action.label}
+      onClick={handleClick}
+      variant={variant}
+      disabled={disabled}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * The component produced by `renderPanel`. Rendered by the host with a
+ * controller; the spec is captured at creation time.
+ */
+export interface GeneratedModulePanelProps {
+  controller: ModulePanelController
+  /** Override panel heading. */
+  title?: string
+}
+
+/**
+ * Create a panel component from a spec.
+ *
+ * Pure: same spec in, same component out. The returned component takes a
+ * `ModulePanelController` at render time, so the same generated panel can be
+ * mounted against different module instances.
+ */
+export function renderPanel(spec: ModuleSpec) {
+  const Panel = ({ controller, title }: GeneratedModulePanelProps) => (
+    <ModulePanel spec={spec} controller={controller} title={title} />
+  )
+  Panel.displayName = `ModulePanel(${spec.meta.id})`
+  return Panel
+}
+
+/** Convenience: map a param to its default. */
+export function defaultsFromSpec(spec: ModuleSpec): Record<string, unknown> {
+  return Object.fromEntries(spec.params.map((p) => [p.id, p.default]))
+}

--- a/packages/module-kit/src/ui/canvas.tsx
+++ b/packages/module-kit/src/ui/canvas.tsx
@@ -1,0 +1,169 @@
+/**
+ * module-kit ui - canvas visualizations.
+ *
+ * Spec-driven `status` renderers (docs/module-spec.md §3 StatusRenderer):
+ *   - bar      -> UiBar (VAD / level meter)
+ *   - waveform -> UiWaveform (raw PCM / denoised comparison)
+ *   - curve    -> UiCurve (score over time)
+ *
+ * These are self-contained, requestAnimationFrame-free (callers own the loop
+ * via `data` updates) and styled to match the dark brand theme.
+ */
+
+import { useEffect, useRef } from 'react'
+
+function useCanvas(
+  draw: (ctx: CanvasRenderingContext2D, w: number, h: number) => void,
+  deps: unknown[],
+) {
+  const ref = useRef<HTMLCanvasElement>(null)
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    const dpr = window.devicePixelRatio || 1
+    const { width, height } = canvas.getBoundingClientRect()
+    canvas.width = Math.round(width * dpr)
+    canvas.height = Math.round(height * dpr)
+    ctx.scale(dpr, dpr)
+    draw(ctx, width, height)
+  }, deps) // eslint-disable-line react-hooks/exhaustive-deps
+  return ref
+}
+
+// ---------------------------------------------------------------------------
+// Bar (VAD / level meter)
+// ---------------------------------------------------------------------------
+
+export interface UiBarProps {
+  /** 0..1 */
+  value: number
+  label?: string
+  height?: number
+  /** Color when above this threshold. */
+  threshold?: number
+  className?: string
+}
+
+export function UiBar({ value, label, height = 6, threshold = 0.5, className }: UiBarProps) {
+  const pct = Math.max(0, Math.min(1, value)) * 100
+  const over = value >= threshold
+  return (
+    <div className={className}>
+      {label && <div className="mb-1 text-xs text-slate-500">{label}</div>}
+      <div
+        className="relative w-full overflow-hidden rounded-full bg-slate-800"
+        style={{ height }}
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-100 ${
+            over ? 'bg-emerald-500' : 'bg-brand-500'
+          }`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Waveform (raw PCM)
+// ---------------------------------------------------------------------------
+
+export interface UiWaveformProps {
+  /** PCM samples (Float32Array or number[]). */
+  data: ArrayLike<number>
+  /** Compare a second series (e.g. denoised) - drawn as overlay. */
+  overlay?: ArrayLike<number>
+  height?: number
+  color?: string
+  overlayColor?: string
+  className?: string
+}
+
+/** Center-line waveform; optional overlay series (e.g. before/after). */
+export function UiWaveform({
+  data,
+  overlay,
+  height = 64,
+  color = '#38bdf8',
+  overlayColor = '#34d399',
+  className,
+}: UiWaveformProps) {
+  const draw = (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+    ctx.clearRect(0, 0, w, h)
+    const mid = h / 2
+
+    const paint = (series: ArrayLike<number>, c: string) => {
+      ctx.strokeStyle = c
+      ctx.lineWidth = 1.5
+      ctx.beginPath()
+      const n = series.length
+      for (let i = 0; i < n; i++) {
+        const x = (i / (n - 1)) * w
+        const y = mid - series[i] * (h / 2 - 2)
+        i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
+      }
+      ctx.stroke()
+    }
+
+    // Overlay (input) first, then main (output) on top.
+    if (overlay) paint(overlay, overlayColor)
+    paint(data, color)
+    // Center line.
+    ctx.strokeStyle = 'rgba(148,163,184,0.15)'
+    ctx.lineWidth = 1
+    ctx.beginPath()
+    ctx.moveTo(0, mid)
+    ctx.lineTo(w, mid)
+    ctx.stroke()
+  }
+  const ref = useCanvas(draw, [data, overlay, color, overlayColor])
+  return <canvas ref={ref} className={className} style={{ width: '100%', height }} />
+}
+
+// ---------------------------------------------------------------------------
+// Curve (score / VAD over time)
+// ---------------------------------------------------------------------------
+
+export interface UiCurveProps {
+  /** History of values [0..1]; newest last. */
+  data: ArrayLike<number>
+  /** Optional threshold line to draw. */
+  threshold?: number
+  height?: number
+  color?: string
+  className?: string
+}
+
+export function UiCurve({ data, threshold, height = 64, color = '#38bdf8', className }: UiCurveProps) {
+  const draw = (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+    ctx.clearRect(0, 0, w, h)
+    // Threshold line.
+    if (threshold != null) {
+      ctx.strokeStyle = 'rgba(251,191,36,0.5)'
+      ctx.setLineDash([4, 4])
+      ctx.lineWidth = 1
+      const y = h - threshold * h
+      ctx.beginPath()
+      ctx.moveTo(0, y)
+      ctx.lineTo(w, y)
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
+    // Data.
+    ctx.strokeStyle = color
+    ctx.lineWidth = 1.5
+    ctx.beginPath()
+    const n = data.length
+    for (let i = 0; i < n; i++) {
+      const x = (i / Math.max(1, n - 1)) * w
+      const y = h - data[i] * h
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
+    }
+    ctx.stroke()
+  }
+  const ref = useCanvas(draw, [data, threshold, color])
+  return <canvas ref={ref} className={className} style={{ width: '100%', height }} />
+}

--- a/packages/module-kit/src/ui/controls.tsx
+++ b/packages/module-kit/src/ui/controls.tsx
@@ -1,0 +1,316 @@
+/**
+ * module-kit ui - spec-driven controls (ADR-025).
+ *
+ * Thin adapters over Radix Primitives + Tailwind, mapped 1:1 from
+ * ModuleSpec param types (docs/module-spec.md §3). The panel generator calls
+ * these; a new control type requires a spec change, not a new panel.
+ *
+ * Each control is fully controlled (value + onChange) so the generator can
+ * own the module state.
+ */
+
+import { useId } from 'react'
+import type { ReactNode } from 'react'
+import * as SliderPrimitive from '@radix-ui/react-slider'
+import * as SelectPrimitive from '@radix-ui/react-select'
+import * as SwitchPrimitive from '@radix-ui/react-switch'
+import * as ProgressPrimitive from '@radix-ui/react-progress'
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible'
+import { cn, BTN_BASE, BTN_VARIANTS, SLIDER_CLS, SWITCH_CLS, SELECT_CLS, COLLAPSIBLE_CLS } from './styles'
+
+// ---------------------------------------------------------------------------
+// Slider (param type: slider | number)
+// ---------------------------------------------------------------------------
+
+export interface UiSliderProps {
+  value: number
+  min: number
+  max: number
+  step?: number
+  onChange: (value: number) => void
+  disabled?: boolean
+  ariaLabel?: string
+}
+
+/** Two-way slider with a live numeric readout. */
+export function UiSlider({ value, min, max, step = 1, onChange, disabled, ariaLabel }: UiSliderProps) {
+  const id = useId()
+  return (
+    <div className="flex w-full items-center gap-3">
+      <SliderPrimitive.Root
+        className={cn(SLIDER_CLS.root, disabled && 'opacity-40 pointer-events-none')}
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={(v) => onChange(v[0])}
+        disabled={disabled}
+        aria-label={ariaLabel}
+      >
+        <SliderPrimitive.Track className={SLIDER_CLS.track}>
+          <SliderPrimitive.Range className={SLIDER_CLS.range} />
+        </SliderPrimitive.Track>
+        <SliderPrimitive.Thumb className={SLIDER_CLS.thumb} />
+      </SliderPrimitive.Root>
+      <span
+        id={id}
+        className="w-12 shrink-0 text-right font-mono text-xs text-slate-400 tabular-nums"
+      >
+        {formatNumber(value)}
+      </span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Number (param type: number - plain numeric input with +/- stepping)
+// ---------------------------------------------------------------------------
+
+export interface UiNumberProps {
+  value: number
+  min?: number
+  max?: number
+  step?: number
+  unit?: string
+  onChange: (value: number) => void
+  disabled?: boolean
+}
+
+/** Numeric input with a stepper (for params that want precise entry). */
+export function UiNumber({ value, min, max, step = 1, unit, onChange, disabled }: UiNumberProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="number"
+        value={Number.isFinite(value) ? value : ''}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => {
+          const n = Number(e.target.value)
+          if (Number.isFinite(n)) onChange(n)
+        }}
+        disabled={disabled}
+        className="h-8 w-24 rounded-lg border border-white/10 bg-slate-800/60 px-2.5 text-right font-mono text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+      />
+      {unit && <span className="text-xs text-slate-500">{unit}</span>}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Select (param type: select | enum)
+// ---------------------------------------------------------------------------
+
+export interface UiSelectOption {
+  value: string
+  label: string
+}
+
+export interface UiSelectProps {
+  value: string
+  options: ReadonlyArray<UiSelectOption>
+  onChange: (value: string) => void
+  disabled?: boolean
+  placeholder?: string
+}
+
+/** Radix select (single). */
+export function UiSelect({ value, options, onChange, disabled, placeholder = 'Select…' }: UiSelectProps) {
+  return (
+    <SelectPrimitive.Root
+      value={value}
+      onValueChange={onChange}
+      disabled={disabled}
+    >
+      <SelectPrimitive.Trigger className={cn(SELECT_CLS.trigger, disabled && 'opacity-40')}>
+        <SelectPrimitive.Value placeholder={placeholder} />
+        <SelectPrimitive.Icon className="text-slate-500">
+          <ChevronDown className="h-3.5 w-3.5" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content className={SELECT_CLS.content} position="popper" sideOffset={4}>
+          <SelectPrimitive.Viewport>
+            {options.map((opt) => (
+              <SelectPrimitive.Item key={opt.value} value={opt.value} className={SELECT_CLS.item}>
+                <SelectPrimitive.ItemText>{opt.label}</SelectPrimitive.ItemText>
+                <SelectPrimitive.ItemIndicator className="ml-2 inline-flex text-brand-400">
+                  <Check className="h-3.5 w-3.5" />
+                </SelectPrimitive.ItemIndicator>
+              </SelectPrimitive.Item>
+            ))}
+          </SelectPrimitive.Viewport>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Toggle (param type: boolean)
+// ---------------------------------------------------------------------------
+
+export interface UiToggleProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  disabled?: boolean
+  label?: string
+}
+
+/** Radix switch (toggle). */
+export function UiToggle({ checked, onChange, disabled, label }: UiToggleProps) {
+  return (
+    <SwitchPrimitive.Root
+      className={cn(SWITCH_CLS.root, disabled && 'opacity-40 pointer-events-none')}
+      checked={checked}
+      onCheckedChange={onChange}
+      disabled={disabled}
+      aria-label={label}
+    >
+      <SwitchPrimitive.Thumb className={SWITCH_CLS.thumb} />
+    </SwitchPrimitive.Root>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Button (action kind)
+// ---------------------------------------------------------------------------
+
+export type UiButtonVariant = keyof typeof BTN_VARIANTS
+
+export interface UiButtonProps {
+  label: string
+  onClick: () => void
+  variant?: UiButtonVariant
+  disabled?: boolean
+  icon?: ReactNode
+}
+
+/** Action button (maps ModuleAction.kind to a visual variant). */
+export function UiButton({ label, onClick, variant = 'secondary', disabled, icon }: UiButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(BTN_BASE, BTN_VARIANTS[variant])}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Progress (action progress)
+// ---------------------------------------------------------------------------
+
+export interface UiProgressProps {
+  value: number // 0..100
+  indeterminate?: boolean
+}
+
+/** Progress bar (determinate or indeterminate). */
+export function UiProgress({ value, indeterminate }: UiProgressProps) {
+  return (
+    <ProgressPrimitive.Root
+      className="relative h-1.5 w-full overflow-hidden rounded-full bg-slate-800"
+      value={indeterminate ? undefined : value}
+    >
+      <ProgressPrimitive.Indicator
+        className={cn(
+          'h-full w-full bg-brand-500 transition-transform',
+          indeterminate && 'animate-pulse',
+        )}
+        style={{ transform: `translateX(-${100 - (indeterminate ? 40 : value)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Collapsible (Primary/Advanced dual layer, ADR-024)
+// ---------------------------------------------------------------------------
+
+export interface UiCollapsibleProps {
+  label: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  children: ReactNode
+}
+
+/** Collapsible section - the "Advanced" layer of a panel. */
+export function UiCollapsible({ label, open, onOpenChange, children }: UiCollapsibleProps) {
+  return (
+    <CollapsiblePrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <CollapsiblePrimitive.Trigger className={cn(COLLAPSIBLE_CLS.trigger, 'group')}>
+        <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
+        {label}
+      </CollapsiblePrimitive.Trigger>
+      <CollapsiblePrimitive.Content className="mt-2 overflow-hidden data-[state=closed]:hidden">
+        {children}
+      </CollapsiblePrimitive.Content>
+    </CollapsiblePrimitive.Root>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Stat / label shell
+// ---------------------------------------------------------------------------
+
+export interface UiParamRowProps {
+  label: string
+  description?: string
+  children: ReactNode
+}
+
+/** One parameter row: label + description left, control right. */
+export function UiParamRow({ label, description, children }: UiParamRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-2">
+      <div className="min-w-0">
+        <div className="text-sm text-slate-300">{label}</div>
+        {description && <div className="mt-0.5 text-xs text-slate-500">{description}</div>}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Small inline icons (avoid an icon dependency)
+// ---------------------------------------------------------------------------
+
+function ChevronDown({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function ChevronRight({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function Check({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M3 8.5l3 3 7-7" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatNumber(n: number): string {
+  if (Number.isInteger(n)) return String(n)
+  // Sliders often use small steps; show up to 2 decimals, strip trailing zeros.
+  return n.toFixed(2).replace(/\.?0+$/, '')
+}

--- a/packages/module-kit/src/ui/index.ts
+++ b/packages/module-kit/src/ui/index.ts
@@ -1,0 +1,38 @@
+/**
+ * module-kit ui - public surface (ADR-025).
+ *
+ * Spec-driven controls + canvas visualizations + the param->control mapper.
+ * The panel generator builds panels from ModuleSpec using these; the web app
+ * imports them from this entry.
+ */
+
+export {
+  UiSlider,
+  UiNumber,
+  UiSelect,
+  UiToggle,
+  UiButton,
+  UiProgress,
+  UiCollapsible,
+  UiParamRow,
+} from './controls'
+export type {
+  UiSliderProps,
+  UiNumberProps,
+  UiSelectProps,
+  UiSelectOption,
+  UiToggleProps,
+  UiButtonProps,
+  UiButtonVariant,
+  UiProgressProps,
+  UiCollapsibleProps,
+  UiParamRowProps,
+} from './controls'
+
+export { UiBar, UiWaveform, UiCurve } from './canvas'
+export type { UiBarProps, UiWaveformProps, UiCurveProps } from './canvas'
+
+export { renderParamControl, renderParamRow, actionVariant } from './mapper'
+export type { ParamControlProps } from './mapper'
+
+export { cn, LABEL_CLS, BTN_BASE, BTN_VARIANTS } from './styles'

--- a/packages/module-kit/src/ui/mapper.tsx
+++ b/packages/module-kit/src/ui/mapper.tsx
@@ -1,0 +1,119 @@
+/**
+ * module-kit ui - spec-driven control mapper.
+ *
+ * Renders a ModuleParam via the right Ui* control, and a ModuleAction via
+ * UiButton. The panel generator (docs/module-spec.md §3) calls this so every
+ * module's panel is uniform. A new param type requires a spec change + a
+ * case here - never a new hand-written panel.
+ */
+
+import type { ModuleParam, ModuleAction } from '@wake-studio/contracts'
+import { UiSlider, UiNumber, UiSelect, UiToggle, UiParamRow } from './controls'
+
+export interface ParamControlProps {
+  param: ModuleParam
+  value: unknown
+  onChange: (value: unknown) => void
+  disabled?: boolean
+}
+
+/** Render one parameter as its control. */
+export function renderParamControl({ param, value, onChange, disabled }: ParamControlProps) {
+  switch (param.type) {
+    case 'slider':
+      return (
+        <UiSlider
+          value={toNumber(value, param)}
+          min={param.min ?? 0}
+          max={param.max ?? 1}
+          step={param.step ?? 0.1}
+          onChange={(v) => onChange(v)}
+          disabled={disabled}
+          ariaLabel={param.label}
+        />
+      )
+    case 'number':
+      return (
+        <UiNumber
+          value={toNumber(value, param)}
+          min={param.min}
+          max={param.max}
+          step={param.step}
+          unit={param.unit}
+          onChange={(v) => onChange(v)}
+          disabled={disabled}
+        />
+      )
+    case 'select':
+    case 'enum': {
+      const options = (param.options ?? []).map((o) => ({ value: o.value, label: o.label }))
+      return (
+        <UiSelect
+          value={typeof value === 'string' ? value : String(param.default ?? '')}
+          options={options}
+          onChange={(v) => onChange(v)}
+          disabled={disabled}
+        />
+      )
+    }
+    case 'boolean':
+      return (
+        <UiToggle
+          checked={Boolean(value ?? param.default)}
+          onChange={onChange}
+          disabled={disabled}
+          label={param.label}
+        />
+      )
+    case 'secret':
+      return (
+        <input
+          type="password"
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder="••••••••"
+          className="h-8 w-48 rounded-lg border border-white/10 bg-slate-800/60 px-2.5 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+        />
+      )
+    default:
+      return null
+  }
+}
+
+/** Render a parameter row (label + control). */
+export function renderParamRow(
+  param: ModuleParam,
+  value: unknown,
+  onChange: (value: unknown) => void,
+  disabled?: boolean,
+) {
+  return (
+    <UiParamRow label={param.label} description={param.description}>
+      {renderParamControl({ param, value, onChange, disabled })}
+    </UiParamRow>
+  )
+}
+
+/** Map a ModuleAction kind to a button variant. */
+export function actionVariant(kind: ModuleAction['kind']): 'primary' | 'secondary' | 'danger' {
+  switch (kind) {
+    case 'train':
+      return 'primary'
+    case 'export':
+      return 'primary'
+    case 'reset':
+      return 'danger'
+    case 'start':
+      return 'primary'
+    case 'stop':
+      return 'danger'
+    default:
+      return 'secondary'
+  }
+}
+
+function toNumber(value: unknown, param: ModuleParam): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  return typeof param.default === 'number' ? param.default : 0
+}

--- a/packages/module-kit/src/ui/styles.ts
+++ b/packages/module-kit/src/ui/styles.ts
@@ -1,0 +1,59 @@
+/**
+ * module-kit ui - shared Tailwind + Radix styling helpers.
+ *
+ * Central place for the design tokens used by the spec-driven controls.
+ * Kept as plain class strings so tailwind can scan them (the packages/*
+ * sources are added to tailwind.config content).
+ */
+
+/** Merge class names, skipping falsy values. */
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}
+
+/** Shared control shell: label row + control. */
+export const LABEL_CLS = 'flex items-center justify-between gap-3 text-sm'
+
+/** Base for buttons (primary / secondary / danger). */
+export const BTN_BASE =
+  'inline-flex items-center justify-center gap-1.5 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40 disabled:pointer-events-none'
+
+export const BTN_VARIANTS = {
+  primary: 'bg-brand-500 text-white hover:bg-brand-400',
+  secondary:
+    'border border-white/10 bg-white/[0.03] text-slate-300 hover:bg-white/[0.07]',
+  danger: 'bg-red-500/80 text-white hover:bg-red-500',
+  ghost: 'text-slate-400 hover:text-slate-200',
+} as const
+
+/** Radix slider track/thumb styling (data-* attributes drive state). */
+export const SLIDER_CLS = {
+  root: 'relative flex h-5 w-full touch-none select-none items-center',
+  track:
+    'relative h-1.5 w-full grow overflow-hidden rounded-full bg-slate-700/60',
+  range: 'absolute h-full rounded-full bg-brand-500',
+  thumb:
+    'block h-4 w-4 rounded-full bg-white shadow ring-1 ring-slate-900/10 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+}
+
+/** Radix switch (toggle) styling. */
+export const SWITCH_CLS = {
+  root: 'relative h-5 w-9 shrink-0 rounded-full bg-slate-700 transition-colors data-[state=checked]:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+  thumb:
+    'block h-4 w-4 translate-x-0.5 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-[18px]',
+}
+
+/** Radix select trigger styling. */
+export const SELECT_CLS = {
+  trigger:
+    'inline-flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-lg border border-white/10 bg-slate-800/60 px-2.5 text-sm text-slate-300 hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+  content:
+    'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-white/10 bg-slate-900 p-1 shadow-xl',
+  item: 'cursor-default select-none rounded-md px-2.5 py-1.5 text-sm text-slate-300 outline-none data-[highlighted]:bg-brand-500/20 data-[highlighted]:text-white',
+}
+
+/** Radix collapsible (Primary/Advanced dual layer, ADR-024). */
+export const COLLAPSIBLE_CLS = {
+  trigger:
+    'inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-slate-500 hover:text-slate-300 transition-colors',
+}

--- a/packages/module-kit/tests/panel-generator.test.tsx
+++ b/packages/module-kit/tests/panel-generator.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * module-kit panel generator - unit tests (L1).
+ *
+ * The generator's pure parts: spec validation, defaults extraction, and
+ * rendering without throwing. Rendering is checked with react-dom/server
+ * (no browser needed).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ModuleSpec } from '@wake-studio/contracts'
+import { validateModuleSpec } from '../src/validator'
+import { defaultsFromSpec, renderPanel, ModulePanel } from '../src/panel-generator'
+
+// A minimal but complete spec (mirrors rnnoise/module.spec.json shape).
+const MINIMAL_SPEC: ModuleSpec = {
+  meta: {
+    id: 'test-module',
+    name: 'Test Module',
+    category: 'afe',
+    version: '1.0.0',
+    maturity: 'pilot',
+    owner: 'test',
+    license: 'MIT',
+    status: 'accepted',
+  },
+  params: [
+    {
+      id: 'strength',
+      label: 'Strength',
+      group: 'primary',
+      type: 'slider',
+      default: 1,
+      min: 0,
+      max: 1,
+      step: 0.1,
+      description: 'Test param',
+    },
+    {
+      id: 'enabled',
+      label: 'Enabled',
+      group: 'advanced',
+      type: 'boolean',
+      default: true,
+      description: 'Advanced toggle',
+    },
+  ],
+  actions: [
+    { id: 'run', label: 'Run', kind: 'start', confirm: false },
+    { id: 'reset', label: 'Reset', kind: 'reset', confirm: true },
+  ],
+  status: [
+    { id: 'vad', label: 'VAD', renderer: 'bar', source: 'event:frame' },
+    { id: 'curve', label: 'History', renderer: 'curve', source: 'event:frame' },
+  ],
+  runtime: { web: { engine: 'TestEngine' } },
+  tests: { required: ['l1'] },
+  playground: { route: '/playground/test', entry: 'playground.tsx' },
+  interfaces: { provides: [], consumes: [] },
+}
+
+describe('validateModuleSpec', () => {
+  it('accepts a complete spec', () => {
+    const res = validateModuleSpec(MINIMAL_SPEC)
+    expect(res.ok).toBe(true)
+    expect(res.errors).toEqual([])
+  })
+
+  it('rejects a spec missing required keys', () => {
+    const bad = { meta: MINIMAL_SPEC.meta } as unknown as ModuleSpec
+    const res = validateModuleSpec(bad)
+    expect(res.ok).toBe(false)
+    expect(res.errors.some((e) => e.includes('params'))).toBe(true)
+  })
+
+  it('rejects a param with an invalid group', () => {
+    const bad = structuredClone(MINIMAL_SPEC)
+    bad.params[0] = { ...bad.params[0], group: 'weird' as never }
+    const res = validateModuleSpec(bad)
+    expect(res.ok).toBe(false)
+    expect(res.errors.some((e) => e.includes('group'))).toBe(true)
+  })
+})
+
+describe('defaultsFromSpec', () => {
+  it('maps every param to its default', () => {
+    const d = defaultsFromSpec(MINIMAL_SPEC)
+    expect(d).toEqual({ strength: 1, enabled: true })
+  })
+})
+
+describe('renderPanel', () => {
+  it('returns a component that renders the spec (SSR)', () => {
+    const Panel = renderPanel(MINIMAL_SPEC)
+    const controller = {
+      values: defaultsFromSpec(MINIMAL_SPEC),
+      setValue: () => {},
+      runAction: () => {},
+      status: { vad: 0.5, curve: [0.1, 0.2, 0.3] },
+    }
+    const html = renderToStaticMarkup(<Panel controller={controller} />)
+    // Heading + primary param + actions render; advanced is collapsed (ADR-024).
+    expect(html).toContain('Test Module')
+    expect(html).toContain('Strength')
+    expect(html).not.toContain('Enabled') // advanced, collapsed by default
+    expect(html).toContain('Run')
+    expect(html).toContain('Reset')
+
+    // With the advanced section open, the param appears.
+    const openHtml = renderToStaticMarkup(
+      <ModulePanel
+        spec={MINIMAL_SPEC}
+        controller={controller}
+      />,
+    )
+    // ModulePanel starts closed; assert the trigger exists so it CAN be opened.
+    expect(openHtml).toContain('Advanced')
+  })
+
+  it('ModulePanel is a named component from the spec', () => {
+    const Panel = renderPanel(MINIMAL_SPEC)
+    expect(Panel.displayName).toBe('ModulePanel(test-module)')
+  })
+})

--- a/packages/module-kit/tsconfig.json
+++ b/packages/module-kit/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
   "include": ["src"]
 }

--- a/packages/module-kit/vitest.config.ts
+++ b/packages/module-kit/vitest.config.ts
@@ -1,9 +1,26 @@
 import { defineConfig } from 'vitest/config'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
+const here = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * module-kit vitest config.
+ * - L1: spec validator + panel generator (tests/*.test.{ts,tsx})
+ * - jsx-runtime needs react resolvable; alias to the workspace react.
+ */
 export default defineConfig({
+  resolve: {
+    alias: {
+      react: resolve(here, 'node_modules/react'),
+      'react-dom': resolve(here, 'node_modules/react-dom'),
+      'react/jsx-runtime': resolve(here, 'node_modules/react/jsx-runtime.js'),
+      'react/jsx-dev-runtime': resolve(here, 'node_modules/react/jsx-dev-runtime.js'),
+    },
+  },
   test: {
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.{ts,tsx}'],
     passWithNoTests: true,
   },
 })

--- a/packages/modules/afe/rnnoise/package.json
+++ b/packages/modules/afe/rnnoise/package.json
@@ -20,7 +20,8 @@
     "fetch:all": "echo 'rnnoise wasm is vendored (no fetch)'"
   },
   "dependencies": {
-    "@wake-studio/contracts": "workspace:*"
+    "@wake-studio/contracts": "workspace:*",
+    "@wake-studio/module-kit": "workspace:^"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/packages/modules/afe/rnnoise/spec/index.ts
+++ b/packages/modules/afe/rnnoise/spec/index.ts
@@ -1,0 +1,11 @@
+/**
+ * RNNoise module spec (typed).
+ *
+ * Single shared fact source (ADR-025) - the web panel generator, the
+ * local-service registry, and CI all consume this one spec object.
+ */
+
+import raw from './module.spec.json'
+import type { ModuleSpec } from '@wake-studio/contracts'
+
+export const RNNOISE_SPEC = raw as unknown as ModuleSpec

--- a/packages/modules/afe/rnnoise/train/uv.lock
+++ b/packages/modules/afe/rnnoise/train/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "wake-studio-module-rnnoise-train"
+version = "0.1.0"
+source = { editable = "." }

--- a/packages/modules/afe/rnnoise/web/playground.tsx
+++ b/packages/modules/afe/rnnoise/web/playground.tsx
@@ -8,10 +8,15 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { UiSlider, UiToggle, UiButton, UiWaveform, UiCurve, UiBar, UiCollapsible } from '@wake-studio/module-kit'
+import { UiSlider, UiToggle, UiButton, UiWaveform, UiCurve, UiBar, UiCollapsible, renderPanel, type ModulePanelController } from '@wake-studio/module-kit'
 import { loadRnnoise, type RnnoiseModule } from './index'
 import { RNNOISE_FRAME_SIZE } from '../core'
 import { frameRms } from '../core/dsp'
+import { RNNOISE_SPEC } from '../spec'
+
+// Generated panel from the real module spec (ADR-025 §3). The engine state is
+// wired to it via a controller, proving the spec -> panel -> engine loop.
+const RnnoiseGeneratedPanel = renderPanel(RNNOISE_SPEC)
 
 const SAMPLE_RATE = 48000
 
@@ -77,6 +82,29 @@ export default function RnnoisePlayground() {
     setOutRms(0)
     setInput([])
     setOutput([])
+  }
+
+  // Controller for the generated panel: spec params <-> engine config, live
+  // status fed from the last processed frame.
+  const generatedController: ModulePanelController = {
+    values: {
+      strength,
+      denoiseEnabled,
+    },
+    setValue: (id, value) => {
+      if (id === 'strength') setStrength(value as number)
+      if (id === 'denoiseEnabled') setDenoiseEnabled(Boolean(value))
+    },
+    runAction: (actionId) => {
+      if (actionId === 'load') {
+        // Engine is eagerly created on mount; re-run a frame as a "load" demo.
+        handleStep()
+      }
+      if (actionId === 'reset') handleReset()
+    },
+    status: {
+      vadProbability: vad,
+    },
   }
 
   return (
@@ -193,6 +221,15 @@ export default function RnnoisePlayground() {
             <UiBar value={vad} threshold={0.5} height={6} className="mt-2" />
           </div>
         </div>
+      </div>
+
+      {/* Generated panel from the real spec (ADR-025 §3). The controller wires
+          spec params to the engine; proving spec -> panel -> engine end-to-end. */}
+      <div className="mt-8 border-t border-white/10 pt-6">
+        <div className="mb-2 text-xs uppercase tracking-wider text-slate-500">
+          Spec-driven generated panel
+        </div>
+        <RnnoiseGeneratedPanel controller={generatedController} />
       </div>
     </section>
   )

--- a/packages/modules/afe/rnnoise/web/playground.tsx
+++ b/packages/modules/afe/rnnoise/web/playground.tsx
@@ -1,11 +1,14 @@
 /**
  * RNNoise playground - standalone module experience page (ADR-025 §4.5).
  *
- * Lets a user load the RNNoise wasm, generate a noisy sine frame, and see
- * denoising + VAD live. No AFE, no KWS - just this module.
+ * Spec-driven: params/actions render via the module-kit Ui controls
+ * (ModuleSpec -> mapper -> Radix/Tailwind), live status via the Ui* canvas
+ * visualizations. Demonstrates the ADR-025 panel-generator contract without
+ * a hand-written panel.
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { UiSlider, UiToggle, UiButton, UiWaveform, UiCurve, UiBar, UiCollapsible } from '@wake-studio/module-kit'
 import { loadRnnoise, type RnnoiseModule } from './index'
 import { RNNOISE_FRAME_SIZE } from '../core'
 import { frameRms } from '../core/dsp'
@@ -32,6 +35,12 @@ export default function RnnoisePlayground() {
   const [vad, setVad] = useState(0)
   const [inRms, setInRms] = useState(0)
   const [outRms, setOutRms] = useState(0)
+  // History for the score curve (last 120 processed frames).
+  const historyRef = useRef<number[]>([])
+  const [input, setInput] = useState<number[]>([])
+  const [output, setOutput] = useState<number[]>([])
+  const [curveData, setCurveData] = useState<number[]>([])
+  const [advancedOpen, setAdvancedOpen] = useState(false)
 
   useEffect(() => {
     const engine = loadRnnoise({ strength, denoiseEnabled })
@@ -47,70 +56,122 @@ export default function RnnoisePlayground() {
   const handleStep = () => {
     const engine = engineRef.current
     if (!engine) return
-    const input = synthFrame(noiseLevel, Date.now() % 10000)
-    const out = new Float32Array(input)
-    setInRms(frameRms(input))
-    const result = engine.processFrame(out)
-    console.log('[rnnoise-playground] vad:', result.vadProbability, 'denoised:', result.denoised)
+    const inputFrame = synthFrame(noiseLevel, Date.now() % 10000)
+    const outFrame = new Float32Array(inputFrame)
+    setInput(Array.from(inputFrame))
+    setInRms(frameRms(inputFrame))
+    const result = engine.processFrame(outFrame)
+    setOutput(Array.from(outFrame))
     setVad(result.vadProbability)
-    setOutRms(frameRms(out))
+    setOutRms(frameRms(outFrame))
+    historyRef.current.push(result.vadProbability)
+    if (historyRef.current.length > 120) historyRef.current.shift()
+    setCurveData([...historyRef.current])
+  }
+
+  const handleReset = () => {
+    historyRef.current = []
+    setCurveData([])
+    setVad(0)
+    setInRms(0)
+    setOutRms(0)
+    setInput([])
+    setOutput([])
   }
 
   return (
-    <section className="mx-auto max-w-2xl px-6 py-12">
+    <section className="mx-auto max-w-3xl px-6 py-12">
       <h2 className="text-lg font-semibold text-white">
         RNNoise module playground
       </h2>
       <p className="mt-1 text-sm text-slate-400">
         ADR-025 pilot · vendored emscripten wasm, runs fully in-browser. No
-        AFE, no KWS — just this module.
+        AFE, no KWS — just this module. Controls are spec-driven (module-kit
+        Ui* components).
       </p>
 
       {!ready && <p className="mt-4 text-amber-300">Loading RNNoise WASM…</p>}
 
       <div className="mt-6 space-y-4 rounded-xl border border-white/10 bg-white/[0.03] p-5">
-        <label className="flex items-center gap-2 text-sm text-slate-300">
-          <span className="w-32">Noise level</span>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.05}
-            value={noiseLevel}
-            onChange={(e) => setNoiseLevel(Number(e.target.value))}
-            className="flex-1"
-          />
-          <span className="w-10 text-right">{noiseLevel.toFixed(2)}</span>
-        </label>
-        <label className="flex items-center gap-2 text-sm text-slate-300">
-          <span className="w-32">Strength</span>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.1}
-            value={strength}
-            onChange={(e) => setStrength(Number(e.target.value))}
-            className="flex-1"
-          />
-          <span className="w-10 text-right">{strength.toFixed(1)}</span>
-        </label>
-        <label className="flex items-center gap-2 text-sm text-slate-300">
-          <input
-            type="checkbox"
-            checked={denoiseEnabled}
-            onChange={(e) => setDenoiseEnabled(e.target.checked)}
-          />
-          Denoise frames
-        </label>
+        {/* Primary params (spec-driven controls). */}
+        <div className="space-y-4">
+          <div className="flex items-center gap-4">
+            <span className="w-28 shrink-0 text-sm text-slate-300">Noise level</span>
+            <div className="flex-1">
+              <UiSlider
+                value={noiseLevel}
+                min={0}
+                max={1}
+                step={0.05}
+                onChange={setNoiseLevel}
+                ariaLabel="Noise level"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="w-28 shrink-0 text-sm text-slate-300">Strength</span>
+            <div className="flex-1">
+              <UiSlider
+                value={strength}
+                min={0}
+                max={1}
+                step={0.1}
+                onChange={setStrength}
+                ariaLabel="Strength"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="w-28 shrink-0 text-sm text-slate-300">Denoise</span>
+            <UiToggle
+              checked={denoiseEnabled}
+              onChange={setDenoiseEnabled}
+              label="Denoise frames"
+            />
+          </div>
+        </div>
 
-        <button
-          onClick={handleStep}
-          disabled={!ready}
-          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white disabled:opacity-40"
+        {/* Advanced (collapsible, ADR-024 dual layer). */}
+        <UiCollapsible
+          label="Advanced"
+          open={advancedOpen}
+          onOpenChange={setAdvancedOpen}
         >
-          Process one frame
-        </button>
+          <div className="rounded-lg border border-white/10 bg-slate-900/40 p-4 text-xs text-slate-400">
+            <p>
+              Sample rate {SAMPLE_RATE / 1000} kHz · frame size{' '}
+              {RNNOISE_FRAME_SIZE} samples (10 ms) · RNNoise wasm embedded as
+              base64 in the vendored glue.
+            </p>
+          </div>
+        </UiCollapsible>
+
+        {/* Actions. */}
+        <div className="flex gap-3 pt-2">
+          <UiButton
+            label="Process one frame"
+            onClick={handleStep}
+            variant="primary"
+            disabled={!ready}
+          />
+          <UiButton label="Reset" onClick={handleReset} variant="secondary" />
+        </div>
+
+        {/* Status: waveform + curve + VAD bar. */}
+        <div className="grid gap-4 pt-2 sm:grid-cols-2">
+          <div className="rounded-lg bg-slate-800/60 p-3">
+            <div className="mb-1 text-xs uppercase tracking-wider text-slate-500">
+              Waveform (input vs denoised)
+            </div>
+            <UiWaveform data={output} overlay={input} height={56} />
+          </div>
+          <div className="rounded-lg bg-slate-800/60 p-3">
+            <div className="mb-1 text-xs uppercase tracking-wider text-slate-500">
+              VAD history
+            </div>
+            <UiCurve data={curveData} threshold={0.5} height={56} />
+          </div>
+        </div>
 
         <div className="grid grid-cols-3 gap-4 pt-2 text-sm">
           <div className="rounded-lg bg-slate-800/60 p-3">
@@ -123,15 +184,13 @@ export default function RnnoisePlayground() {
             <div className="text-xs uppercase tracking-wider text-slate-500">
               Output RMS
             </div>
-            <div className="mt-1 text-lg text-emerald-300">
-              {outRms.toFixed(3)}
-            </div>
+            <div className="mt-1 text-lg text-emerald-300">{outRms.toFixed(3)}</div>
           </div>
           <div className="rounded-lg bg-slate-800/60 p-3">
             <div className="text-xs uppercase tracking-wider text-slate-500">
               VAD
             </div>
-            <div className="mt-1 text-lg text-sky-300">{vad.toFixed(3)}</div>
+            <UiBar value={vad} threshold={0.5} height={6} className="mt-2" />
           </div>
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,12 @@ importers:
       '@wake-studio/contracts':
         specifier: workspace:*
         version: link:../contracts
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,31 @@ importers:
         specifier: ~5.6.3
         version: 5.6.3
 
+  apps/local-service:
+    dependencies:
+      '@wake-studio/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@wake-studio/module-kit':
+        specifier: workspace:*
+        version: link:../../packages/module-kit
+      '@wake-studio/module-rnnoise':
+        specifier: workspace:^
+        version: link:../../packages/modules/afe/rnnoise
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.6
+        version: 20.19.43
+      tsx:
+        specifier: ^4.19.2
+        version: 4.23.6
+      typescript:
+        specifier: ~5.6.3
+        version: 5.6.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)
+
   apps/web:
     dependencies:
       '@wake-studio/contracts':
@@ -75,7 +100,7 @@ importers:
         version: 8.5.23
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.23.6)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -706,9 +731,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -718,9 +755,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -730,9 +779,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -742,9 +803,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -754,9 +827,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -766,9 +851,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -778,9 +875,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -790,9 +899,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -802,11 +923,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -814,9 +959,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -826,15 +989,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -2071,6 +2252,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3153,6 +3339,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.6:
+    resolution: {integrity: sha512-D/YYGUDqKlLvXhM5fBBbiENaGICxLfU4viHnZEkgmgplnDFa+Kczy34VV7AmLJgdzisv0I/J3zitfC26JH3GXg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4110,70 +4301,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@1.21.7))':
@@ -5432,6 +5701,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6113,12 +6411,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.23
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.23.6):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.23
+      tsx: 4.23.6
 
   postcss-nested@6.2.0(postcss@8.5.23):
     dependencies:
@@ -6530,7 +6829,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.23.6):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -6549,7 +6848,7 @@ snapshots:
       postcss: 8.5.23
       postcss-import: 15.1.0(postcss@8.5.23)
       postcss-js: 4.1.0(postcss@8.5.23)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.23.6)
       postcss-nested: 6.2.0(postcss@8.5.23)
       postcss-selector-parser: 6.1.4
       resolve: 1.22.12
@@ -6608,6 +6907,12 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.23.6:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,10 +103,28 @@ importers:
 
   packages/module-kit:
     dependencies:
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.20
+        version: 1.1.20(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.16
+        version: 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select':
+        specifier: ^2.3.7
+        version: 2.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider':
+        specifier: ^1.4.7
+        version: 1.4.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.3.7
+        version: 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wake-studio/contracts':
         specifier: workspace:*
         version: link:../contracts
     devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -119,6 +137,9 @@ importers:
       '@wake-studio/contracts':
         specifier: workspace:*
         version: link:../../../contracts
+      '@wake-studio/module-kit':
+        specifier: workspace:^
+        version: link:../../../module-kit
     devDependencies:
       '@types/react':
         specifier: ^18.3.12
@@ -849,6 +870,21 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
@@ -1082,6 +1118,314 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@radix-ui/number@1.1.3':
+    resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
+
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
+  '@radix-ui/react-arrow@1.1.15':
+    resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.20':
+    resolution: {integrity: sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.15':
+    resolution: {integrity: sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.5':
+    resolution: {integrity: sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.2':
+    resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.4':
+    resolution: {integrity: sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.19':
+    resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.6':
+    resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.16':
+    resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.4':
+    resolution: {integrity: sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.7':
+    resolution: {integrity: sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.17':
+    resolution: {integrity: sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.10':
+    resolution: {integrity: sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.10':
+    resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.16':
+    resolution: {integrity: sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.3.7':
+    resolution: {integrity: sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.4.7':
+    resolution: {integrity: sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.3':
+    resolution: {integrity: sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.7':
+    resolution: {integrity: sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.4':
+    resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.6':
+    resolution: {integrity: sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.5':
+    resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.4':
+    resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.4':
+    resolution: {integrity: sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.4':
+    resolution: {integrity: sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.4':
+    resolution: {integrity: sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.11':
+    resolution: {integrity: sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.3':
+    resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1433,6 +1777,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -1653,6 +2001,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -1892,6 +2243,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
@@ -2475,6 +2830,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2845,6 +3230,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3811,6 +4216,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.12': {}
+
   '@huggingface/jinja@0.5.9':
     optional: true
 
@@ -4000,6 +4422,287 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@radix-ui/number@1.1.3': {}
+
+  '@radix-ui/primitive@1.1.7': {}
+
+  '@radix-ui/react-arrow@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-collapsible@1.1.20(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-collection@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-compose-refs@1.1.5(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-context@1.2.2(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-direction@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-focus-guards@1.1.6(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-id@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-popper@1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/rect': 1.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-progress@1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-select@2.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-slider@1.4.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-slot@1.3.3(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-switch@1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-use-callback-ref@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-controllable-state@1.2.6(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-effect-event@0.0.5(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-layout-effect@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-previous@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-rect@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.3
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-size@1.1.4(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-visually-hidden@1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/rect@1.1.3': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -4354,6 +5057,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4578,6 +5285,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  detect-node-es@1.1.0: {}
 
   detect-node@2.1.0:
     optional: true
@@ -4915,6 +5624,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-own-enumerable-property-symbols@3.0.2: {}
 
@@ -5453,6 +6164,33 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.31)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  react-remove-scroll@2.7.2(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.31)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.31)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  react-style-singleton@2.2.3(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5863,8 +6601,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -5958,6 +6695,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  use-sidecar@1.1.3(@types/react@18.3.31)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.31
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

Three commits delivering the spec-driven UI layer (ADR-025) and the
self-hosted local-service skeleton (ADR-005/028):

1. **module-kit: spec-driven UI controls** - Radix Primitives + Tailwind
   control layer, canvas visualizations, param->control mapper
2. **module-kit: complete panel generator** - `renderPanel(spec)` -> React
   component (pure + controlled), ModulePanelController bridge
3. **local-service: self-hosted backend skeleton** - module registry +
   train-runner (uv) + zero-dep HTTP server

## Changes

### 1. UI controls (`packages/module-kit/src/ui/`)
- controls.tsx: UiSlider/UiNumber/UiSelect/UiToggle/UiButton/UiProgress/
  UiCollapsible/UiParamRow - thin adapters over `@radix-ui` (headless)
- canvas.tsx: UiBar (VAD meter), UiWaveform (PCM + overlay), UiCurve
  (score history) - self-contained canvas
- mapper.tsx: ModuleParam -> control mapping (new type = spec change, not
  a new panel)
- styles.ts: shared Tailwind class tokens + cn helper

### 2. Panel generator (`packages/module-kit/src/panel-generator.tsx`)
- `renderPanel(spec)` -> React component; pure and controlled
- ModulePanel: params (primary + collapsible Advanced, ADR-024), actions
  (variant by kind + confirm), status (bar/waveform/curve/badge/gauge/text)
- ModulePanelController: values/setValue/runAction/status/disabled -
  host wires the engine, panel stays headless
- rnnoise playground mounts a generated panel from the REAL RNNOISE_SPEC
  (spec/index.ts typed export) - end-to-end proof

### 3. Local service (`apps/local-service/`)
- server.ts: LocalService - /health, /modules (catalog from specs),
  POST /modules/:id/train (uv, ADR-028), /modules/:id/status
- module-registry.ts: discovers packages/modules/*/*/spec/ specs, validates
  via module-kit, reports node/train/device target presence
- train-runner.ts: spawns module train scripts with `uv run`; entry resolved
  relative to module; outputs from spec.train.outputs; streams logs
- module-kit gains /validator subpath export (server-only import, no react)
- root: `pnpm dev:service` script

## Verified

- typecheck / lint: 0 errors
- 121 unit tests (6 module-kit + 7 rnnoise + 6 local-service + 102 web)
- RNNoise wasm L2 (Node) + playground e2e pass
- uv 0.12.1 installed; rnnoise train.py runs via `uv run`, writes
  metrics.json (ADR-028 no-op stub)
- train-runner (Node spawn uv) exitCode 0, correct output paths
- HTTP server: health/modules/POST train respond correctly

## Notes

- prebuilts (125 MB) + sherpa-kws wasm (55 MB) remain gitignored (ADR-011)
- sherpa-kws e2e still times out on the 55 MB wasm fetch (pre-existing)
- Only rnnoise is a full module so far; AFE/KWS/FewShot panels are still
  hand-written (next: extract them onto the generator)
