### PR TITLE
style(web): light theme with semantic design tokens

### DIFF
--- a/apps/web/e2e/light-theme.spec.ts
+++ b/apps/web/e2e/light-theme.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Light-theme smoke test.
+ *
+ * Verifies the semantic design tokens resolve (a regression guard: a broken
+ * comment or token swap silently degrades the whole page to transparent
+ * backgrounds / black-on-black).
+ */
+
+test('semantic light theme resolves', async ({ page }) => {
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  const probe = await page.evaluate(() => {
+    const cs = getComputedStyle(document.documentElement)
+    const header = document.querySelector('header')
+    return {
+      colorScheme: cs.colorScheme,
+      surface: cs.getPropertyValue('--ws-surface'),
+      bodyBg: getComputedStyle(document.body).backgroundColor,
+      headerBg: header ? getComputedStyle(header).backgroundColor : null,
+    }
+  })
+
+  // :root variables are defined and body uses the light surface.
+  expect(probe.surface).not.toBe('')
+  expect(probe.colorScheme).toBe('light')
+  // Body background resolves to a light color, not transparent.
+  expect(probe.bodyBg).not.toBe('rgba(0, 0, 0, 0)')
+  expect(probe.headerBg).not.toBe('rgba(0, 0, 0, 0)')
+
+  // Header text is dark ink on the light surface (readable).
+  const headerColor = await page.evaluate(() => {
+    const h = document.querySelector('header span')
+    return h ? getComputedStyle(h).color : null
+  })
+  expect(headerColor).not.toBe('rgb(0, 0, 0)') // not raw black fallback
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,7 +26,7 @@ export default function App() {
           <>
             <button
               onClick={() => setRoute('main')}
-              className="mt-6 ml-6 rounded-lg border border-white/10 px-3 py-1 text-xs text-slate-400 hover:bg-white/5"
+              className="mt-6 ml-6 rounded-lg border border-line px-3 py-1 text-xs text-ink-3 hover:bg-surface-4/50"
             >
               ← Back to console
             </button>
@@ -36,24 +36,24 @@ export default function App() {
           <>
             {/* Hero */}
             <section className="mx-auto max-w-5xl px-6 pt-16 pb-4 text-center">
-              <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+              <h1 className="text-4xl font-bold tracking-tight text-ink-1 sm:text-5xl">
                 From wake-word idea to deployable{' '}
-                <span className="bg-gradient-to-r from-brand-300 to-brand-500 bg-clip-text text-transparent">
+                <span className="bg-gradient-to-r from-brand-500 to-brand-600 bg-clip-text text-transparent">
                   KWS bundle
                 </span>
               </h1>
-              <p className="mx-auto mt-4 max-w-2xl text-base text-slate-400">
+              <p className="mx-auto mt-4 max-w-2xl text-base text-ink-2">
                 A browser-first studio for the full far-field voice pipeline - no
                 toolchain, runtime, or Python to install. Visualize every stage,
                 enroll a custom wake word with a few samples, and export a
                 ready-to-build package for your target chip.
               </p>
-              <p className="mt-4 text-xs uppercase tracking-widest text-amber-300/80">
+              <p className="mt-4 text-xs uppercase tracking-widest text-brand-600/80">
                 Phase 1-3 · AFE + KWS + Few-Shot enrollment · in progress
               </p>
               <button
                 onClick={() => setRoute('playground-rnnoise')}
-                className="mt-6 rounded-lg bg-brand-500/10 px-4 py-2 text-sm font-medium text-brand-300 hover:bg-brand-500/20"
+                className="mt-6 rounded-lg bg-brand-500/10 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-500/20"
               >
                 Try the RNNoise module playground
               </button>

--- a/apps/web/src/components/AFEPanel.tsx
+++ b/apps/web/src/components/AFEPanel.tsx
@@ -81,34 +81,34 @@ export function AFEPanel({ afeRef, onRunningChange }: AFEPanelProps) {
 
   const latencyColor =
     latencyMs > 150
-      ? 'text-red-400'
+      ? 'text-danger'
       : latencyMs > 100
-        ? 'text-amber-400'
-        : 'text-emerald-400'
+        ? 'text-warning'
+        : 'text-success'
 
   return (
     <section className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">Live AFE pipeline</h2>
-        <p className="text-sm text-slate-400">
+        <h2 className="text-lg font-semibold text-ink-1">Live AFE pipeline</h2>
+        <p className="text-sm text-ink-2">
           Phase 1 · AEC (passthrough) -&gt; BSS (passthrough) -&gt; NS (RNNoise
           WASM). AEC3 and BSS are deferred (ADR-016); VAD from RNNoise for v1.
         </p>
       </div>
 
       {/* Controls */}
-      <div className="mb-6 flex flex-nowrap items-center gap-4 overflow-x-auto rounded-xl border border-white/10 bg-white/[0.03] p-5">
+      <div className="mb-6 flex flex-nowrap items-center gap-4 overflow-x-auto rounded-xl border border-line bg-surface-2 p-5">
         {!running ? (
           <button
             onClick={handleStart}
-            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-400"
+            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 transition hover:bg-brand-400"
           >
             Start microphone
           </button>
         ) : (
           <button
             onClick={handleStop}
-            className="rounded-lg bg-red-500/80 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-500"
+            className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 transition hover:bg-red-500"
           >
             Stop
           </button>
@@ -116,16 +116,16 @@ export function AFEPanel({ afeRef, onRunningChange }: AFEPanelProps) {
 
         {running && (
           <div className="flex items-center gap-2 text-sm whitespace-nowrap">
-            <span className="text-slate-400">Latency:</span>
+            <span className="text-ink-2">Latency:</span>
             <span className={`inline-block w-14 text-right font-mono font-semibold ${latencyColor}`}>
               {latencyMs.toFixed(0)} ms
             </span>
-            <span className="text-slate-500">/ 150 ms budget</span>
+            <span className="text-ink-3">/ 150 ms budget</span>
           </div>
         )}
 
         {error && (
-          <span className="text-sm text-red-400">{error}</span>
+          <span className="text-sm text-danger">{error}</span>
         )}
       </div>
 
@@ -163,14 +163,14 @@ export function AFEPanel({ afeRef, onRunningChange }: AFEPanelProps) {
       )}
 
       {/* Config panel (ADR-017) */}
-      <div className="mt-6 rounded-xl border border-white/10 bg-white/[0.03] p-5">
-        <h3 className="mb-4 text-sm font-semibold text-white">
+      <div className="mt-6 rounded-xl border border-line bg-surface-2 p-5">
+        <h3 className="mb-4 text-sm font-semibold text-ink-1">
           Configuration{' '}
-          <span className="text-xs font-normal text-slate-500">(ADR-017)</span>
+          <span className="text-xs font-normal text-ink-3">(ADR-017)</span>
         </h3>
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="flex items-center gap-3 text-sm">
-            <span className="w-32 text-slate-400">Visualization FPS</span>
+            <span className="w-32 text-ink-2">Visualization FPS</span>
             <input
               type="range"
               min={15}
@@ -184,20 +184,20 @@ export function AFEPanel({ afeRef, onRunningChange }: AFEPanelProps) {
               }}
               className="flex-1 accent-brand-400"
             />
-            <span className="w-10 text-right font-mono text-slate-300">
+            <span className="w-10 text-right font-mono text-ink-2">
               {vizFps}
             </span>
           </label>
-          <div className="flex items-center gap-3 text-sm text-slate-500">
+          <div className="flex items-center gap-3 text-sm text-ink-3">
             <span className="w-32">Topology</span>
-            <span className="rounded bg-slate-700/50 px-2 py-1 text-xs text-slate-300">
+            <span className="rounded bg-surface-4 px-2 py-1 text-xs text-ink-2">
               single-worklet (v1)
             </span>
           </div>
         </div>
-        <p className="mt-3 text-xs text-slate-500">
+        <p className="mt-3 text-xs text-ink-3">
           {params.length} parameters exposed via{' '}
-          <code className="text-slate-400">describeParameters()</code> · config
+          <code className="text-ink-2">describeParameters()</code> · config
           panel is built incrementally per phase.
         </p>
       </div>
@@ -219,7 +219,7 @@ const StagePanel = memo(function StagePanel({
   onToggleBypass: (id: 'aec' | 'bss' | 'ns') => void
 }) {
   return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-5">
+    <div className="rounded-xl border border-line bg-surface-2 p-5">
       <div className="mb-3 flex items-center justify-between">
         <span className="text-sm font-semibold uppercase text-brand-300">
           {id}
@@ -228,7 +228,7 @@ const StagePanel = memo(function StagePanel({
           onClick={() => onToggleBypass(id)}
           className={`rounded px-2 py-0.5 text-[10px] font-medium uppercase ${
             isBypassed
-              ? 'bg-slate-700 text-slate-400'
+              ? 'bg-surface-4 text-ink-2'
               : 'bg-emerald-500/20 text-emerald-300'
           }`}
         >
@@ -243,11 +243,11 @@ const StagePanel = memo(function StagePanel({
 
       {/* Level - always rendered for stable card height */}
       <div className="flex items-center gap-2 text-xs whitespace-nowrap">
-        <span className="w-12 shrink-0 text-slate-500">Level</span>
+        <span className="w-12 shrink-0 text-ink-3">Level</span>
         <div className="flex-1">
           <LevelBar db={data?.levelDb ?? -60} />
         </div>
-        <span className="w-20 shrink-0 text-right font-mono text-slate-400">
+        <span className="w-20 shrink-0 text-right font-mono text-ink-2">
           {data?.levelDb != null ? `${data.levelDb.toFixed(1)} dB` : '-'}
         </span>
       </div>
@@ -255,9 +255,9 @@ const StagePanel = memo(function StagePanel({
       {/* VAD (NS only for v1) - always rendered for stable card height */}
       {id === 'ns' && (
         <div className="mt-2 flex items-center gap-2 text-xs whitespace-nowrap">
-          <span className="w-12 shrink-0 text-slate-500">VAD</span>
+          <span className="w-12 shrink-0 text-ink-3">VAD</span>
           <div className="flex-1">
-            <div className="h-2 overflow-hidden rounded-full bg-slate-700">
+            <div className="h-2 overflow-hidden rounded-full bg-surface-4">
               <div
                 className="h-full rounded-full bg-sky-400"
                 style={{
@@ -266,7 +266,7 @@ const StagePanel = memo(function StagePanel({
               />
             </div>
           </div>
-          <span className="w-20 shrink-0 text-right font-mono text-slate-400">
+          <span className="w-20 shrink-0 text-right font-mono text-ink-2">
             {data?.vadProbability != null
               ? `${(data.vadProbability * 100).toFixed(0)}%`
               : '-'}
@@ -277,7 +277,7 @@ const StagePanel = memo(function StagePanel({
       {/* Spectrum (NS only) - always rendered for stable card height */}
       {id === 'ns' && (
         <div className="mt-2">
-          <div className="mb-1 text-xs text-slate-500">Spectrum</div>
+          <div className="mb-1 text-xs text-ink-3">Spectrum</div>
           <SpectrogramCanvas data={data?.spectrum ?? new Float32Array(64)} />
         </div>
       )}
@@ -321,7 +321,7 @@ function WaveformCanvas({ data }: { data?: Float32Array }) {
       ref={canvasRef}
       width={256}
       height={64}
-      className="h-16 w-full rounded bg-slate-950/60"
+      className="h-16 w-full rounded bg-surface-3"
     />
   )
 }
@@ -330,9 +330,9 @@ function WaveformCanvas({ data }: { data?: Float32Array }) {
 function LevelBar({ db }: { db: number }) {
   const pct = Math.max(0, Math.min(100, ((db + 60) / 60) * 100))
   const color =
-    db > -6 ? 'bg-red-400' : db > -20 ? 'bg-amber-400' : 'bg-emerald-400'
+    db > -6 ? 'bg-red-400' : db > -20 ? 'bg-amber-400' : 'bg-success'
   return (
-    <div className="h-2 overflow-hidden rounded-full bg-slate-700">
+    <div className="h-2 overflow-hidden rounded-full bg-surface-4">
       <div
         className={`h-full rounded-full ${color}`}
         style={{ width: `${pct}%` }}
@@ -371,7 +371,7 @@ function SpectrogramCanvas({ data }: { data: Float32Array }) {
       ref={canvasRef}
       width={256}
       height={48}
-      className="h-12 w-full rounded bg-slate-950/60"
+      className="h-12 w-full rounded bg-surface-3"
     />
   )
 }

--- a/apps/web/src/components/Domains.tsx
+++ b/apps/web/src/components/Domains.tsx
@@ -19,8 +19,8 @@ export function Domains() {
   return (
     <section className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">Two domains</h2>
-        <p className="text-sm text-slate-400">
+        <h2 className="text-lg font-semibold text-ink-1">Two domains</h2>
+        <p className="text-sm text-ink-2">
           Different targets use different KWS stacks (R6 / R8).
         </p>
       </div>
@@ -28,30 +28,30 @@ export function Domains() {
         {DOMAINS.map((d) => (
           <div
             key={d.name}
-            className="rounded-xl border border-white/10 bg-white/[0.03] p-5"
+            className="rounded-xl border border-line bg-surface-2 p-5 shadow-sm"
           >
             <div className="mb-2 flex flex-wrap items-center gap-2">
-              <h3 className="text-sm font-semibold text-white">{d.name}</h3>
+              <h3 className="text-sm font-semibold text-ink-1">{d.name}</h3>
               {d.chips.map((c) => (
                 <span
                   key={c}
-                  className="rounded bg-brand-500/15 px-1.5 py-0.5 text-[10px] font-medium text-brand-300"
+                  className="rounded bg-brand-50 px-1.5 py-0.5 text-[10px] font-medium text-brand-700"
                 >
                   {c}
                 </span>
               ))}
             </div>
-            <dl className="space-y-1 text-xs text-slate-400">
+            <dl className="space-y-1 text-xs text-ink-2">
               <div>
-                <dt className="inline font-medium text-slate-300">KWS: </dt>
+                <dt className="inline font-medium text-ink-1">KWS: </dt>
                 <dd className="inline">{d.kws}</dd>
               </div>
               <div>
-                <dt className="inline font-medium text-slate-300">AFE: </dt>
+                <dt className="inline font-medium text-ink-1">AFE: </dt>
                 <dd className="inline">{d.afe}</dd>
               </div>
             </dl>
-            <p className="mt-3 text-xs text-slate-500">{d.note}</p>
+            <p className="mt-3 text-xs text-ink-3">{d.note}</p>
           </div>
         ))}
       </div>

--- a/apps/web/src/components/FewShotPanel.tsx
+++ b/apps/web/src/components/FewShotPanel.tsx
@@ -285,8 +285,8 @@ export const FewShotPanel = memo(function FewShotPanel({
   return (
     <section className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">Few-Shot enrollment</h2>
-        <p className="text-sm text-slate-400">
+        <h2 className="text-lg font-semibold text-ink-1">Few-Shot enrollment</h2>
+        <p className="text-sm text-ink-2">
           Phase 3 · enroll a custom wake word with {MIN_SAMPLES}+ samples (PLiX
           embedding + prototype-distance scoring, ADR-020). 100% client-side
           (enrollment/inference, not training - ADR-013).
@@ -294,17 +294,17 @@ export const FewShotPanel = memo(function FewShotPanel({
       </div>
 
       {/* Controls */}
-      <div className="mb-6 flex flex-wrap items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-5">
+      <div className="mb-6 flex flex-wrap items-center gap-4 rounded-xl border border-line bg-surface-2 p-5">
         {status === 'idle' && (
           <>
-            <label className="flex items-center gap-2 text-sm text-slate-400">
+            <label className="flex items-center gap-2 text-sm text-ink-2">
               <span className="shrink-0">Encoder</span>
               <select
                 value={encoderVariant}
                 onChange={(e) =>
                   setEncoderVariant(e.target.value as PlixEncoderVariant['id'])
                 }
-                className="rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+                className="rounded bg-surface-3 px-2 py-1 text-ink-1"
                 title="Select the PLiX encoder variant (ADR-002). 'base' = EfficientNet-v2-M; 'small' = TinyNet-E (lighter). Both emit a 1280-dim embedding."
               >
                 {PLIX_VARIANTS.map((v) => (
@@ -314,12 +314,12 @@ export const FewShotPanel = memo(function FewShotPanel({
                 ))}
               </select>
             </label>
-            <label className="flex items-center gap-2 text-sm text-slate-400">
+            <label className="flex items-center gap-2 text-sm text-ink-2">
               <span className="shrink-0">Runtime</span>
               <select
                 value={runtime}
                 onChange={(e) => setRuntime(e.target.value as ModelRuntime)}
-                className="rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+                className="rounded bg-surface-3 px-2 py-1 text-ink-1"
                 title="PLiX execution runtime (ADR-002). 'onnx' (default) loads the exported ONNX graph; 'transformers' runs browser-native via @huggingface/transformers (CDN, no ONNX file)."
               >
                 <option value="onnx">ONNX (onnxruntime-web)</option>
@@ -328,20 +328,20 @@ export const FewShotPanel = memo(function FewShotPanel({
             </label>
             <button
               onClick={handleLoadEncoder}
-              className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-400"
+              className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400"
             >
               Load PLiX encoder
             </button>
           </>
         )}
         {status === 'loading' && (
-          <span className="text-sm text-slate-400">Loading PLiX…</span>
+          <span className="text-sm text-ink-2">Loading PLiX…</span>
         )}
         {encoderReady && !detecting && (
           <button
             onClick={handleRecord}
             disabled={recording}
-            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500 disabled:opacity-50"
           >
             {recording ? `Recording… (${RECORD_MS}ms)` : 'Record sample'}
           </button>
@@ -350,7 +350,7 @@ export const FewShotPanel = memo(function FewShotPanel({
           <button
             onClick={handleBuildPrototype}
             disabled={building}
-            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-50"
+            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
           >
             {building ? 'Building…' : `Build prototype (${samples.length} samples)`}
           </button>
@@ -359,12 +359,12 @@ export const FewShotPanel = memo(function FewShotPanel({
           <>
             <button
               onClick={handleStartDetection}
-              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500"
             >
               Start Few-Shot detection
             </button>
             {!afeRunning && (
-              <span className="text-sm text-amber-400">
+              <span className="text-sm text-warning">
                 Start the AFE microphone (top panel) first, then click above.
               </span>
             )}
@@ -373,32 +373,32 @@ export const FewShotPanel = memo(function FewShotPanel({
         {detecting && (
           <button
             onClick={handleStopDetection}
-            className="rounded-lg bg-red-500/80 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
+            className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-red-500"
           >
             Stop detection
           </button>
         )}
         <div
           className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold transition-all ${
-            triggerFlash ? 'scale-125 bg-amber-400 text-slate-900' : 'bg-slate-700 text-slate-500'
+            triggerFlash ? 'scale-125 bg-amber-400 text-ink-1' : 'bg-surface-4 text-ink-3'
           }`}
         >
           {triggerFlash ? '!' : '·'}
         </div>
-        {error && <span className="text-sm text-red-400">{error}</span>}
+        {error && <span className="text-sm text-danger">{error}</span>}
       </div>
 
       {/* Sample list */}
       {encoderReady && !detecting && samples.length > 0 && (
-        <div className="mb-6 rounded-xl border border-white/10 bg-white/[0.03] p-5">
-          <h3 className="mb-3 text-sm font-semibold text-white">
+        <div className="mb-6 rounded-xl border border-line bg-surface-2 p-5">
+          <h3 className="mb-3 text-sm font-semibold text-ink-1">
             Enrolled samples
           </h3>
           <div className="space-y-2">
             {samples.map((s, i) => (
               <div
                 key={s.id}
-                className="flex items-center gap-4 text-xs text-slate-400"
+                className="flex items-center gap-4 text-xs text-ink-2"
               >
                 <span className="w-8 font-mono">#{i + 1}</span>
                 <span>{s.quality.durationMs.toFixed(0)} ms</span>
@@ -406,7 +406,7 @@ export const FewShotPanel = memo(function FewShotPanel({
                 <span>SNR {s.quality.snrDb.toFixed(1)} dB</span>
                 <span
                   className={
-                    s.quality.acceptable ? 'text-emerald-400' : 'text-amber-400'
+                    s.quality.acceptable ? 'text-success' : 'text-warning'
                   }
                 >
                   {s.quality.clipped ? 'clipped' : s.quality.acceptable ? 'OK' : 'low quality'}
@@ -415,7 +415,7 @@ export const FewShotPanel = memo(function FewShotPanel({
             ))}
           </div>
           {prototype && (
-            <p className="mt-3 text-xs text-emerald-400">
+            <p className="mt-3 text-xs text-success">
               Prototype built: {prototype.word} ({prototype.vector.length}-dim vector). Ready for detection.
             </p>
           )}
@@ -425,8 +425,8 @@ export const FewShotPanel = memo(function FewShotPanel({
       {/* Score curve + Advanced (inside the detecting block) */}
       {detecting && (
         <>
-        <div className="mb-6 rounded-xl border border-white/10 bg-white/[0.03] p-5">
-          <div className="mb-2 flex items-center justify-between text-xs text-slate-500">
+        <div className="mb-6 rounded-xl border border-line bg-surface-2 p-5">
+          <div className="mb-2 flex items-center justify-between text-xs text-ink-3">
             <span>Few-Shot score curve (prototype-distance similarity)</span>
             <span className="font-mono">
               {historyRef.current.length > 0
@@ -438,45 +438,45 @@ export const FewShotPanel = memo(function FewShotPanel({
             ref={canvasRef}
             width={800}
             height={160}
-            className="h-[160px] w-full rounded bg-slate-950/60"
+            className="h-[160px] w-full rounded bg-surface-3"
           />
         </div>
 
         {/* Advanced (collapsible) — §4.1 Few-Shot advanced params */}
-        <div className="mb-6 rounded-xl border border-white/10 bg-white/[0.03] p-5">
+        <div className="mb-6 rounded-xl border border-line bg-surface-2 p-5">
           <button
             onClick={() => setAdvancedOpen((v) => !v)}
-            className="text-xs font-medium text-slate-400 hover:text-slate-200"
+            className="text-xs font-medium text-ink-2 hover:text-ink-1"
           >
             {advancedOpen ? '▾' : '▸'} Advanced
           </button>
           {advancedOpen && (
             <div className="mt-3 grid gap-4 sm:grid-cols-2">
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-slate-400">Mel preprocessing</span>
+                <span className="w-36 shrink-0 text-ink-2">Mel preprocessing</span>
                 <input type="checkbox" defaultChecked className="accent-brand-400" />
-                <span className="text-xs text-slate-500">64x100 log-Mel</span>
+                <span className="text-xs text-ink-3">64x100 log-Mel</span>
               </label>
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-slate-400">Frame cache</span>
+                <span className="w-36 shrink-0 text-ink-2">Frame cache</span>
                 <input
                   type="number"
                   defaultValue={1500}
                   min={500}
                   max={3000}
                   step={100}
-                  className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+                  className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-1"
                 />
-                <span className="text-xs text-slate-500">ms</span>
+                <span className="text-xs text-ink-3">ms</span>
               </label>
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-slate-400">Feature smoothing</span>
+                <span className="w-36 shrink-0 text-ink-2">Feature smoothing</span>
                 <input type="checkbox" defaultChecked className="accent-brand-400" />
               </label>
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-slate-400">Embedding viz</span>
+                <span className="w-36 shrink-0 text-ink-2">Embedding viz</span>
                 <input type="checkbox" className="accent-brand-400" />
-                <span className="text-xs text-slate-500">show 1280-d vector</span>
+                <span className="text-xs text-ink-3">show 1280-d vector</span>
               </label>
             </div>
           )}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,14 +1,14 @@
 export function Footer() {
   return (
-    <footer className="border-t border-white/10">
-      <div className="mx-auto max-w-5xl px-6 py-8 text-xs text-slate-500">
+    <footer className="border-t border-line">
+      <div className="mx-auto max-w-5xl px-6 py-8 text-xs text-ink-3">
         <p className="mb-2">
           WakeStudio is a productization layer over open-source models and DSP
           components. We do not invent models.
         </p>
         <p>
           Source is MIT. Integrated models retain their own licenses - see{' '}
-          <span className="text-slate-300">LICENSES.md</span>. openWakeWord
+          <span className="text-ink-1">LICENSES.md</span>. openWakeWord
           pre-trained models are CC BY-NC-SA 4.0 (demo-only).
         </p>
       </div>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -6,8 +6,8 @@ function Logo() {
       role="img"
       aria-label="WakeStudio logo"
     >
-      <rect width="512" height="512" rx="96" fill="#0b1020" />
-      <g stroke="#38bdf8" strokeLinecap="round" fill="none">
+      <rect width="512" height="512" rx="96" fill="#0284c7" />
+      <g stroke="#e0f2fe" strokeLinecap="round" fill="none">
         <line x1="160" y1="224" x2="160" y2="288" strokeWidth="20" />
         <line x1="208" y1="176" x2="208" y2="336" strokeWidth="20" />
         <line x1="256" y1="128" x2="256" y2="384" strokeWidth="24" />
@@ -20,18 +20,18 @@ function Logo() {
 
 export function Header() {
   return (
-    <header className="border-b border-white/10 bg-slate-950/80 backdrop-blur">
+    <header className="border-b border-line bg-surface-2/90 backdrop-blur">
       <div className="mx-auto flex max-w-5xl items-center gap-3 px-6 py-4">
         <Logo />
         <div className="flex flex-col leading-tight">
-          <span className="text-base font-semibold tracking-tight text-white">
+          <span className="text-base font-semibold tracking-tight text-ink-1">
             WakeStudio
           </span>
-          <span className="text-xs text-slate-400">
+          <span className="text-xs text-ink-3">
             On-device wake-word pipeline studio
           </span>
         </div>
-        <span className="ml-auto rounded-md border border-white/10 px-3 py-1.5 text-xs text-slate-300">
+        <span className="ml-auto rounded-md border border-line bg-surface-3 px-3 py-1.5 text-xs text-ink-2">
           v0.0.1 · Phase 1
         </span>
       </div>

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -168,8 +168,8 @@ export const KWSPanel = memo(function KWSPanel({
   return (
     <section className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">KWS detection</h2>
-        <p className="text-sm text-slate-400">
+        <h2 className="text-lg font-semibold text-ink-1">KWS detection</h2>
+        <p className="text-sm text-ink-2">
           Phase 2 · pluggable KWS backend (ADR-020) running in a Web Worker
           (ADR-018). Active backend:{' '}
           <span className="text-emerald-300/80">OpenWakeWord</span> (hey-buddy,
@@ -180,16 +180,16 @@ export const KWSPanel = memo(function KWSPanel({
       </div>
 
       {/* Controls */}
-      <div className="mb-6 flex flex-wrap items-center gap-4 whitespace-nowrap rounded-xl border border-white/10 bg-white/[0.03] p-5">
+      <div className="mb-6 flex flex-wrap items-center gap-4 whitespace-nowrap rounded-xl border border-line bg-surface-2 p-5">
         <label className="flex items-center gap-2 text-sm">
-          <span className="text-slate-400">Backend</span>
+          <span className="text-ink-2">Backend</span>
           <select
             value={config.backend}
             disabled={status === 'loading' || running}
             onChange={(e) =>
               updateConfig({ backend: e.target.value as KWSConfig['backend'] })
             }
-            className="truncate rounded bg-slate-800/80 px-2 py-1 text-slate-300"
+            className="truncate rounded bg-surface-3 px-2 py-1 text-ink-2"
           >
             {BACKEND_REGISTRY.map((r) => (
               <option key={r.id} value={r.id} disabled={!r.browserFeasible}>
@@ -201,18 +201,18 @@ export const KWSPanel = memo(function KWSPanel({
         {status === 'idle' && (
           <button
             onClick={handleLoad}
-            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-400"
+            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-400"
           >
             Load KWS models
           </button>
         )}
         {status === 'loading' && (
-          <span className="text-sm text-slate-400">Loading models…</span>
+          <span className="text-sm text-ink-2">Loading models…</span>
         )}
         {canStart && (
           <button
             onClick={handleStart}
-            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-emerald-500"
           >
             Start detection
           </button>
@@ -220,26 +220,26 @@ export const KWSPanel = memo(function KWSPanel({
         {running && (
           <button
             onClick={handleStop}
-            className="rounded-lg bg-red-500/80 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
+            className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-red-500"
           >
             Stop detection
           </button>
         )}
 
         {status === 'ready' && !afeRunning && (
-          <span className="text-xs text-amber-300/80">
+          <span className="text-xs text-warning">
             Start the AFE microphone first
           </span>
         )}
 
         {status === 'ready' && (
-          <span className="text-xs text-slate-500">
+          <span className="text-xs text-ink-3">
             EP: {executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}
           </span>
         )}
 
         {running && warmup && (
-          <span className="text-xs text-amber-300/80">
+          <span className="text-xs text-warning">
             Warming up… (collecting ~2 s of audio context)
           </span>
         )}
@@ -248,20 +248,20 @@ export const KWSPanel = memo(function KWSPanel({
         <div
           className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold transition-all ${
             triggerFlash
-              ? 'scale-125 bg-amber-400 text-slate-900'
-              : 'bg-slate-700 text-slate-500'
+              ? 'scale-125 bg-amber-400 text-ink-1'
+              : 'bg-surface-4 text-ink-3'
           }`}
         >
           {triggerFlash ? '!' : '·'}
         </div>
 
-        {error && <span className="text-sm text-red-400">{error}</span>}
+        {error && <span className="text-sm text-danger">{error}</span>}
       </div>
 
       {/* Score curve */}
       {running && (
-        <div className="mb-6 rounded-xl border border-white/10 bg-white/[0.03] p-5">
-          <div className="mb-2 flex items-center justify-between text-xs text-slate-500">
+        <div className="mb-6 rounded-xl border border-line bg-surface-2 p-5">
+          <div className="mb-2 flex items-center justify-between text-xs text-ink-3">
             <span>Score curve (raw + smoothed + threshold)</span>
             <span className="font-mono">
               {historyRef.current.length > 0
@@ -273,17 +273,17 @@ export const KWSPanel = memo(function KWSPanel({
             ref={canvasRef}
             width={800}
             height={160}
-            className="h-[160px] w-full rounded bg-slate-950/60"
+            className="h-[160px] w-full rounded bg-surface-3"
           />
         </div>
       )}
 
       {/* Config panel (ADR-017) - dual-layer: Primary + Advanced (kws-categories §4.1) */}
       {status === 'ready' && (
-        <div className="rounded-xl border border-white/10 bg-white/[0.03] p-5">
-          <h3 className="mb-4 text-sm font-semibold text-white">
+        <div className="rounded-xl border border-line bg-surface-2 p-5">
+          <h3 className="mb-4 text-sm font-semibold text-ink-1">
             Configuration{' '}
-            <span className="text-xs font-normal text-slate-500">
+            <span className="text-xs font-normal text-ink-3">
               (Traditional KWS · Primary)
             </span>
           </h3>
@@ -291,11 +291,11 @@ export const KWSPanel = memo(function KWSPanel({
           {/* Primary: inference mode, threshold, output mode */}
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-              <span className="w-32 shrink-0 text-slate-400">Inference mode</span>
+              <span className="w-32 shrink-0 text-ink-2">Inference mode</span>
               <select
                 value={config.executionProvider === 'webgpu' ? 'realtime' : 'realtime'}
                 disabled
-                className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-300"
+                className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
                 title="Real-time mic detection (offline-file import is reserved)."
               >
                 <option value="realtime">Real-time mic</option>
@@ -303,7 +303,7 @@ export const KWSPanel = memo(function KWSPanel({
               </select>
             </label>
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-              <span className="w-32 shrink-0 text-slate-400">Confidence</span>
+              <span className="w-32 shrink-0 text-ink-2">Confidence</span>
               <input
                 type="range"
                 min={0}
@@ -315,16 +315,16 @@ export const KWSPanel = memo(function KWSPanel({
                 }
                 className="flex-1 accent-brand-400"
               />
-              <span className="w-10 shrink-0 text-right font-mono text-slate-300">
+              <span className="w-10 shrink-0 text-right font-mono text-ink-2">
                 {config.threshold.toFixed(2)}
               </span>
             </label>
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-              <span className="w-32 shrink-0 text-slate-400">Output mode</span>
+              <span className="w-32 shrink-0 text-ink-2">Output mode</span>
               <select
                 value="trigger"
                 disabled
-                className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-300"
+                className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
                 title="Emit a trigger event + score (reserved: score-only / CSV)."
               >
                 <option value="trigger">Trigger + score</option>
@@ -333,7 +333,7 @@ export const KWSPanel = memo(function KWSPanel({
               </select>
             </label>
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-              <span className="w-32 shrink-0 text-slate-400">VAD gate</span>
+              <span className="w-32 shrink-0 text-ink-2">VAD gate</span>
               <input
                 type="checkbox"
                 checked={config.vadGateEnabled}
@@ -342,24 +342,24 @@ export const KWSPanel = memo(function KWSPanel({
                 }
                 className="accent-brand-400"
               />
-              <span className="text-xs text-slate-500">
+              <span className="text-xs text-ink-3">
                 Suppress triggers in silence
               </span>
             </label>
           </div>
 
           {/* Advanced (collapsible) */}
-          <div className="mt-4 border-t border-white/10 pt-3">
+          <div className="mt-4 border-t border-line pt-3">
             <button
               onClick={() => setAdvancedOpen((v) => !v)}
-              className="text-xs font-medium text-slate-400 hover:text-slate-200"
+              className="text-xs font-medium text-ink-2 hover:text-ink-1"
             >
               {advancedOpen ? '▾' : '▸'} Advanced
             </button>
             {advancedOpen && (
               <div className="mt-3 grid gap-4 sm:grid-cols-2">
                 <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-slate-400">Min. duration</span>
+                  <span className="w-32 shrink-0 text-ink-2">Min. duration</span>
                   <input
                     type="range"
                     min={100}
@@ -371,12 +371,12 @@ export const KWSPanel = memo(function KWSPanel({
                     }
                     className="flex-1 accent-brand-400"
                   />
-                  <span className="w-14 shrink-0 text-right font-mono text-slate-300">
+                  <span className="w-14 shrink-0 text-right font-mono text-ink-2">
                     {config.minDurationMs} ms
                   </span>
                 </label>
                 <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-slate-400">Smoothing</span>
+                  <span className="w-32 shrink-0 text-ink-2">Smoothing</span>
                   <input
                     type="range"
                     min={1}
@@ -390,12 +390,12 @@ export const KWSPanel = memo(function KWSPanel({
                     }
                     className="flex-1 accent-brand-400"
                   />
-                  <span className="w-10 shrink-0 text-right font-mono text-slate-300">
+                  <span className="w-10 shrink-0 text-right font-mono text-ink-2">
                     {config.smoothingWindowFrames}
                   </span>
                 </label>
                 <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-slate-400">Cooldown</span>
+                  <span className="w-32 shrink-0 text-ink-2">Cooldown</span>
                   <input
                     type="range"
                     min={500}
@@ -407,27 +407,27 @@ export const KWSPanel = memo(function KWSPanel({
                     }
                     className="flex-1 accent-brand-400"
                   />
-                  <span className="w-14 shrink-0 text-right font-mono text-slate-300">
+                  <span className="w-14 shrink-0 text-right font-mono text-ink-2">
                     {config.cooldownMs} ms
                   </span>
                 </label>
                 <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-slate-400">Mel window</span>
+                  <span className="w-32 shrink-0 text-ink-2">Mel window</span>
                   <input
                     type="number"
                     value={MEL_WINDOW_SIZE}
                     disabled
-                    className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-300"
+                    className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
                   />
                 </label>
                 <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-slate-400">
+                  <span className="w-32 shrink-0 text-ink-2">
                     Acceleration
                   </span>
                   <select
                     value={config.executionProvider}
                     disabled
-                    className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-300"
+                    className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
                     title="WebGPU when available, else WASM (ADR-018)."
                   >
                     <option value="webgpu">WebGPU</option>
@@ -435,23 +435,23 @@ export const KWSPanel = memo(function KWSPanel({
                   </select>
                 </label>
                 <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-slate-400">Log export</span>
+                  <span className="w-32 shrink-0 text-ink-2">Log export</span>
                   <input
                     type="checkbox"
                     checked={logExport}
                     onChange={(e) => setLogExport(e.target.checked)}
                     className="accent-brand-400"
                   />
-                  <span className="text-xs text-slate-500">
+                  <span className="text-xs text-ink-3">
                     Stream scores to console
                   </span>
                 </label>
               </div>
             )}
           </div>
-          <p className="mt-3 text-xs text-slate-500">
+          <p className="mt-3 text-xs text-ink-3">
             {params.length} parameters exposed via{' '}
-            <code className="text-slate-400">describeParameters()</code>. Mel
+            <code className="text-ink-2">describeParameters()</code>. Mel
             window: {MEL_WINDOW_SIZE} samples (80 ms @ 16 kHz).
             {lastKeyword && (
               <>

--- a/apps/web/src/components/PipelineOverview.tsx
+++ b/apps/web/src/components/PipelineOverview.tsx
@@ -53,17 +53,17 @@ export const PipelineOverview = memo(function PipelineOverview({ frameData, runn
   }, [running])
 
   return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-5">
+    <div className="rounded-xl border border-line bg-surface-2 p-5 shadow-sm">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-white">Pipeline overview</h3>
+        <h3 className="text-sm font-semibold text-ink-1">Pipeline overview</h3>
         {running && (
           <span
             className={`font-mono text-xs ${
               latencyMs > 150
-                ? 'text-red-400'
+                ? 'text-danger'
                 : latencyMs > 100
-                  ? 'text-amber-400'
-                  : 'text-emerald-400'
+                  ? 'text-warning'
+                  : 'text-success'
             }`}
           >
             {latencyMs.toFixed(0)} ms
@@ -90,7 +90,7 @@ export const PipelineOverview = memo(function PipelineOverview({ frameData, runn
 
       {/* Scrolling level + VAD curve */}
       <div className="relative">
-        <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
+        <div className="mb-1 flex items-center justify-between text-xs text-ink-3">
           <span>Level (dBFS) + VAD · last ~10 s</span>
           <div className="flex gap-3">
             {STAGES.map((id) => (
@@ -103,7 +103,7 @@ export const PipelineOverview = memo(function PipelineOverview({ frameData, runn
               </span>
             ))}
             <span className="flex items-center gap-1">
-              <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
+              <span className="inline-block h-2 w-2 rounded-full bg-success" />
               VAD
             </span>
           </div>
@@ -157,7 +157,7 @@ function FlowNode({
         ref={canvasRef}
         width={80}
         height={40}
-        className="rounded bg-slate-950/60"
+        className="rounded bg-surface-3"
       />
       <span
         className="text-[10px] font-medium uppercase"
@@ -275,7 +275,7 @@ function ScrollingCurve({
       ref={canvasRef}
       width={800}
       height={120}
-      className="h-[120px] w-full rounded bg-slate-950/60"
+      className="h-[120px] w-full rounded bg-surface-3"
     />
   )
 }

--- a/apps/web/src/components/PipelineView.tsx
+++ b/apps/web/src/components/PipelineView.tsx
@@ -5,8 +5,8 @@ export function PipelineView() {
   return (
     <section className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">The pipeline</h2>
-        <p className="text-sm text-slate-400">
+        <h2 className="text-lg font-semibold text-ink-1">The pipeline</h2>
+        <p className="text-sm text-ink-2">
           A fixed four-stage front-end (ADR-001): each stage is pluggable,
           bypassable, and visualized in real time from Phase 1 onward.
         </p>

--- a/apps/web/src/components/RecordReplay.tsx
+++ b/apps/web/src/components/RecordReplay.tsx
@@ -100,10 +100,10 @@ export const RecordReplay = memo(function RecordReplay({ pipeline, running }: Pr
   }, [stopPlayback])
 
   return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-5">
-      <h3 className="mb-4 text-sm font-semibold text-white">
+    <div className="rounded-xl border border-line bg-surface-2 p-5">
+      <h3 className="mb-4 text-sm font-semibold text-ink-1">
         Record &amp; replay{' '}
-        <span className="text-xs font-normal text-slate-500">
+        <span className="text-xs font-normal text-ink-3">
           · 10 s A/B comparison
         </span>
       </h3>
@@ -114,8 +114,8 @@ export const RecordReplay = memo(function RecordReplay({ pipeline, running }: Pr
           disabled={recording}
           className={`min-w-[140px] whitespace-nowrap rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
             recording
-              ? 'cursor-not-allowed bg-slate-700 text-slate-500'
-              : 'bg-red-500/80 text-white hover:bg-red-500'
+              ? 'cursor-not-allowed bg-surface-4 text-ink-3'
+              : 'bg-danger/90 text-ink-1 hover:bg-red-500'
           }`}
         >
           {recording
@@ -125,7 +125,7 @@ export const RecordReplay = memo(function RecordReplay({ pipeline, running }: Pr
 
         {/* Always rendered to prevent layout shift; hidden when idle. */}
         <div
-          className={`h-2 w-48 overflow-hidden rounded-full bg-slate-700 transition-opacity ${
+          className={`h-2 w-48 overflow-hidden rounded-full bg-surface-4 transition-opacity ${
             recording ? 'opacity-100' : 'opacity-0'
           }`}
         >
@@ -142,8 +142,8 @@ export const RecordReplay = memo(function RecordReplay({ pipeline, running }: Pr
               disabled={playing !== null}
               className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                 playing === 'raw'
-                  ? 'bg-amber-500/30 text-amber-300'
-                  : 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                  ? 'bg-amber-500/30 text-warning'
+                  : 'bg-surface-4 text-ink-1 hover:bg-surface-4'
               }`}
             >
               {playing === 'raw' ? 'Playing raw…' : 'Play raw'}
@@ -164,7 +164,7 @@ export const RecordReplay = memo(function RecordReplay({ pipeline, running }: Pr
             {playing && (
               <button
                 onClick={stopPlayback}
-                className="rounded-lg bg-slate-700 px-3 py-2 text-sm text-slate-300 hover:bg-slate-600"
+                className="rounded-lg bg-surface-4 px-3 py-2 text-sm text-ink-2 hover:bg-surface-4"
               >
                 Stop
               </button>
@@ -177,7 +177,7 @@ export const RecordReplay = memo(function RecordReplay({ pipeline, running }: Pr
       {clip && !recording && (
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
           <div>
-            <div className="mb-1 text-xs font-medium text-amber-300/80">
+            <div className="mb-1 text-xs font-medium text-warning">
               Raw (before NS)
             </div>
             <RecordingWaveform data={clip.raw} color="#fbbf24" />
@@ -236,7 +236,7 @@ function RecordingWaveform({
       ref={canvasRef}
       width={400}
       height={64}
-      className="h-16 w-full rounded bg-slate-950/60"
+      className="h-16 w-full rounded bg-surface-3"
     />
   )
 }

--- a/apps/web/src/components/StageCard.tsx
+++ b/apps/web/src/components/StageCard.tsx
@@ -1,29 +1,29 @@
 import type { PipelineStage } from '../data/pipeline'
 
 const STATUS_STYLES: Record<PipelineStage['status'], string> = {
-  pending: 'bg-slate-700 text-slate-300',
-  'in-progress': 'bg-amber-500/20 text-amber-300',
-  done: 'bg-emerald-500/20 text-emerald-300',
+  pending: 'bg-surface-4 text-ink-3',
+  'in-progress': 'bg-amber-100 text-amber-700',
+  done: 'bg-emerald-100 text-emerald-700',
 }
 
 export function StageCard({ stage, index }: { stage: PipelineStage; index: number }) {
   return (
-    <article className="relative flex flex-col gap-3 rounded-xl border border-white/10 bg-white/[0.03] p-5">
+    <article className="relative flex flex-col gap-3 rounded-xl border border-line bg-surface-2 p-5 shadow-sm">
       <div className="flex items-center gap-3">
-        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-500/15 text-sm font-bold text-brand-300">
+        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-50 text-sm font-bold text-brand-700">
           {stage.abbr}
         </span>
-        <h3 className="text-sm font-semibold text-white">{stage.name}</h3>
+        <h3 className="text-sm font-semibold text-ink-1">{stage.name}</h3>
       </div>
-      <p className="text-sm text-slate-400">{stage.role}</p>
-      <dl className="mt-auto space-y-1 text-xs text-slate-500">
+      <p className="text-sm text-ink-2">{stage.role}</p>
+      <dl className="mt-auto space-y-1 text-xs text-ink-3">
         <div className="flex gap-2">
           <dt className="w-20 shrink-0">Browser</dt>
-          <dd className="text-slate-300">{stage.browserRuntime}</dd>
+          <dd className="text-ink-2">{stage.browserRuntime}</dd>
         </div>
         <div className="flex gap-2">
           <dt className="w-20 shrink-0">Export</dt>
-          <dd className="text-slate-300">{stage.exportRuntime}</dd>
+          <dd className="text-ink-2">{stage.exportRuntime}</dd>
         </div>
       </dl>
       <span
@@ -31,7 +31,7 @@ export function StageCard({ stage, index }: { stage: PipelineStage; index: numbe
       >
         {stage.status === 'in-progress' ? 'In progress' : stage.status}
       </span>
-      <span className="absolute -left-2 top-1/2 hidden -translate-y-1/2 text-lg text-white/20 md:block">
+      <span className="absolute -left-2 top-1/2 hidden -translate-y-1/2 text-lg text-ink-3/40 md:block">
         {index < 3 ? '→' : ''}
       </span>
     </article>

--- a/apps/web/src/components/TrainingPanel.tsx
+++ b/apps/web/src/components/TrainingPanel.tsx
@@ -28,10 +28,10 @@ export const TrainingPanel = memo(function TrainingPanel() {
   return (
     <section className="mx-auto max-w-5xl px-6 py-12">
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">
+        <h2 className="text-lg font-semibold text-ink-1">
           Traditional KWS — Training
         </h2>
-        <p className="text-sm text-slate-400">
+        <p className="text-sm text-ink-2">
           Train a fixed-class wake-word model (§4.2). New keywords require a full
           retrain; supports quantization + export to TFLite / ONNX. Training runs
           on a Phase-5 backend (self-hosted / cloud / Colab, ADR-013/023) — this
@@ -39,27 +39,27 @@ export const TrainingPanel = memo(function TrainingPanel() {
         </p>
       </div>
 
-      <div className="mb-6 rounded-xl border border-white/10 bg-white/[0.03] p-5">
-        <h3 className="mb-4 text-sm font-semibold text-white">
+      <div className="mb-6 rounded-xl border border-line bg-surface-2 p-5">
+        <h3 className="mb-4 text-sm font-semibold text-ink-1">
           Configuration{' '}
-          <span className="text-xs font-normal text-slate-500">(Primary)</span>
+          <span className="text-xs font-normal text-ink-3">(Primary)</span>
         </h3>
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="flex flex-col gap-1 text-sm">
-            <span className="text-slate-400">Dataset import</span>
+            <span className="text-ink-2">Dataset import</span>
             <input
               type="file"
               multiple
               accept=".wav,.zip"
-              className="rounded bg-slate-800/80 px-2 py-1 text-slate-300"
+              className="rounded bg-surface-3 px-2 py-1 text-ink-2"
             />
           </label>
           <label className="flex flex-col gap-1 text-sm">
-            <span className="text-slate-400">Network architecture</span>
+            <span className="text-ink-2">Network architecture</span>
             <select
               value={architecture}
               onChange={(e) => setArchitecture(e.target.value)}
-              className="rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+              className="rounded bg-surface-3 px-2 py-1 text-ink-1"
             >
               <option value="micro-wake-word">micro-wake-word (MCU)</option>
               <option value="ml-kws-mcu">ARM-software/ML-KWS-for-MCU</option>
@@ -68,29 +68,29 @@ export const TrainingPanel = memo(function TrainingPanel() {
             </select>
           </label>
           <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-            <span className="w-32 shrink-0 text-slate-400">Epochs</span>
+            <span className="w-32 shrink-0 text-ink-2">Epochs</span>
             <input
               type="number"
               min={1}
               max={500}
               value={epochs}
               onChange={(e) => setEpochs(Number(e.target.value))}
-              className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+              className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-1"
             />
           </label>
           <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-            <span className="w-32 shrink-0 text-slate-400">Batch size</span>
+            <span className="w-32 shrink-0 text-ink-2">Batch size</span>
             <input
               type="number"
               min={1}
               max={256}
               value={batchSize}
               onChange={(e) => setBatchSize(Number(e.target.value))}
-              className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+              className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-1"
             />
           </label>
           <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-            <span className="w-32 shrink-0 text-slate-400">Learning rate</span>
+            <span className="w-32 shrink-0 text-ink-2">Learning rate</span>
             <input
               type="number"
               min={0.0001}
@@ -98,32 +98,32 @@ export const TrainingPanel = memo(function TrainingPanel() {
               step={0.0001}
               value={lr}
               onChange={(e) => setLr(Number(e.target.value))}
-              className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+              className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-1"
             />
           </label>
           <label className="flex flex-col gap-1 text-sm">
-            <span className="text-slate-400">Target keyword list</span>
+            <span className="text-ink-2">Target keyword list</span>
             <textarea
               value={keywords}
               onChange={(e) => setKeywords(e.target.value)}
               rows={3}
-              className="rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+              className="rounded bg-surface-3 px-2 py-1 text-ink-1"
               placeholder="one keyword per line"
             />
           </label>
         </div>
 
-        <div className="mt-4 border-t border-white/10 pt-3">
+        <div className="mt-4 border-t border-line pt-3">
           <button
             onClick={() => setAdvancedOpen((v) => !v)}
-            className="text-xs font-medium text-slate-400 hover:text-slate-200"
+            className="text-xs font-medium text-ink-2 hover:text-ink-1"
           >
             {advancedOpen ? '▾' : '▸'} Advanced
           </button>
           {advancedOpen && (
             <div className="mt-3 grid gap-4 sm:grid-cols-2">
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-40 shrink-0 text-slate-400">
+                <span className="w-40 shrink-0 text-ink-2">
                   Audio augmentation
                 </span>
                 <input
@@ -134,19 +134,19 @@ export const TrainingPanel = memo(function TrainingPanel() {
                 />
               </label>
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-40 shrink-0 text-slate-400">
+                <span className="w-40 shrink-0 text-ink-2">
                   Optimizer / scheduler
                 </span>
                 <select
                   defaultValue="adamw"
-                  className="flex-1 rounded bg-slate-800/80 px-2 py-1 text-slate-200"
+                  className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-1"
                 >
                   <option value="adamw">AdamW</option>
                   <option value="sgd">SGD + cosine</option>
                 </select>
               </label>
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-40 shrink-0 text-slate-400">
+                <span className="w-40 shrink-0 text-ink-2">
                   Quantization export
                 </span>
                 <input
@@ -155,10 +155,10 @@ export const TrainingPanel = memo(function TrainingPanel() {
                   onChange={(e) => setQuantize(e.target.checked)}
                   className="accent-brand-400"
                 />
-                <span className="text-xs text-slate-500">TFLite / ONNX int8</span>
+                <span className="text-xs text-ink-3">TFLite / ONNX int8</span>
               </label>
               <label className="flex items-center gap-3 text-sm">
-                <span className="w-40 shrink-0 text-slate-400">Early stopping</span>
+                <span className="w-40 shrink-0 text-ink-2">Early stopping</span>
                 <input
                   type="checkbox"
                   checked={earlyStop}
@@ -167,7 +167,7 @@ export const TrainingPanel = memo(function TrainingPanel() {
                 />
               </label>
               <label className="flex items-center gap-3 text-sm sm:col-span-2">
-                <span className="w-40 shrink-0 text-slate-400">
+                <span className="w-40 shrink-0 text-ink-2">
                   GitHub Action cloud conversion
                 </span>
                 <input
@@ -176,7 +176,7 @@ export const TrainingPanel = memo(function TrainingPanel() {
                   onChange={(e) => setGhAction(e.target.checked)}
                   className="accent-brand-400"
                 />
-                <span className="text-xs text-slate-500">
+                <span className="text-xs text-ink-3">
                   build + export on push
                 </span>
               </label>
@@ -187,12 +187,12 @@ export const TrainingPanel = memo(function TrainingPanel() {
         <div className="mt-4 flex items-center gap-3">
           <button
             disabled
-            className="cursor-not-allowed rounded-lg bg-slate-700 px-4 py-2 text-sm font-medium text-slate-400"
+            className="cursor-not-allowed rounded-lg bg-surface-4 px-4 py-2 text-sm font-medium text-ink-2"
             title="Training backend lands in Phase 5 (ADR-013/023). UI ready; execution reserved."
           >
             Start training
           </button>
-          <span className="text-xs text-amber-300/80">
+          <span className="text-xs text-warning">
             Reserved — training backend arrives in Phase 5.
           </span>
         </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,19 +2,64 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  :root {
-    color-scheme: dark;
-  }
+/*
+ * WakeStudio semantic design tokens (light theme, v1).
+ *
+ * Components use semantic utilities (bg-surface, text-ink-2, border-line...)
+ * instead of raw slate-xxx/white classes, so a dark theme is a token swap, not
+ * a component sweep. Defined here as CSS variables + mapped in
+ * tailwind.config.ts.
+ *
+ * Palette rationale:
+ *   - ink-1  : primary text (near-black, high contrast)
+ *   - ink-2  : secondary text (60% ink)
+ *   - ink-3  : tertiary / captions (45% ink)
+ *   - surface: page background (very light cool gray)
+ *   - surface-2: card background (white)
+ *   - surface-3: inset / input background (slightly gray)
+ *   - line   : hairline borders
+ *   - line-2 : stronger borders (focus rings, active)
+ *   - brand  : the sky-blue accent (unchanged from dark theme)
+ */
 
-  /* Always show the scrollbar: prevents a feedback loop where content height
-     changes cause the scrollbar to appear/disappear, which changes the viewport
-     width, which re-wraps text, which changes content height (ADR: flicker fix). */
-  html {
-    overflow-y: scroll;
-  }
+/* CSS variables live OUTSIDE @layer so they always exist at :root (Tailwind
+   drops unlayered custom props inside @layer base in some purge paths).
+   Colors are rgb() TRIPLES so Tailwind's <alpha-value> can compose
+   opacity modifiers (e.g. bg-surface-2/90). */
+:root {
+  color-scheme: light;
 
-  body {
-    @apply bg-slate-950 text-slate-100 antialiased;
-  }
+  /* Surfaces. */
+  --ws-surface: 248 250 252;    /* slate-50  - page bg */
+  --ws-surface-2: 255 255 255;  /* white     - card bg */
+  --ws-surface-3: 241 245 249;  /* slate-100 - inset/input bg */
+  --ws-surface-4: 226 232 240;  /* slate-200 - hover/active bg */
+
+  /* Ink (text). */
+  --ws-ink-1: 15 23 42;         /* slate-900 - primary text */
+  --ws-ink-2: 71 85 105;        /* slate-600 - secondary text */
+  --ws-ink-3: 100 116 139;      /* slate-500 - tertiary/captions */
+
+  /* Lines. */
+  --ws-line: 226 232 240;       /* slate-200 - hairlines */
+  --ws-line-2: 203 213 225;     /* slate-300 - stronger borders */
+
+  /* Semantic (status). */
+  --ws-success: 5 150 105;      /* emerald-600 */
+  --ws-warning: 217 119 6;      /* amber-600 */
+  --ws-danger: 220 38 38;       /* red-600 */
+}
+
+/* Always show the scrollbar: prevents a feedback loop where content height
+   changes cause the scrollbar to appear/disappear, which changes the viewport
+   width, which re-wraps text, which changes content height (ADR: flicker fix). */
+html {
+  overflow-y: scroll;
+}
+
+body {
+  background-color: rgb(var(--ws-surface));
+  color: rgb(var(--ws-ink-1));
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -25,6 +25,24 @@ export default {
           600: '#0284c7',
           700: '#0369a1',
         },
+        // Semantic tokens (light theme) - see index.css for values.
+        // Stored as rgb() triples so Tailwind can compose opacity modifiers.
+        surface: 'rgb(var(--ws-surface) / <alpha-value>)',
+        'surface-2': 'rgb(var(--ws-surface-2) / <alpha-value>)',
+        'surface-3': 'rgb(var(--ws-surface-3) / <alpha-value>)',
+        'surface-4': 'rgb(var(--ws-surface-4) / <alpha-value>)',
+        ink: {
+          1: 'rgb(var(--ws-ink-1) / <alpha-value>)',
+          2: 'rgb(var(--ws-ink-2) / <alpha-value>)',
+          3: 'rgb(var(--ws-ink-3) / <alpha-value>)',
+        },
+        line: {
+          DEFAULT: 'rgb(var(--ws-line) / <alpha-value>)',
+          2: 'rgb(var(--ws-line-2) / <alpha-value>)',
+        },
+        success: 'rgb(var(--ws-success) / <alpha-value>)',
+        warning: 'rgb(var(--ws-warning) / <alpha-value>)',
+        danger: 'rgb(var(--ws-danger) / <alpha-value>)',
       },
     },
   },

--- a/packages/module-kit/src/panel-generator.tsx
+++ b/packages/module-kit/src/panel-generator.tsx
@@ -68,7 +68,7 @@ function renderStatus(
       return (
         <div className="flex items-center gap-2">
           <span className="h-2 w-2 rounded-full bg-emerald-400" />
-          <span className="text-sm text-slate-300">{statusDef.label}</span>
+          <span className="text-sm text-ink-2">{statusDef.label}</span>
         </div>
       )
     case 'gauge':
@@ -77,8 +77,8 @@ function renderStatus(
     default:
       return (
         <div className="flex items-center justify-between gap-2">
-          <span className="text-sm text-slate-400">{statusDef.label}</span>
-          <span className="font-mono text-sm text-slate-200">{String(value ?? '—')}</span>
+          <span className="text-sm text-ink-2">{statusDef.label}</span>
+          <span className="font-mono text-sm text-ink-1">{String(value ?? '—')}</span>
         </div>
       )
   }
@@ -112,16 +112,16 @@ export function ModulePanel({ spec, controller, title }: GeneratedPanelProps) {
     <section className="mx-auto max-w-5xl px-6 py-12">
       {/* Panel header from spec.meta. */}
       <div className="mb-6">
-        <h2 className="text-lg font-semibold text-white">
+        <h2 className="text-lg font-semibold text-ink-1">
           {title ?? spec.meta.name}
         </h2>
-        <p className="mt-1 text-sm text-slate-400">
+        <p className="mt-1 text-sm text-ink-2">
           {spec.meta.category} module · v{spec.meta.version} ·{' '}
-          <span className="text-slate-500">{spec.meta.license}</span>
+          <span className="text-ink-3">{spec.meta.license}</span>
         </p>
       </div>
 
-      <div className="space-y-4 rounded-xl border border-white/10 bg-white/[0.03] p-5">
+      <div className="space-y-4 rounded-xl border border-line bg-surface-2 p-5">
         {/* Primary params. */}
         {primary.map((param) => (
           <UiParamRow
@@ -145,7 +145,7 @@ export function ModulePanel({ spec, controller, title }: GeneratedPanelProps) {
             open={advancedOpen}
             onOpenChange={setAdvancedOpen}
           >
-            <div className="space-y-3 rounded-lg border border-white/10 bg-slate-900/40 p-4">
+            <div className="space-y-3 rounded-lg border border-line bg-surface-3 p-4">
               {advanced.map((param) => (
                 <UiParamRow
                   key={param.id}
@@ -180,7 +180,7 @@ export function ModulePanel({ spec, controller, title }: GeneratedPanelProps) {
 
         {/* Status (live values from controller.status). */}
         {spec.status.length > 0 && (
-          <div className="grid gap-4 border-t border-white/5 pt-4 sm:grid-cols-2">
+          <div className="grid gap-4 border-t border-line pt-4 sm:grid-cols-2">
             {spec.status.map((statusDef) => (
               <div key={statusDef.id}>
                 {renderStatus(statusDef, controller.status?.[statusDef.id])}

--- a/packages/module-kit/src/ui/canvas.tsx
+++ b/packages/module-kit/src/ui/canvas.tsx
@@ -51,9 +51,9 @@ export function UiBar({ value, label, height = 6, threshold = 0.5, className }: 
   const over = value >= threshold
   return (
     <div className={className}>
-      {label && <div className="mb-1 text-xs text-slate-500">{label}</div>}
+      {label && <div className="mb-1 text-xs text-ink-3">{label}</div>}
       <div
-        className="relative w-full overflow-hidden rounded-full bg-slate-800"
+        className="relative w-full overflow-hidden rounded-full bg-surface-3"
         style={{ height }}
       >
         <div

--- a/packages/module-kit/src/ui/controls.tsx
+++ b/packages/module-kit/src/ui/controls.tsx
@@ -54,7 +54,7 @@ export function UiSlider({ value, min, max, step = 1, onChange, disabled, ariaLa
       </SliderPrimitive.Root>
       <span
         id={id}
-        className="w-12 shrink-0 text-right font-mono text-xs text-slate-400 tabular-nums"
+        className="w-12 shrink-0 text-right font-mono text-xs text-ink-2 tabular-nums"
       >
         {formatNumber(value)}
       </span>
@@ -91,9 +91,9 @@ export function UiNumber({ value, min, max, step = 1, unit, onChange, disabled }
           if (Number.isFinite(n)) onChange(n)
         }}
         disabled={disabled}
-        className="h-8 w-24 rounded-lg border border-white/10 bg-slate-800/60 px-2.5 text-right font-mono text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+        className="h-8 w-24 rounded-lg border border-line bg-surface-3 px-2.5 text-right font-mono text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
       />
-      {unit && <span className="text-xs text-slate-500">{unit}</span>}
+      {unit && <span className="text-xs text-ink-3">{unit}</span>}
     </div>
   )
 }
@@ -125,7 +125,7 @@ export function UiSelect({ value, options, onChange, disabled, placeholder = 'Se
     >
       <SelectPrimitive.Trigger className={cn(SELECT_CLS.trigger, disabled && 'opacity-40')}>
         <SelectPrimitive.Value placeholder={placeholder} />
-        <SelectPrimitive.Icon className="text-slate-500">
+        <SelectPrimitive.Icon className="text-ink-3">
           <ChevronDown className="h-3.5 w-3.5" />
         </SelectPrimitive.Icon>
       </SelectPrimitive.Trigger>
@@ -214,7 +214,7 @@ export interface UiProgressProps {
 export function UiProgress({ value, indeterminate }: UiProgressProps) {
   return (
     <ProgressPrimitive.Root
-      className="relative h-1.5 w-full overflow-hidden rounded-full bg-slate-800"
+      className="relative h-1.5 w-full overflow-hidden rounded-full bg-surface-3"
       value={indeterminate ? undefined : value}
     >
       <ProgressPrimitive.Indicator
@@ -269,8 +269,8 @@ export function UiParamRow({ label, description, children }: UiParamRowProps) {
   return (
     <div className="flex items-center justify-between gap-4 py-2">
       <div className="min-w-0">
-        <div className="text-sm text-slate-300">{label}</div>
-        {description && <div className="mt-0.5 text-xs text-slate-500">{description}</div>}
+        <div className="text-sm text-ink-2">{label}</div>
+        {description && <div className="mt-0.5 text-xs text-ink-3">{description}</div>}
       </div>
       <div className="shrink-0">{children}</div>
     </div>

--- a/packages/module-kit/src/ui/mapper.tsx
+++ b/packages/module-kit/src/ui/mapper.tsx
@@ -73,7 +73,7 @@ export function renderParamControl({ param, value, onChange, disabled }: ParamCo
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
           placeholder="••••••••"
-          className="h-8 w-48 rounded-lg border border-white/10 bg-slate-800/60 px-2.5 text-sm text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+          className="h-8 w-48 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
         />
       )
     default:

--- a/packages/module-kit/src/ui/styles.ts
+++ b/packages/module-kit/src/ui/styles.ts
@@ -1,9 +1,11 @@
 /**
- * module-kit ui - shared Tailwind + Radix styling helpers.
+ * module-kit ui - shared styling helpers.
  *
  * Central place for the design tokens used by the spec-driven controls.
- * Kept as plain class strings so tailwind can scan them (the packages/*
- * sources are added to tailwind.config content).
+ * Uses SEMANTIC classes (bg-surface-2, text-ink-1, border-line, ...) defined
+ * by the host app's Tailwind config (apps/web/tailwind.config.ts) so the
+ * kit follows whatever theme the host uses (light or dark). These classes
+ * must be present in the host's content scan (tailwind.config content).
  */
 
 /** Merge class names, skipping falsy values. */
@@ -19,26 +21,26 @@ export const BTN_BASE =
   'inline-flex items-center justify-center gap-1.5 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40 disabled:pointer-events-none'
 
 export const BTN_VARIANTS = {
-  primary: 'bg-brand-500 text-white hover:bg-brand-400',
+  primary: 'bg-brand-600 text-white hover:bg-brand-500',
   secondary:
-    'border border-white/10 bg-white/[0.03] text-slate-300 hover:bg-white/[0.07]',
-  danger: 'bg-red-500/80 text-white hover:bg-red-500',
-  ghost: 'text-slate-400 hover:text-slate-200',
+    'border border-line bg-surface-2 text-ink-2 hover:bg-surface-4/60',
+  danger: 'bg-danger/90 text-white hover:bg-danger',
+  ghost: 'text-ink-3 hover:text-ink-1',
 } as const
 
 /** Radix slider track/thumb styling (data-* attributes drive state). */
 export const SLIDER_CLS = {
   root: 'relative flex h-5 w-full touch-none select-none items-center',
   track:
-    'relative h-1.5 w-full grow overflow-hidden rounded-full bg-slate-700/60',
+    'relative h-1.5 w-full grow overflow-hidden rounded-full bg-surface-4',
   range: 'absolute h-full rounded-full bg-brand-500',
   thumb:
-    'block h-4 w-4 rounded-full bg-white shadow ring-1 ring-slate-900/10 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+    'block h-4 w-4 rounded-full bg-white shadow ring-1 ring-line-2 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
 }
 
 /** Radix switch (toggle) styling. */
 export const SWITCH_CLS = {
-  root: 'relative h-5 w-9 shrink-0 rounded-full bg-slate-700 transition-colors data-[state=checked]:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+  root: 'relative h-5 w-9 shrink-0 rounded-full bg-surface-4 transition-colors data-[state=checked]:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
   thumb:
     'block h-4 w-4 translate-x-0.5 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-[18px]',
 }
@@ -46,14 +48,14 @@ export const SWITCH_CLS = {
 /** Radix select trigger styling. */
 export const SELECT_CLS = {
   trigger:
-    'inline-flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-lg border border-white/10 bg-slate-800/60 px-2.5 text-sm text-slate-300 hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+    'inline-flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-2 hover:bg-surface-4/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
   content:
-    'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-white/10 bg-slate-900 p-1 shadow-xl',
-  item: 'cursor-default select-none rounded-md px-2.5 py-1.5 text-sm text-slate-300 outline-none data-[highlighted]:bg-brand-500/20 data-[highlighted]:text-white',
+    'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-line bg-surface-2 p-1 shadow-xl',
+  item: 'cursor-default select-none rounded-md px-2.5 py-1.5 text-sm text-ink-2 outline-none data-[highlighted]:bg-brand-50 data-[highlighted]:text-ink-1',
 }
 
 /** Radix collapsible (Primary/Advanced dual layer, ADR-024). */
 export const COLLAPSIBLE_CLS = {
   trigger:
-    'inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-slate-500 hover:text-slate-300 transition-colors',
+    'inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-ink-3 hover:text-ink-1 transition-colors',
 }

--- a/packages/modules/afe/rnnoise/web/playground.tsx
+++ b/packages/modules/afe/rnnoise/web/playground.tsx
@@ -109,22 +109,22 @@ export default function RnnoisePlayground() {
 
   return (
     <section className="mx-auto max-w-3xl px-6 py-12">
-      <h2 className="text-lg font-semibold text-white">
+      <h2 className="text-lg font-semibold text-ink-1">
         RNNoise module playground
       </h2>
-      <p className="mt-1 text-sm text-slate-400">
+      <p className="mt-1 text-sm text-ink-2">
         ADR-025 pilot · vendored emscripten wasm, runs fully in-browser. No
         AFE, no KWS — just this module. Controls are spec-driven (module-kit
         Ui* components).
       </p>
 
-      {!ready && <p className="mt-4 text-amber-300">Loading RNNoise WASM…</p>}
+      {!ready && <p className="mt-4 text-warning">Loading RNNoise WASM…</p>}
 
-      <div className="mt-6 space-y-4 rounded-xl border border-white/10 bg-white/[0.03] p-5">
+      <div className="mt-6 space-y-4 rounded-xl border border-line bg-surface-2 p-5">
         {/* Primary params (spec-driven controls). */}
         <div className="space-y-4">
           <div className="flex items-center gap-4">
-            <span className="w-28 shrink-0 text-sm text-slate-300">Noise level</span>
+            <span className="w-28 shrink-0 text-sm text-ink-2">Noise level</span>
             <div className="flex-1">
               <UiSlider
                 value={noiseLevel}
@@ -137,7 +137,7 @@ export default function RnnoisePlayground() {
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <span className="w-28 shrink-0 text-sm text-slate-300">Strength</span>
+            <span className="w-28 shrink-0 text-sm text-ink-2">Strength</span>
             <div className="flex-1">
               <UiSlider
                 value={strength}
@@ -150,7 +150,7 @@ export default function RnnoisePlayground() {
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <span className="w-28 shrink-0 text-sm text-slate-300">Denoise</span>
+            <span className="w-28 shrink-0 text-sm text-ink-2">Denoise</span>
             <UiToggle
               checked={denoiseEnabled}
               onChange={setDenoiseEnabled}
@@ -165,7 +165,7 @@ export default function RnnoisePlayground() {
           open={advancedOpen}
           onOpenChange={setAdvancedOpen}
         >
-          <div className="rounded-lg border border-white/10 bg-slate-900/40 p-4 text-xs text-slate-400">
+          <div className="rounded-lg border border-line bg-surface-3 p-4 text-xs text-ink-2">
             <p>
               Sample rate {SAMPLE_RATE / 1000} kHz · frame size{' '}
               {RNNOISE_FRAME_SIZE} samples (10 ms) · RNNoise wasm embedded as
@@ -187,14 +187,14 @@ export default function RnnoisePlayground() {
 
         {/* Status: waveform + curve + VAD bar. */}
         <div className="grid gap-4 pt-2 sm:grid-cols-2">
-          <div className="rounded-lg bg-slate-800/60 p-3">
-            <div className="mb-1 text-xs uppercase tracking-wider text-slate-500">
+          <div className="rounded-lg bg-surface-3 p-3">
+            <div className="mb-1 text-xs uppercase tracking-wider text-ink-3">
               Waveform (input vs denoised)
             </div>
             <UiWaveform data={output} overlay={input} height={56} />
           </div>
-          <div className="rounded-lg bg-slate-800/60 p-3">
-            <div className="mb-1 text-xs uppercase tracking-wider text-slate-500">
+          <div className="rounded-lg bg-surface-3 p-3">
+            <div className="mb-1 text-xs uppercase tracking-wider text-ink-3">
               VAD history
             </div>
             <UiCurve data={curveData} threshold={0.5} height={56} />
@@ -202,20 +202,20 @@ export default function RnnoisePlayground() {
         </div>
 
         <div className="grid grid-cols-3 gap-4 pt-2 text-sm">
-          <div className="rounded-lg bg-slate-800/60 p-3">
-            <div className="text-xs uppercase tracking-wider text-slate-500">
+          <div className="rounded-lg bg-surface-3 p-3">
+            <div className="text-xs uppercase tracking-wider text-ink-3">
               Input RMS
             </div>
-            <div className="mt-1 text-lg text-slate-200">{inRms.toFixed(3)}</div>
+            <div className="mt-1 text-lg text-ink-1">{inRms.toFixed(3)}</div>
           </div>
-          <div className="rounded-lg bg-slate-800/60 p-3">
-            <div className="text-xs uppercase tracking-wider text-slate-500">
+          <div className="rounded-lg bg-surface-3 p-3">
+            <div className="text-xs uppercase tracking-wider text-ink-3">
               Output RMS
             </div>
-            <div className="mt-1 text-lg text-emerald-300">{outRms.toFixed(3)}</div>
+            <div className="mt-1 text-lg text-success">{outRms.toFixed(3)}</div>
           </div>
-          <div className="rounded-lg bg-slate-800/60 p-3">
-            <div className="text-xs uppercase tracking-wider text-slate-500">
+          <div className="rounded-lg bg-surface-3 p-3">
+            <div className="text-xs uppercase tracking-wider text-ink-3">
               VAD
             </div>
             <UiBar value={vad} threshold={0.5} height={6} className="mt-2" />
@@ -225,8 +225,8 @@ export default function RnnoisePlayground() {
 
       {/* Generated panel from the real spec (ADR-025 §3). The controller wires
           spec params to the engine; proving spec -> panel -> engine end-to-end. */}
-      <div className="mt-8 border-t border-white/10 pt-6">
-        <div className="mb-2 text-xs uppercase tracking-wider text-slate-500">
+      <div className="mt-8 border-t border-line pt-6">
+        <div className="mb-2 text-xs uppercase tracking-wider text-ink-3">
           Spec-driven generated panel
         </div>
         <RnnoiseGeneratedPanel controller={generatedController} />


### PR DESCRIPTION
## Summary

Redesign the WakeStudio web app for **light mode** - clear, professional, and
token-driven. All hard-coded dark classes (slate-950/800, text-white,
bg-white/[0.03]...) are replaced with **semantic design tokens**, so a future
dark theme is a variable swap, not a component sweep.

## Changes

### Semantic design tokens
- `apps/web/src/index.css`: `:root` CSS variables as **rgb() triples** -
  `surface-{2,3,4}`, `ink-{1,2,3}`, `line`, `line-2`, `success/warning/danger`
- `apps/web/tailwind.config.ts`: semantic color utilities map the vars with
  `<alpha-value>` so opacity modifiers work (`bg-surface-2/90`, `text-ink-2/60`)

### Migration scope
- **web components (12)**: App, Header, Footer, StageCard, PipelineView,
  PipelineOverview, Domains, AFEPanel, KWSPanel, FewShotPanel, TrainingPanel,
  RecordReplay
- **module-kit (5)**: styles.ts, controls.tsx, canvas.tsx, mapper.tsx,
  panel-generator.tsx (follows the host theme)
- **rnnoise playground**

### Bug fixed
- `index.css` comment contained `slate-*/white` - the `*/` terminated the
  block comment early, swallowing the `:root` rule (all semantic vars
  unresolved -> transparent page, black text on nothing). Fixed to
  `slate-xxx/white`. This also explains the earlier "Expected identifier
  found whitespace" build warning.

## Verified

- `:root` vars resolve: `colorScheme: light`, `body rgb(248 250 252)`,
  header `rgba(255 255 255 / 0.9)`, dark ink text
- New `e2e/light-theme.spec.ts` regression guard (catches token loss)
- 121 unit tests, typecheck/lint clean, build OK
- e2e: light-theme + rnnoise + smoke all pass

## Notes

- prebuilts (125 MB) + sherpa-kws wasm (55 MB) remain gitignored (ADR-011)
- Only the web app + module-kit UI were re-themed; the local-service and
  device worlds are unaffected
