### PR TITLE
feat(web): console/studio shell - sidebar, workspace, project model, model library, session console

### DIFF
--- a/apps/web/e2e/rnnoise.spec.ts
+++ b/apps/web/e2e/rnnoise.spec.ts
@@ -8,14 +8,8 @@ import { test, expect } from '@playwright/test'
  */
 
 test('RNNoise playground loads and processes a frame', async ({ page }) => {
-  await page.goto('/')
-
-  // Open the playground from the console hero.
-  const playgroundButton = page.getByRole('button', {
-    name: /RNNoise module playground/i,
-  })
-  await expect(playgroundButton).toBeVisible()
-  await playgroundButton.click()
+  // Navigate directly to the module playground route (hash deep link).
+  await page.goto('/#/playground/rnnoise')
 
   // The module's own heading is visible.
   await expect(
@@ -26,13 +20,22 @@ test('RNNoise playground loads and processes a frame', async ({ page }) => {
   const processButton = page.getByRole('button', { name: /Process one frame/i })
   await expect(processButton).toBeEnabled({ timeout: 30_000 })
 
-  // VAD is rendered in the third stat card; start at 0.000.
-  const vadCard = page.locator('div.rounded-lg').nth(2)
-  await expect(vadCard).toContainText('0.000')
+  // VAD stat card (third stat card: label 'VAD' + UiBar; NOT the 'VAD
+  // history' curve card above it).
+  const vadCard = page
+    .locator('div.rounded-lg')
+    .filter({ hasText: 'VAD' })
+    .filter({ hasNotText: 'history' })
+    .first()
+  await expect(vadCard).toContainText('VAD')
+
+  // Before processing, the UiBar fill is 0% (inline style width).
+  const fill = vadCard.locator('.h-full.rounded-full')
+  await expect(fill).toHaveAttribute('style', /width: 0%/)
 
   await processButton.click()
 
-  // After processing, VAD should be a value in [0,1] - assert the text is no
-  // longer exactly "0.000" (a real frame always produces a non-zero VAD).
-  await expect(vadCard).not.toContainText('0.000', { timeout: 5_000 })
+  // After processing, a real frame always produces a non-zero VAD, so the
+  // UiBar fill grows past 0%.
+  await expect(fill).not.toHaveCSS('width', '0%', { timeout: 5_000 })
 })

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,57 +1,124 @@
 import { test, expect } from '@playwright/test'
 
-test('app shell renders the pipeline', async ({ page }) => {
+/**
+ * Console shell + workspace smoke tests (Phase 1).
+ *
+ * The app is now an IDE-style console (left sidebar + hash-routed views).
+ * Workspace hosts the live panels (AFE/KWS/Few-Shot/Training) — those still
+ * render, but under the new shell.
+ */
+
+test('console shell renders: sidebar + workspace default view', async ({ page }) => {
   await page.goto('/')
 
   await expect(page).toHaveTitle('WakeStudio')
-  await expect(page.getByRole('heading', { name: /From wake-word idea/i })).toBeVisible()
 
-  // The four pipeline stages are rendered (ADR-001).
-  await expect(page.getByText('Acoustic Echo Cancellation')).toBeVisible()
-  await expect(page.getByText('Blind Source Separation')).toBeVisible()
-  await expect(page.getByText('Noise Suppression')).toBeVisible()
-  await expect(page.getByText('Keyword Spotting')).toBeVisible()
+  // Left sidebar with primary nav.
+  const sidebar = page.locator('aside')
+  await expect(sidebar).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: 'Workspace' })).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: 'Model Library' })).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: 'Projects' })).toBeVisible()
+
+  // Default view is the workspace (h1 in the top bar + main heading). Root
+  // path ('/') renders the workspace without rewriting the URL.
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Workspace' })).toBeVisible()
+})
+
+test('hash routing navigates between views', async ({ page }) => {
+  await page.goto('/')
+
+  // Model Library: registry-driven view.
+  await sidebarNav(page, 'Model Library')
+  await expect(page).toHaveURL(/#\/library/)
+  await expect(page.getByRole('heading', { name: /Models \(\d+\)/ })).toBeVisible()
+
+  // Projects scaffold.
+  await sidebarNav(page, 'Projects')
+  await expect(page).toHaveURL(/#\/projects/)
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Projects' })).toBeVisible()
+
+  // Settings placeholder.
+  await sidebarNav(page, 'Settings')
+  await expect(page).toHaveURL(/#\/settings/)
+  await expect(page.getByText('Coming soon')).toBeVisible()
+
+  // Device SDK placeholder.
+  await sidebarNav(page, 'Device SDK')
+  await expect(page).toHaveURL(/#\/device-sdk/)
+  await expect(page.getByText('Coming soon')).toBeVisible()
+
+  // Back to workspace.
+  await sidebarNav(page, 'Workspace')
+  await expect(page).toHaveURL(/#\/workspace/)
+})
+
+test('model library renders registry entries', async ({ page }) => {
+  await page.goto('/#/library')
+
+  // Registry is fetched and rendered (ADR-011 model cards).
+  await expect(page.getByText('openWakeWord melspectrogram')).toBeVisible()
+  // KWS backend availability section.
+  await expect(page.getByText('OpenWakeWord (mel -> embedding -> classifier)')).toBeVisible()
+})
+
+test('live workspace panels still render (AFE/KWS/Few-Shot/Training)', async ({ page }) => {
+  await page.goto('/#/workspace')
+
+  // AFE live pipeline.
+  await expect(page.getByText('Live AFE pipeline')).toBeVisible()
+  // KWS detection.
+  await expect(page.getByText('KWS detection')).toBeVisible()
+  // Few-Shot enrollment (h2 in the panel).
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Few-Shot enrollment' })).toBeVisible()
+
+  // Training is under the "Modules" tab.
+  await page.getByRole('tab', { name: 'Modules' }).click()
+  await expect(
+    page.getByRole('heading', { name: /Traditional KWS — Training/i }),
+  ).toBeVisible()
 })
 
 test('KWS panel renders with the pluggable-backend UI (ADR-020)', async ({ page }) => {
-  await page.goto('/')
+  await page.goto('/#/workspace')
 
-  // The KWS section heading and description are visible.
-  await expect(page.getByRole('heading', { name: /KWS detection/i })).toBeVisible()
   await expect(page.getByText(/pluggable KWS backend/i)).toBeVisible()
 
-  // The "Load KWS models" button is visible in the idle state.
   const loadButton = page.getByRole('button', { name: /Load KWS models/i })
   await expect(loadButton).toBeVisible()
 
-  // Clicking load transitions away from idle (button disappears). Actual model
-  // loading (ONNX/WASM init + remote fetch) is too slow for e2e and is validated
-  // manually; here we only assert the UI transitions out of idle.
+  // Clicking load transitions away from idle. Actual model loading is too
+  // slow for e2e and is validated manually.
   await loadButton.click()
   await expect(loadButton).toBeHidden({ timeout: 5_000 })
 })
 
 test('Few-Shot enrollment panel renders (Phase 3)', async ({ page }) => {
-  await page.goto('/')
+  await page.goto('/#/workspace')
 
-  // The Few-Shot section heading is visible.
   await expect(page.getByRole('heading', { name: /Few-Shot enrollment/i })).toBeVisible()
-
-  // The "Load PLiX encoder" button is visible in the idle state.
   await expect(page.getByRole('button', { name: /Load PLiX encoder/i })).toBeVisible()
 })
 
 test('Traditional KWS Training panel renders (§4.2)', async ({ page }) => {
-  await page.goto('/')
+  await page.goto('/#/workspace')
 
+  await page.getByRole('tab', { name: 'Modules' }).click()
   await expect(
     page.getByRole('heading', { name: /Traditional KWS — Training/i }),
   ).toBeVisible()
-  // Primary params visible.
   await expect(page.getByText(/Network architecture/i)).toBeVisible()
   await expect(page.getByText(/Target keyword list/i)).toBeVisible()
-  // Advanced is collapsible.
+
   await expect(page.getByText(/Audio augmentation/i)).toBeHidden()
   await page.getByRole('button', { name: /Advanced/i }).first().click()
   await expect(page.getByText(/Audio augmentation/i)).toBeVisible()
 })
+
+/** Click a primary/secondary nav item in the left sidebar. */
+async function sidebarNav(
+  page: import('@playwright/test').Page,
+  name: string,
+): Promise<void> {
+  await page.locator('aside').getByRole('button', { name }).click()
+}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -31,7 +31,7 @@ test('hash routing navigates between views', async ({ page }) => {
   // Model Library: registry-driven view.
   await sidebarNav(page, 'Model Library')
   await expect(page).toHaveURL(/#\/library/)
-  await expect(page.getByRole('heading', { name: /Models \(\d+\)/ })).toBeVisible()
+  await expect(page.getByRole('heading', { name: /Models \(\d+ of \d+\)/ })).toBeVisible()
 
   // Projects scaffold.
   await sidebarNav(page, 'Projects')

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -115,6 +115,29 @@ test('Traditional KWS Training panel renders (§4.2)', async ({ page }) => {
   await expect(page.getByText(/Audio augmentation/i)).toBeVisible()
 })
 
+test('workspace: create a project and it persists across reload', async ({ page }) => {
+  await page.goto('/#/workspace')
+
+  // Project bar dropdown -> New project. The trigger shows the current
+  // project name or "No project selected".
+  await page.getByRole('button', { name: /No project selected|▾/ }).first().click()
+  await page.getByRole('menuitem', { name: /New project/ }).click()
+
+  await page.getByRole('textbox', { name: 'Project name' }).fill('E2E Word')
+  await page.getByRole('textbox', { name: 'Wake word' }).fill('hey e2e')
+  await page.getByRole('button', { name: 'Create' }).click()
+
+  // Project bar shows the new project; pipeline canvas is present.
+  await expect(page.getByText('E2E Word').first()).toBeVisible()
+  await expect(page.getByText('AEC → BSS → NS → KWS')).toBeVisible()
+
+  // Reload: the project (and selection) persists via IndexedDB + localStorage.
+  // refresh() is async (IndexedDB), so wait for the project bar to settle.
+  await page.reload()
+  await page.waitForSelector('aside')
+  await expect(page.getByText('E2E Word').first()).toBeVisible({ timeout: 10_000 })
+})
+
 /** Click a primary/secondary nav item in the left sidebar. */
 async function sidebarNav(
   page: import('@playwright/test').Page,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,11 @@
     "fetch:all": "node scripts/fetch-sherpa-kws-assets.mjs"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.23",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@radix-ui/react-tabs": "^1.1.21",
+    "@radix-ui/react-toast": "^1.2.23",
+    "@radix-ui/react-tooltip": "^1.2.16",
     "@wake-studio/contracts": "workspace:*",
     "@wake-studio/module-rnnoise": "workspace:^",
     "onnxruntime-web": "^1.27.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-toast": "^1.2.23",
     "@radix-ui/react-tooltip": "^1.2.16",
     "@wake-studio/contracts": "workspace:*",
+    "@wake-studio/module-kit": "workspace:^",
     "@wake-studio/module-rnnoise": "workspace:^",
     "onnxruntime-web": "^1.27.0",
     "react": "^18.3.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,8 +11,10 @@ import { ConsoleShell } from './components/ConsoleShell'
 import { ConsoleStatusProvider } from './status'
 import { AppToastProvider } from './components/toast'
 import { ProjectProvider } from './projects'
+import { LogProvider } from './log'
 import { WorkspaceView } from './views/WorkspaceView'
 import { ModelLibraryView } from './views/ModelLibraryView'
+import { SessionConsoleView } from './views/SessionConsoleView'
 import { ComingSoonView, ProjectsView } from './views/placeholders'
 import { RnnoisePlayground } from '@wake-studio/module-rnnoise/web'
 
@@ -23,24 +25,27 @@ export default function App() {
     <ConsoleStatusProvider>
       <AppToastProvider>
         <ProjectProvider>
-          <ConsoleShell route={route} onNavigate={navigate}>
-            {route === 'workspace' && <WorkspaceView />}
-            {route === 'library' && <ModelLibraryView />}
-            {route === 'projects' && <ProjectsView />}
-            {route === 'playground-rnnoise' && <RnnoisePlayground />}
-            {route === 'settings' && (
-              <ComingSoonView
-                title="Settings"
-                description="Console preferences, model source configuration and export defaults will live here."
-              />
-            )}
-            {route === 'device-sdk' && (
-              <ComingSoonView
-                title="Device SDK"
-                description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
-              />
-            )}
-          </ConsoleShell>
+          <LogProvider>
+            <ConsoleShell route={route} onNavigate={navigate}>
+              {route === 'workspace' && <WorkspaceView />}
+              {route === 'library' && <ModelLibraryView />}
+              {route === 'projects' && <ProjectsView />}
+              {route === 'console' && <SessionConsoleView />}
+              {route === 'playground-rnnoise' && <RnnoisePlayground />}
+              {route === 'settings' && (
+                <ComingSoonView
+                  title="Settings"
+                  description="Console preferences, model source configuration and export defaults will live here."
+                />
+              )}
+              {route === 'device-sdk' && (
+                <ComingSoonView
+                  title="Device SDK"
+                  description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
+                />
+              )}
+            </ConsoleShell>
+          </LogProvider>
         </ProjectProvider>
       </AppToastProvider>
     </ConsoleStatusProvider>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,75 +1,47 @@
-import { useRef, useState } from 'react'
-import type { AFEPipeline } from './afe'
-import { Header } from './components/Header'
-import { PipelineView } from './components/PipelineView'
-import { AFEPanel } from './components/AFEPanel'
-import { KWSPanel } from './components/KWSPanel'
-import { TrainingPanel } from './components/TrainingPanel'
-import { FewShotPanel } from './components/FewShotPanel'
-import { Domains } from './components/Domains'
-import { Footer } from './components/Footer'
+/**
+ * WakeStudio console app.
+ *
+ * Phase 1 shell: left sidebar + top bar + hash-routed views, built on Radix
+ * primitives. The Workspace hosts the existing live panels (AFE/KWS/Few-Shot)
+ * — their internals are refactored in Phase 2.
+ */
+
+import { useConsoleRoute } from './router'
+import { ConsoleShell } from './components/ConsoleShell'
+import { ConsoleStatusProvider } from './status'
+import { AppToastProvider } from './components/toast'
+import { WorkspaceView } from './views/WorkspaceView'
+import { ModelLibraryView } from './views/ModelLibraryView'
+import { ComingSoonView, ProjectsView } from './views/placeholders'
 import { RnnoisePlayground } from '@wake-studio/module-rnnoise/web'
 
 export default function App() {
-  // Shared AFE pipeline ref + running state, passed to both AFEPanel and KWSPanel
-  // so KWS can subscribe to the AFE output stream.
-  const afeRef = useRef<AFEPipeline | null>(null)
-  const [afeRunning, setAfeRunning] = useState(false)
-  const [route, setRoute] = useState<'main' | 'playground-rnnoise'>('main')
+  const [route, navigate] = useConsoleRoute()
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header />
-
-      <main className="flex-1">
-        {route === 'playground-rnnoise' ? (
-          <>
-            <button
-              onClick={() => setRoute('main')}
-              className="mt-6 ml-6 rounded-lg border border-line px-3 py-1 text-xs text-ink-3 hover:bg-surface-4/50"
-            >
-              ← Back to console
-            </button>
+    <ConsoleStatusProvider>
+      <AppToastProvider>
+        <ConsoleShell route={route} onNavigate={navigate}>
+          {route === 'workspace' && <WorkspaceView />}
+          {route === 'library' && <ModelLibraryView />}
+          {route === 'projects' && <ProjectsView />}
+          {route === 'playground-rnnoise' && (
             <RnnoisePlayground />
-          </>
-        ) : (
-          <>
-            {/* Hero */}
-            <section className="mx-auto max-w-5xl px-6 pt-16 pb-4 text-center">
-              <h1 className="text-4xl font-bold tracking-tight text-ink-1 sm:text-5xl">
-                From wake-word idea to deployable{' '}
-                <span className="bg-gradient-to-r from-brand-500 to-brand-600 bg-clip-text text-transparent">
-                  KWS bundle
-                </span>
-              </h1>
-              <p className="mx-auto mt-4 max-w-2xl text-base text-ink-2">
-                A browser-first studio for the full far-field voice pipeline - no
-                toolchain, runtime, or Python to install. Visualize every stage,
-                enroll a custom wake word with a few samples, and export a
-                ready-to-build package for your target chip.
-              </p>
-              <p className="mt-4 text-xs uppercase tracking-widest text-brand-600/80">
-                Phase 1-3 · AFE + KWS + Few-Shot enrollment · in progress
-              </p>
-              <button
-                onClick={() => setRoute('playground-rnnoise')}
-                className="mt-6 rounded-lg bg-brand-500/10 px-4 py-2 text-sm font-medium text-brand-700 hover:bg-brand-500/20"
-              >
-                Try the RNNoise module playground
-              </button>
-            </section>
-
-            <AFEPanel afeRef={afeRef} onRunningChange={setAfeRunning} />
-            <KWSPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
-            <TrainingPanel />
-            <FewShotPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
-            <PipelineView />
-            <Domains />
-          </>
-        )}
-      </main>
-
-      <Footer />
-    </div>
+          )}
+          {route === 'settings' && (
+            <ComingSoonView
+              title="Settings"
+              description="Console preferences, model source configuration and export defaults will live here."
+            />
+          )}
+          {route === 'device-sdk' && (
+            <ComingSoonView
+              title="Device SDK"
+              description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
+            />
+          )}
+        </ConsoleShell>
+      </AppToastProvider>
+    </ConsoleStatusProvider>
   )
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import { useConsoleRoute } from './router'
 import { ConsoleShell } from './components/ConsoleShell'
 import { ConsoleStatusProvider } from './status'
 import { AppToastProvider } from './components/toast'
+import { ProjectProvider } from './projects'
 import { WorkspaceView } from './views/WorkspaceView'
 import { ModelLibraryView } from './views/ModelLibraryView'
 import { ComingSoonView, ProjectsView } from './views/placeholders'
@@ -21,26 +22,26 @@ export default function App() {
   return (
     <ConsoleStatusProvider>
       <AppToastProvider>
-        <ConsoleShell route={route} onNavigate={navigate}>
-          {route === 'workspace' && <WorkspaceView />}
-          {route === 'library' && <ModelLibraryView />}
-          {route === 'projects' && <ProjectsView />}
-          {route === 'playground-rnnoise' && (
-            <RnnoisePlayground />
-          )}
-          {route === 'settings' && (
-            <ComingSoonView
-              title="Settings"
-              description="Console preferences, model source configuration and export defaults will live here."
-            />
-          )}
-          {route === 'device-sdk' && (
-            <ComingSoonView
-              title="Device SDK"
-              description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
-            />
-          )}
-        </ConsoleShell>
+        <ProjectProvider>
+          <ConsoleShell route={route} onNavigate={navigate}>
+            {route === 'workspace' && <WorkspaceView />}
+            {route === 'library' && <ModelLibraryView />}
+            {route === 'projects' && <ProjectsView />}
+            {route === 'playground-rnnoise' && <RnnoisePlayground />}
+            {route === 'settings' && (
+              <ComingSoonView
+                title="Settings"
+                description="Console preferences, model source configuration and export defaults will live here."
+              />
+            )}
+            {route === 'device-sdk' && (
+              <ComingSoonView
+                title="Device SDK"
+                description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
+              />
+            )}
+          </ConsoleShell>
+        </ProjectProvider>
       </AppToastProvider>
     </ConsoleStatusProvider>
   )

--- a/apps/web/src/__tests__/log.test.ts
+++ b/apps/web/src/__tests__/log.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Log store unit tests.
+ *
+ * Covers the ring-buffer cap, trigger recording, and CSV export escaping.
+ * These functions are pure-ish (module store); we clear between tests.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  clearLog,
+  getLogEntries,
+  getTriggerEntries,
+  logInfo,
+  logWarn,
+  logError,
+  logTrigger,
+  triggersToCsv,
+  LOG_CAP,
+} from '../log'
+
+beforeEach(() => {
+  clearLog()
+})
+
+describe('log store', () => {
+  it('records info/warn/error entries with source + message', () => {
+    logInfo('afe', 'started')
+    logWarn('kws', 'threshold low')
+    logError('kws', 'load failed')
+    const all = getLogEntries()
+    expect(all).toHaveLength(3)
+    expect(all[0].source).toBe('afe')
+    expect(all[0].level).toBe('info')
+    expect(all[1].level).toBe('warn')
+    expect(all[2].level).toBe('error')
+  })
+
+  it('caps the ring buffer at LOG_CAP', () => {
+    for (let i = 0; i < LOG_CAP + 50; i++) logInfo('src', `e${i}`)
+    const all = getLogEntries()
+    expect(all.length).toBe(LOG_CAP)
+    // Oldest dropped; newest retained.
+    expect(all[0].message).toBe(`e${50}`)
+    expect(all[all.length - 1].message).toBe(`e${LOG_CAP + 49}`)
+  })
+
+  it('records triggers separately from plain log entries', () => {
+    logInfo('afe', 'started')
+    logTrigger('kws', { triggeredAtMs: 1, peakScore: 0.92, word: 'hey studio' })
+    const triggers = getTriggerEntries()
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0].trigger?.word).toBe('hey studio')
+    expect(triggers[0].trigger?.peakScore).toBe(0.92)
+  })
+})
+
+describe('triggersToCsv', () => {
+  it('produces a header + one row per trigger', () => {
+    logTrigger('kws', { triggeredAtMs: 1, peakScore: 0.9, word: 'hey' })
+    logTrigger('kws', { triggeredAtMs: 2, peakScore: 0.7, word: 'jarvis' })
+    const csv = triggersToCsv(getTriggerEntries())
+    const lines = csv.split('\n')
+    expect(lines[0]).toBe('time,word,peak_score')
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toContain('hey')
+    expect(lines[2]).toContain('jarvis')
+  })
+
+  it('escapes commas and quotes in words', () => {
+    logTrigger('kws', { triggeredAtMs: 1, peakScore: 0.5, word: 'a, "quoted"' })
+    const csv = triggersToCsv(getTriggerEntries())
+    expect(csv).toContain('"a, ""quoted"""')
+  })
+
+  it('returns just the header for no triggers', () => {
+    expect(triggersToCsv([])).toBe('time,word,peak_score')
+  })
+})

--- a/apps/web/src/components/AFEPanel.tsx
+++ b/apps/web/src/components/AFEPanel.tsx
@@ -6,6 +6,7 @@ import type { StageFrameData } from '../afe'
 import { describeParameters } from '../afe'
 import { UnifiedConfigPanel } from './UnifiedConfigPanel'
 import { useProjectStageConfig } from '../projects'
+import { logInfo, logError } from '../log'
 import { PipelineOverview } from './PipelineOverview'
 import { RecordReplay } from './RecordReplay'
 
@@ -45,8 +46,10 @@ export function AFEPanel({ afeRef, onRunningChange, commandRef }: AFEPanelProps)
       await p.start()
       setRunning(true)
       onRunningChange(true)
+      logInfo('afe', 'Pipeline started (microphone live)')
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
+      logError('afe', err instanceof Error ? err.message : String(err))
     }
   }, [afeRef, onRunningChange])
 
@@ -56,6 +59,7 @@ export function AFEPanel({ afeRef, onRunningChange, commandRef }: AFEPanelProps)
     onRunningChange(false)
     setFrameData({})
     setLatencyMs(0)
+    logInfo('afe', 'Pipeline stopped')
   }, [afeRef, onRunningChange])
 
   // Expose start/stop to the workspace pipeline canvas via commandRef.

--- a/apps/web/src/components/AFEPanel.tsx
+++ b/apps/web/src/components/AFEPanel.tsx
@@ -5,6 +5,7 @@ import { AFEPipeline as AFEPipelineClass } from '../afe'
 import type { StageFrameData } from '../afe'
 import { describeParameters } from '../afe'
 import { UnifiedConfigPanel } from './UnifiedConfigPanel'
+import { useProjectStageConfig } from '../projects'
 import { PipelineOverview } from './PipelineOverview'
 import { RecordReplay } from './RecordReplay'
 
@@ -16,11 +17,13 @@ interface AFEPanelProps {
 }
 
 export function AFEPanel({ afeRef, onRunningChange, commandRef }: AFEPanelProps) {
+  const { projectConfig: projCfg, persist } = useProjectStageConfig('afe')
   const [running, setRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [latencyMs, setLatencyMs] = useState(0)
   const [frameData, setFrameData] = useState<Record<string, StageFrameData>>({})
-  const [vizFps, setVizFps] = useState(30)
+  // Seed vizFps from the active project's AFE snapshot (falls back to 30).
+  const [vizFps, setVizFps] = useState(projCfg?.vizFps ?? 30)
   const [bypass, setBypass] = useState({ aec: true, bss: true, ns: false })
 
   // Keep a ref to bypass so toggleBypass has a stable identity (for memo).
@@ -194,6 +197,7 @@ export function AFEPanel({ afeRef, onRunningChange, commandRef }: AFEPanelProps)
               const n = Number(v)
               setVizFps(n)
               afeRef.current?.setConfig({ vizFps: n })
+              persist({ vizFps: n })
             } else if (id.startsWith('bypass.')) {
               const stageId = id.slice('bypass.'.length) as 'aec' | 'bss' | 'ns'
               toggleBypass(stageId)

--- a/apps/web/src/components/AFEPanel.tsx
+++ b/apps/web/src/components/AFEPanel.tsx
@@ -4,6 +4,7 @@ import type { AFEPipeline } from '../afe'
 import { AFEPipeline as AFEPipelineClass } from '../afe'
 import type { StageFrameData } from '../afe'
 import { describeParameters } from '../afe'
+import { UnifiedConfigPanel } from './UnifiedConfigPanel'
 import { PipelineOverview } from './PipelineOverview'
 import { RecordReplay } from './RecordReplay'
 
@@ -172,39 +173,35 @@ export function AFEPanel({ afeRef, onRunningChange, commandRef }: AFEPanelProps)
         </div>
       )}
 
-      {/* Config panel (ADR-017) */}
+      {/* Config panel (ADR-017) - unified spec-driven rendering. */}
       <div className="mt-6 rounded-xl border border-line bg-surface-2 p-5">
         <h3 className="mb-4 text-sm font-semibold text-ink-1">
           Configuration{' '}
           <span className="text-xs font-normal text-ink-3">(ADR-017)</span>
         </h3>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <label className="flex items-center gap-3 text-sm">
-            <span className="w-32 text-ink-2">Visualization FPS</span>
-            <input
-              type="range"
-              min={15}
-              max={60}
-              step={5}
-              value={vizFps}
-              onChange={(e) => {
-                const v = Number(e.target.value)
-                setVizFps(v)
-                afeRef.current?.setConfig({ vizFps: v })
-              }}
-              className="flex-1 accent-brand-400"
-            />
-            <span className="w-10 text-right font-mono text-ink-2">
-              {vizFps}
-            </span>
-          </label>
-          <div className="flex items-center gap-3 text-sm text-ink-3">
-            <span className="w-32">Topology</span>
-            <span className="rounded bg-surface-4 px-2 py-1 text-xs text-ink-2">
-              single-worklet (v1)
-            </span>
-          </div>
-        </div>
+        <UnifiedConfigPanel
+          title="Pipeline parameters"
+          subtitle="Rendered from describeParameters() via module-kit controls."
+          params={params}
+          values={{
+            vizFps,
+            'bypass.aec': bypass.aec,
+            'bypass.bss': bypass.bss,
+            'bypass.ns': bypass.ns,
+          }}
+          onParamChange={(id, v) => {
+            if (id === 'vizFps') {
+              const n = Number(v)
+              setVizFps(n)
+              afeRef.current?.setConfig({ vizFps: n })
+            } else if (id.startsWith('bypass.')) {
+              const stageId = id.slice('bypass.'.length) as 'aec' | 'bss' | 'ns'
+              toggleBypass(stageId)
+            }
+          }}
+          advancedIds={['bypass.aec', 'bypass.bss', 'bypass.ns', 'latencyBudgetMs']}
+          disabled={running}
+        />
         <p className="mt-3 text-xs text-ink-3">
           {params.length} parameters exposed via{' '}
           <code className="text-ink-2">describeParameters()</code> · config

--- a/apps/web/src/components/AFEPanel.tsx
+++ b/apps/web/src/components/AFEPanel.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import type { MutableRefObject } from 'react'
 import type { AFEPipeline } from '../afe'
 import { AFEPipeline as AFEPipelineClass } from '../afe'
 import type { StageFrameData } from '../afe'
@@ -7,11 +8,13 @@ import { PipelineOverview } from './PipelineOverview'
 import { RecordReplay } from './RecordReplay'
 
 interface AFEPanelProps {
-  afeRef: React.MutableRefObject<AFEPipeline | null>
+  afeRef: MutableRefObject<AFEPipeline | null>
   onRunningChange: (running: boolean) => void
+  /** Optional: external control (workspace pipeline canvas) to start/stop. */
+  commandRef?: MutableRefObject<{ start: () => void; stop: () => void } | null>
 }
 
-export function AFEPanel({ afeRef, onRunningChange }: AFEPanelProps) {
+export function AFEPanel({ afeRef, onRunningChange, commandRef }: AFEPanelProps) {
   const [running, setRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [latencyMs, setLatencyMs] = useState(0)
@@ -50,6 +53,13 @@ export function AFEPanel({ afeRef, onRunningChange }: AFEPanelProps) {
     setFrameData({})
     setLatencyMs(0)
   }, [afeRef, onRunningChange])
+
+  // Expose start/stop to the workspace pipeline canvas via commandRef.
+  useEffect(() => {
+    if (commandRef) {
+      commandRef.current = { start: () => void handleStart(), stop: handleStop }
+    }
+  }, [commandRef, handleStart, handleStop])
 
   const toggleBypass = useCallback(
     (stageId: 'aec' | 'bss' | 'ns') => {

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -1,0 +1,79 @@
+/**
+ * Console shell layout: left sidebar (desktop) + mobile drawer + top bar +
+ * content. Wraps the routed views.
+ */
+
+import * as React from 'react'
+import type { ConsoleRoute } from '../router'
+import { Sidebar, TopBar } from './shell'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  TooltipProvider,
+} from './ui'
+import { useConsoleStatus } from '../status'
+
+const VIEW_TITLES: Record<ConsoleRoute, string> = {
+  workspace: 'Workspace',
+  library: 'Model Library',
+  projects: 'Projects',
+  'playground-rnnoise': 'RNNoise Playground',
+  settings: 'Settings',
+  'device-sdk': 'Device SDK',
+}
+
+export function ConsoleShell({
+  route,
+  onNavigate,
+  children,
+}: {
+  route: ConsoleRoute
+  onNavigate: (r: ConsoleRoute) => void
+  children: React.ReactNode
+}) {
+  const { status } = useConsoleStatus()
+  const [mobileNavOpen, setMobileNavOpen] = React.useState(false)
+
+  const navigate = (r: ConsoleRoute) => {
+    onNavigate(r)
+    setMobileNavOpen(false)
+  }
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="flex h-screen flex-col overflow-hidden bg-surface">
+        <div className="flex flex-1 overflow-hidden">
+          {/* Desktop sidebar */}
+          <aside className="hidden w-56 shrink-0 border-r border-line bg-surface-2/70 lg:block">
+            <Sidebar route={route} onNavigate={navigate} />
+          </aside>
+
+          {/* Mobile drawer */}
+          <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+            <DialogContent className="left-4 top-4 -translate-x-0 -translate-y-0 w-[min(80vw,17rem)] p-0">
+              <DialogTitle className="sr-only">Navigation</DialogTitle>
+              <DialogDescription className="sr-only">
+                Primary navigation
+              </DialogDescription>
+              <Sidebar route={route} onNavigate={navigate} />
+            </DialogContent>
+          </Dialog>
+
+          {/* Main column */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <TopBar
+              title={VIEW_TITLES[route]}
+              status={status}
+              onToggleSidebar={() => setMobileNavOpen(true)}
+            />
+            <main className="flex-1 overflow-y-auto">
+              <div className="mx-auto max-w-6xl px-6 py-8">{children}</div>
+            </main>
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -19,6 +19,7 @@ const VIEW_TITLES: Record<ConsoleRoute, string> = {
   workspace: 'Workspace',
   library: 'Model Library',
   projects: 'Projects',
+  console: 'Session Console',
   'playground-rnnoise': 'RNNoise Playground',
   settings: 'Settings',
   'device-sdk': 'Device SDK',

--- a/apps/web/src/components/FewShotPanel.tsx
+++ b/apps/web/src/components/FewShotPanel.tsx
@@ -5,6 +5,7 @@ import type { KWSScoreSample, KWSStatus } from '../kws'
 import { FewShotEngine, DEFAULT_CONFIG as FS_DEFAULTS, describeParameters } from '../few-shot'
 import type { EnrolledSample, FewShotConfig, WakeWordPrototype } from '../few-shot'
 import { UnifiedConfigPanel, type ParamValue } from './UnifiedConfigPanel'
+import { useProjectStageConfig } from '../projects'
 import recorderUrl from '../few-shot/recorder.worklet.ts?worker&url'
 import type { ModelRuntime } from '../runtime'
 import {
@@ -59,14 +60,20 @@ export const FewShotPanel = memo(function FewShotPanel({
   const [triggerFlash, setTriggerFlash] = useState(false)
   const [prototype, setPrototype] = useState<WakeWordPrototype | null>(null)
   const [building, setBuilding] = useState(false)
-  const [config, setConfigState] = useState<FewShotConfig>({ ...FS_DEFAULTS })
+  const { projectConfig: projCfg, persist } = useProjectStageConfig('fewShot')
+  const [config, setConfigState] = useState<FewShotConfig>({
+    ...FS_DEFAULTS,
+    ...(projCfg as Partial<FewShotConfig> | undefined),
+  })
   const updateConfig = useCallback((patch: Partial<FewShotConfig>) => {
     setConfigState((prev) => {
       const next = { ...prev, ...patch }
       fsEngineRef.current?.setConfig(patch)
       return next
     })
-  }, [])
+    // Persist to the active project's Few-Shot snapshot.
+    persist(patch)
+  }, [persist])
   const [encoderVariant, setEncoderVariant] =
     useState<PlixEncoderVariant['id']>(DEFAULT_VARIANT)
   const [runtime, setRuntime] = useState<ModelRuntime>('onnx')

--- a/apps/web/src/components/FewShotPanel.tsx
+++ b/apps/web/src/components/FewShotPanel.tsx
@@ -2,8 +2,9 @@ import { memo, useCallback, useRef, useState, useEffect } from 'react'
 import type { AFEPipeline } from '../afe'
 import { KWSEngine, DEFAULT_CONFIG as KWS_DEFAULTS } from '../kws'
 import type { KWSScoreSample, KWSStatus } from '../kws'
-import { FewShotEngine, DEFAULT_CONFIG as FS_DEFAULTS } from '../few-shot'
+import { FewShotEngine, DEFAULT_CONFIG as FS_DEFAULTS, describeParameters } from '../few-shot'
 import type { EnrolledSample, FewShotConfig, WakeWordPrototype } from '../few-shot'
+import { UnifiedConfigPanel, type ParamValue } from './UnifiedConfigPanel'
 import recorderUrl from '../few-shot/recorder.worklet.ts?worker&url'
 import type { ModelRuntime } from '../runtime'
 import {
@@ -58,11 +59,17 @@ export const FewShotPanel = memo(function FewShotPanel({
   const [triggerFlash, setTriggerFlash] = useState(false)
   const [prototype, setPrototype] = useState<WakeWordPrototype | null>(null)
   const [building, setBuilding] = useState(false)
-  const [config] = useState<FewShotConfig>({ ...FS_DEFAULTS })
+  const [config, setConfigState] = useState<FewShotConfig>({ ...FS_DEFAULTS })
+  const updateConfig = useCallback((patch: Partial<FewShotConfig>) => {
+    setConfigState((prev) => {
+      const next = { ...prev, ...patch }
+      fsEngineRef.current?.setConfig(patch)
+      return next
+    })
+  }, [])
   const [encoderVariant, setEncoderVariant] =
     useState<PlixEncoderVariant['id']>(DEFAULT_VARIANT)
   const [runtime, setRuntime] = useState<ModelRuntime>('onnx')
-  const [advancedOpen, setAdvancedOpen] = useState(false)
   const historyRef = useRef<KWSScoreSample[]>([])
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -442,44 +449,23 @@ export const FewShotPanel = memo(function FewShotPanel({
           />
         </div>
 
-        {/* Advanced (collapsible) — §4.1 Few-Shot advanced params */}
+        {/* Config (unified, spec-driven) — §4.1 Few-Shot params. */}
         <div className="mb-6 rounded-xl border border-line bg-surface-2 p-5">
-          <button
-            onClick={() => setAdvancedOpen((v) => !v)}
-            className="text-xs font-medium text-ink-2 hover:text-ink-1"
-          >
-            {advancedOpen ? '▾' : '▸'} Advanced
-          </button>
-          {advancedOpen && (
-            <div className="mt-3 grid gap-4 sm:grid-cols-2">
-              <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-ink-2">Mel preprocessing</span>
-                <input type="checkbox" defaultChecked className="accent-brand-400" />
-                <span className="text-xs text-ink-3">64x100 log-Mel</span>
-              </label>
-              <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-ink-2">Frame cache</span>
-                <input
-                  type="number"
-                  defaultValue={1500}
-                  min={500}
-                  max={3000}
-                  step={100}
-                  className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-1"
-                />
-                <span className="text-xs text-ink-3">ms</span>
-              </label>
-              <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-ink-2">Feature smoothing</span>
-                <input type="checkbox" defaultChecked className="accent-brand-400" />
-              </label>
-              <label className="flex items-center gap-3 text-sm">
-                <span className="w-36 shrink-0 text-ink-2">Embedding viz</span>
-                <input type="checkbox" className="accent-brand-400" />
-                <span className="text-xs text-ink-3">show 1280-d vector</span>
-              </label>
-            </div>
-          )}
+          <UnifiedConfigPanel
+            title="Detection parameters"
+            subtitle="Rendered from describeParameters() via module-kit controls."
+            params={describeParameters()}
+            values={config as unknown as Record<string, ParamValue>}
+            onParamChange={(id, v) => updateConfig({ [id]: v })}
+            advancedIds={[
+              'smoothingWindowFrames',
+              'windowMs',
+              'vadGateEnabled',
+              'vadThreshold',
+              'useNegativePrototype',
+            ]}
+            disabled={detecting}
+          />
         </div>
         </>
       )}

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -16,6 +16,7 @@ import type {
 import { MEL_WINDOW_SIZE } from '../kws'
 import type { SherpaOnnxKwsConfig } from '../kws'
 import { UnifiedConfigPanel, type ParamValue } from './UnifiedConfigPanel'
+import { useProjectStageConfig } from '../projects'
 
 // Default keyword list for the sherpa-onnx KWS backend (matches the model
 // prebuilt into the wasm .data bundle). For the wenetspeech-3.3M-2024-01-01
@@ -54,7 +55,12 @@ export const KWSPanel = memo(function KWSPanel({
   const [running, setRunning] = useState(false)
   const [triggerFlash, setTriggerFlash] = useState(false)
   const [warmup, setWarmup] = useState(false)
-  const [config, setConfig] = useState<KWSConfig>({ ...DEFAULT_CONFIG })
+  // Seed config from the active project's KWS snapshot (falls back to defaults).
+  const { projectConfig: projCfg, persist } = useProjectStageConfig('kws')
+  const [config, setConfig] = useState<KWSConfig>({
+    ...DEFAULT_CONFIG,
+    ...(projCfg as Partial<KWSConfig> | undefined),
+  })
   const [executionProvider, setExecutionProvider] = useState<'webgpu' | 'wasm'>(
     'wasm',
   )
@@ -112,7 +118,9 @@ export const KWSPanel = memo(function KWSPanel({
       engineRef.current?.setConfig(patch)
       return next
     })
-  }, [])
+    // Persist to the active project's KWS snapshot.
+    persist(patch)
+  }, [persist])
 
   // Render the score curve via requestAnimationFrame.
   useEffect(() => {

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -17,6 +17,7 @@ import { MEL_WINDOW_SIZE } from '../kws'
 import type { SherpaOnnxKwsConfig } from '../kws'
 import { UnifiedConfigPanel, type ParamValue } from './UnifiedConfigPanel'
 import { useProjectStageConfig } from '../projects'
+import { logTrigger, logInfo, logError } from '../log'
 
 // Default keyword list for the sherpa-onnx KWS backend (matches the model
 // prebuilt into the wasm .data bundle). For the wenetspeech-3.3M-2024-01-01
@@ -88,9 +89,11 @@ export const KWSPanel = memo(function KWSPanel({
       await engine.load(MODEL_URLS, undefined, sherpaKwsConfig)
       setStatus(engine.status)
       setExecutionProvider(engine.executionProvider)
+      logInfo('kws', `Models loaded (backend: ${config.backend})`)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
+      logError('kws', err instanceof Error ? err.message : String(err))
     }
   }, [config.backend, config.threshold])
 
@@ -159,10 +162,14 @@ export const KWSPanel = memo(function KWSPanel({
     engine.onTrigger((e: KWSTriggerEvent) => {
       setTriggerFlash(true)
       setTimeout(() => setTriggerFlash(false), 500)
-      console.log('[KWS] Trigger:', e.word, e.peakScore.toFixed(3))
+      // Publish to the session console (Phase 4) - replaces console.log.
+      logTrigger('kws', e)
     })
     engine.onPartial((text: string) => {
-      if (text) setLastKeyword(text)
+      if (text) {
+        setLastKeyword(text)
+        logInfo('kws', `partial: ${text}`)
+      }
     })
     engine.setConfig({ backend: config.backend, threshold: config.threshold })
     // The engine is created once; backend/threshold changes are pushed via

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -15,6 +15,7 @@ import type {
 } from '../kws'
 import { MEL_WINDOW_SIZE } from '../kws'
 import type { SherpaOnnxKwsConfig } from '../kws'
+import { UnifiedConfigPanel, type ParamValue } from './UnifiedConfigPanel'
 
 // Default keyword list for the sherpa-onnx KWS backend (matches the model
 // prebuilt into the wasm .data bundle). For the wenetspeech-3.3M-2024-01-01
@@ -57,7 +58,6 @@ export const KWSPanel = memo(function KWSPanel({
   const [executionProvider, setExecutionProvider] = useState<'webgpu' | 'wasm'>(
     'wasm',
   )
-  const [advancedOpen, setAdvancedOpen] = useState(false)
   const [logExport, setLogExport] = useState(false)
 
   const [lastKeyword, setLastKeyword] = useState('')
@@ -288,12 +288,12 @@ export const KWSPanel = memo(function KWSPanel({
             </span>
           </h3>
 
-          {/* Primary: inference mode, threshold, output mode */}
-          <div className="grid gap-4 sm:grid-cols-2">
+          {/* Read-only surface flags (not tunable params; reserved). */}
+          <div className="mb-4 grid gap-4 sm:grid-cols-2">
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
               <span className="w-32 shrink-0 text-ink-2">Inference mode</span>
               <select
-                value={config.executionProvider === 'webgpu' ? 'realtime' : 'realtime'}
+                value="realtime"
                 disabled
                 className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
                 title="Real-time mic detection (offline-file import is reserved)."
@@ -301,23 +301,6 @@ export const KWSPanel = memo(function KWSPanel({
                 <option value="realtime">Real-time mic</option>
                 <option value="offline">Offline file</option>
               </select>
-            </label>
-            <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-              <span className="w-32 shrink-0 text-ink-2">Confidence</span>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.05}
-                value={config.threshold}
-                onChange={(e) =>
-                  updateConfig({ threshold: Number(e.target.value) })
-                }
-                className="flex-1 accent-brand-400"
-              />
-              <span className="w-10 shrink-0 text-right font-mono text-ink-2">
-                {config.threshold.toFixed(2)}
-              </span>
             </label>
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
               <span className="w-32 shrink-0 text-ink-2">Output mode</span>
@@ -333,122 +316,46 @@ export const KWSPanel = memo(function KWSPanel({
               </select>
             </label>
             <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-              <span className="w-32 shrink-0 text-ink-2">VAD gate</span>
+              <span className="w-32 shrink-0 text-ink-2">Acceleration</span>
+              <select
+                value={config.executionProvider}
+                disabled
+                className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
+                title="WebGPU when available, else WASM (ADR-018)."
+              >
+                <option value="webgpu">WebGPU</option>
+                <option value="wasm">WASM</option>
+              </select>
+            </label>
+            <label className="flex items-center gap-3 whitespace-nowrap text-sm">
+              <span className="w-32 shrink-0 text-ink-2">Log export</span>
               <input
                 type="checkbox"
-                checked={config.vadGateEnabled}
-                onChange={(e) =>
-                  updateConfig({ vadGateEnabled: e.target.checked })
-                }
+                checked={logExport}
+                onChange={(e) => setLogExport(e.target.checked)}
                 className="accent-brand-400"
               />
               <span className="text-xs text-ink-3">
-                Suppress triggers in silence
+                Stream scores to console
               </span>
             </label>
           </div>
 
-          {/* Advanced (collapsible) */}
-          <div className="mt-4 border-t border-line pt-3">
-            <button
-              onClick={() => setAdvancedOpen((v) => !v)}
-              className="text-xs font-medium text-ink-2 hover:text-ink-1"
-            >
-              {advancedOpen ? '▾' : '▸'} Advanced
-            </button>
-            {advancedOpen && (
-              <div className="mt-3 grid gap-4 sm:grid-cols-2">
-                <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-ink-2">Min. duration</span>
-                  <input
-                    type="range"
-                    min={100}
-                    max={3000}
-                    step={100}
-                    value={config.minDurationMs}
-                    onChange={(e) =>
-                      updateConfig({ minDurationMs: Number(e.target.value) })
-                    }
-                    className="flex-1 accent-brand-400"
-                  />
-                  <span className="w-14 shrink-0 text-right font-mono text-ink-2">
-                    {config.minDurationMs} ms
-                  </span>
-                </label>
-                <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-ink-2">Smoothing</span>
-                  <input
-                    type="range"
-                    min={1}
-                    max={30}
-                    step={1}
-                    value={config.smoothingWindowFrames}
-                    onChange={(e) =>
-                      updateConfig({
-                        smoothingWindowFrames: Number(e.target.value),
-                      })
-                    }
-                    className="flex-1 accent-brand-400"
-                  />
-                  <span className="w-10 shrink-0 text-right font-mono text-ink-2">
-                    {config.smoothingWindowFrames}
-                  </span>
-                </label>
-                <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-ink-2">Cooldown</span>
-                  <input
-                    type="range"
-                    min={500}
-                    max={10000}
-                    step={500}
-                    value={config.cooldownMs}
-                    onChange={(e) =>
-                      updateConfig({ cooldownMs: Number(e.target.value) })
-                    }
-                    className="flex-1 accent-brand-400"
-                  />
-                  <span className="w-14 shrink-0 text-right font-mono text-ink-2">
-                    {config.cooldownMs} ms
-                  </span>
-                </label>
-                <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-ink-2">Mel window</span>
-                  <input
-                    type="number"
-                    value={MEL_WINDOW_SIZE}
-                    disabled
-                    className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
-                  />
-                </label>
-                <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-ink-2">
-                    Acceleration
-                  </span>
-                  <select
-                    value={config.executionProvider}
-                    disabled
-                    className="flex-1 rounded bg-surface-3 px-2 py-1 text-ink-2"
-                    title="WebGPU when available, else WASM (ADR-018)."
-                  >
-                    <option value="webgpu">WebGPU</option>
-                    <option value="wasm">WASM</option>
-                  </select>
-                </label>
-                <label className="flex items-center gap-3 whitespace-nowrap text-sm">
-                  <span className="w-32 shrink-0 text-ink-2">Log export</span>
-                  <input
-                    type="checkbox"
-                    checked={logExport}
-                    onChange={(e) => setLogExport(e.target.checked)}
-                    className="accent-brand-400"
-                  />
-                  <span className="text-xs text-ink-3">
-                    Stream scores to console
-                  </span>
-                </label>
-              </div>
-            )}
-          </div>
+          {/* Tunable params rendered from the spec descriptors (module-kit). */}
+          <UnifiedConfigPanel
+            title="Tunable parameters"
+            subtitle="Rendered from describeParameters() via module-kit controls."
+            params={params}
+            values={config as unknown as Record<string, ParamValue>}
+            onParamChange={(id, v) => updateConfig({ [id]: v })}
+            advancedIds={[
+              'minDurationMs',
+              'smoothingWindowFrames',
+              'cooldownMs',
+              'vadThreshold',
+            ]}
+            disabled={running}
+          />
           <p className="mt-3 text-xs text-ink-3">
             {params.length} parameters exposed via{' '}
             <code className="text-ink-2">describeParameters()</code>. Mel

--- a/apps/web/src/components/PipelineCanvas.tsx
+++ b/apps/web/src/components/PipelineCanvas.tsx
@@ -1,0 +1,97 @@
+/**
+ * Pipeline canvas - visual orchestration of AEC -> BSS -> NS -> KWS.
+ *
+ * Renders the four stages as connected nodes with live status (bypass /
+ * active / running) and a shared run/stop control that drives the AFE
+ * (which feeds KWS). Phase 2 scope: orchestration + rendering; the engine
+ * internals stay behind the existing module APIs.
+ */
+
+import * as React from 'react'
+import type { ConsoleStatus } from '../status'
+import { IconPlay, IconStop, IconSpinner } from './icons'
+import { cn } from './cn'
+
+interface PipelineCanvasProps {
+  afeRunning: boolean
+  onStart: () => void
+  onStop: () => void
+  status: ConsoleStatus
+}
+
+const STAGES = [
+  { id: 'aec', name: 'AEC', detail: 'Acoustic echo cancellation', color: '#818cf8' },
+  { id: 'bss', name: 'BSS', detail: 'Blind source separation', color: '#a78bfa' },
+  { id: 'ns', name: 'NS', detail: 'Noise suppression', color: '#38bdf8' },
+  { id: 'kws', name: 'KWS', detail: 'Keyword spotting', color: '#34d399' },
+] as const
+
+export function PipelineCanvas({ afeRunning, onStart, onStop, status }: PipelineCanvasProps) {
+  const micOk = status.mic === 'active'
+
+  return (
+    <div className="rounded-xl border border-line bg-surface-2 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold text-ink-1">Pipeline</div>
+          <div className="text-xs text-ink-3">
+            AEC → BSS → NS → KWS · live capture drives detection
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {!afeRunning ? (
+            <button
+              onClick={onStart}
+              className="flex items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-400"
+            >
+              <IconPlay className="h-3.5 w-3.5" /> Start pipeline
+            </button>
+          ) : (
+            <button
+              onClick={onStop}
+              className="flex items-center gap-1.5 rounded-lg bg-danger/90 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-red-500"
+            >
+              <IconStop className="h-3.5 w-3.5" /> Stop
+            </button>
+          )}
+          {afeRunning && <IconSpinner className="h-4 w-4 text-brand-600" />}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        {STAGES.map((stage, i) => (
+          <React.Fragment key={stage.id}>
+            <div className="flex flex-col items-center gap-1">
+              <div
+                className={cn(
+                  'flex h-10 w-14 items-center justify-center rounded-lg border text-xs font-bold uppercase tracking-wide',
+                  afeRunning
+                    ? 'border-brand-500/40 bg-brand-500/10 text-brand-700'
+                    : 'border-line bg-surface-3 text-ink-2',
+                )}
+                style={afeRunning ? { color: stage.color } : undefined}
+              >
+                {stage.name}
+              </div>
+              <span className="max-w-24 truncate text-center text-[10px] text-ink-3">
+                {stage.detail}
+              </span>
+            </div>
+            {i < STAGES.length - 1 && (
+              <div
+                className={cn(
+                  'mx-0.5 mb-4 h-0.5 w-4 rounded sm:w-6',
+                  afeRunning ? 'bg-brand-400' : 'bg-line-2',
+                )}
+              />
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+
+      {!micOk && afeRunning && (
+        <div className="mt-3 text-xs text-warning">Microphone not active — check permissions.</div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/ProjectBar.tsx
+++ b/apps/web/src/components/ProjectBar.tsx
@@ -1,0 +1,178 @@
+/**
+ * Project bar - select/create the active project in the workspace.
+ *
+ * Shows the current project (name, target word, domain) with a dropdown to
+ * switch, and a "New project" dialog (Radix). Project data lives in the
+ * project context (IndexedDB).
+ */
+
+import * as React from 'react'
+import { useProjects, PROJECT_DOMAINS } from '../projects'
+import type { ProjectDomain } from '../projects'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui'
+import { useToast } from './toast'
+import { cn } from './cn'
+
+export function ProjectBar() {
+  const { projects, current, selectProject, createProject, busy } = useProjects()
+  const { toast } = useToast()
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [draft, setDraft] = React.useState({
+    name: '',
+    targetWord: '',
+    domain: 'high-performance' as ProjectDomain,
+    targetChip: '',
+  })
+
+  const submitCreate = async () => {
+    try {
+      await createProject(draft)
+      setCreateOpen(false)
+      setDraft({ name: '', targetWord: '', domain: 'high-performance', targetChip: '' })
+      toast({ title: 'Project created', description: draft.name || 'Untitled project' })
+    } catch (err) {
+      toast({
+        title: 'Failed to create project',
+        description: err instanceof Error ? err.message : String(err),
+        variant: 'error',
+      })
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-xl border border-line bg-surface-2 px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-widest text-ink-3">
+          Project
+        </span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="flex items-center gap-1.5 rounded-lg border border-line bg-surface-3 px-2.5 py-1.5 text-sm font-medium text-ink-1 hover:bg-surface-4">
+              {current ? (
+                <>
+                  <span className="max-w-40 truncate">{current.name}</span>
+                  <span className="text-ink-3">▾</span>
+                </>
+              ) : (
+                <span className="text-ink-3">No project selected</span>
+              )}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-56">
+            {projects.length === 0 && (
+              <div className="px-2.5 py-2 text-xs text-ink-3">No projects yet</div>
+            )}
+            {projects.map((p) => (
+              <DropdownMenuItem key={p.id} onSelect={() => selectProject(p.id)}>
+                <span className="flex-1 truncate">{p.name}</span>
+                {current?.id === p.id && <span className="text-brand-600">✓</span>}
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setCreateOpen(true)}>
+              <span className="text-brand-600">+ New project…</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {current && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ink-2">
+          <span>
+            Target:{' '}
+            <span className="font-medium text-ink-1">{current.targetWord || '—'}</span>
+          </span>
+          <span>
+            Domain:{' '}
+            <span className="font-medium text-ink-1">
+              {PROJECT_DOMAINS.find((d) => d.value === current.domain)?.label ?? current.domain}
+            </span>
+          </span>
+          {current.targetChip && (
+            <span>
+              Chip: <span className="font-medium text-ink-1">{current.targetChip}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* New project dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogTitle>New project</DialogTitle>
+          <DialogDescription>
+            Create a wake-word project: target word, domain and target chip.
+          </DialogDescription>
+          <div className="mt-4 space-y-3">
+            <label className="block text-sm">
+              <span className="text-ink-2">Project name</span>
+              <input
+                value={draft.name}
+                onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+                placeholder="e.g. Hey Studio"
+                className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-ink-2">Wake word</span>
+              <input
+                value={draft.targetWord}
+                onChange={(e) => setDraft((d) => ({ ...d, targetWord: e.target.value }))}
+                placeholder="e.g. hey studio"
+                className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-ink-2">Domain</span>
+              <select
+                value={draft.domain}
+                onChange={(e) => setDraft((d) => ({ ...d, domain: e.target.value as ProjectDomain }))}
+                className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              >
+                {PROJECT_DOMAINS.map((d) => (
+                  <option key={d.value} value={d.value}>
+                    {d.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-ink-2">Target chip (optional)</span>
+              <input
+                value={draft.targetChip}
+                onChange={(e) => setDraft((d) => ({ ...d, targetChip: e.target.value }))}
+                placeholder="e.g. rpi4, esp32-s3, linux-x64"
+                className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              />
+            </label>
+          </div>
+          <div className="mt-5 flex justify-end gap-2">
+            <button
+              onClick={() => setCreateOpen(false)}
+              className={cn('rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3')}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={submitCreate}
+              disabled={busy}
+              className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+            >
+              {busy ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/web/src/components/UnifiedConfigPanel.tsx
+++ b/apps/web/src/components/UnifiedConfigPanel.tsx
@@ -1,0 +1,74 @@
+/**
+ * Unified config panel (Phase 2 - read-side unification).
+ *
+ * Renders any module's `ParameterDescriptor[]` (AFE / KWS / Few-Shot
+ * `describeParameters()`) through the module-kit spec-driven controls
+ * (`renderParamRow`), instead of hand-written <select>/<input> JSX.
+ *
+ * Read-side only for now: the descriptor drives HOW a control renders
+ * (label/type/min/max/step/options); writes still go through the panel's
+ * existing setConfig() path. This keeps the change low-risk while making
+ * module-kit the single source of truth for control rendering (ADR-025).
+ */
+
+import type { ModuleParam } from '@wake-studio/contracts'
+import { renderParamRow } from '@wake-studio/module-kit'
+import type { ParameterDescriptor } from '../afe'
+import { cn } from '../components/cn'
+
+export type ParamValue = string | number | boolean
+
+/** Bridge: a module ParameterDescriptor -> a ModuleSpec param shape. */
+function toModuleParam(desc: ParameterDescriptor): ModuleParam {
+  return {
+    id: desc.id,
+    label: desc.label,
+    group: 'primary', // descriptor groups are handled by the caller's grouping
+    type: desc.type === 'number' && desc.min !== undefined && desc.max !== undefined && desc.step !== undefined ? 'slider' : desc.type,
+    default: desc.default,
+    min: desc.min,
+    max: desc.max,
+    step: desc.step,
+    unit: desc.unit,
+    description: desc.description,
+    options: desc.options,
+  }
+}
+
+interface UnifiedConfigPanelProps {
+  title: string
+  subtitle?: string
+  params: ReadonlyArray<ParameterDescriptor>
+  values: Record<string, ParamValue>
+  onParamChange: (id: string, value: ParamValue) => void
+  /** Placeholder for primary/advanced grouping (used by the panels). */
+  group?: 'primary' | 'advanced'
+  className?: string
+}
+
+export function UnifiedConfigPanel({
+  title,
+  subtitle,
+  params,
+  values,
+  onParamChange,
+  className,
+}: UnifiedConfigPanelProps) {
+  return (
+    <div className={cn('rounded-xl border border-line bg-surface-2 p-5', className)}>
+      {title && <h3 className="mb-1 text-sm font-semibold text-ink-1">{title}</h3>}
+      {subtitle && <p className="mb-3 text-xs text-ink-3">{subtitle}</p>}
+      <div className="divide-y divide-line">
+        {params.map((desc) => (
+          <div key={desc.id}>
+            {renderParamRow(toModuleParam(desc), values[desc.id] ?? desc.default, (v: unknown) =>
+              onParamChange(desc.id, v as ParamValue),
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export { toModuleParam }

--- a/apps/web/src/components/UnifiedConfigPanel.tsx
+++ b/apps/web/src/components/UnifiedConfigPanel.tsx
@@ -12,7 +12,7 @@
  */
 
 import type { ModuleParam } from '@wake-studio/contracts'
-import { renderParamRow } from '@wake-studio/module-kit'
+import { renderParamRow, UiCollapsible } from '@wake-studio/module-kit'
 import type { ParameterDescriptor } from '../afe'
 import { cn } from '../components/cn'
 
@@ -41,9 +41,44 @@ interface UnifiedConfigPanelProps {
   params: ReadonlyArray<ParameterDescriptor>
   values: Record<string, ParamValue>
   onParamChange: (id: string, value: ParamValue) => void
-  /** Placeholder for primary/advanced grouping (used by the panels). */
-  group?: 'primary' | 'advanced'
+  /** Param ids rendered under an "Advanced" collapsible (panel UI decision). */
+  advancedIds?: string[]
+  /** Disabled controls (e.g. while running). */
+  disabled?: boolean
   className?: string
+}
+
+function ParamRows({
+  ids,
+  params,
+  values,
+  onParamChange,
+  disabled,
+}: {
+  ids: string[]
+  params: ReadonlyArray<ParameterDescriptor>
+  values: Record<string, ParamValue>
+  onParamChange: (id: string, value: ParamValue) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className="divide-y divide-line">
+      {ids.map((id) => {
+        const desc = params.find((p) => p.id === id)
+        if (!desc) return null
+        return (
+          <div key={desc.id}>
+            {renderParamRow(
+              toModuleParam(desc),
+              values[desc.id] ?? desc.default,
+              (v: unknown) => onParamChange(desc.id, v as ParamValue),
+              disabled,
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 export function UnifiedConfigPanel({
@@ -52,21 +87,39 @@ export function UnifiedConfigPanel({
   params,
   values,
   onParamChange,
+  advancedIds = [],
+  disabled,
   className,
 }: UnifiedConfigPanelProps) {
+  const primaryIds = params.map((p) => p.id).filter((id) => !advancedIds.includes(id))
+  const advanced = params.filter((p) => advancedIds.includes(p.id))
+
   return (
     <div className={cn('rounded-xl border border-line bg-surface-2 p-5', className)}>
       {title && <h3 className="mb-1 text-sm font-semibold text-ink-1">{title}</h3>}
       {subtitle && <p className="mb-3 text-xs text-ink-3">{subtitle}</p>}
-      <div className="divide-y divide-line">
-        {params.map((desc) => (
-          <div key={desc.id}>
-            {renderParamRow(toModuleParam(desc), values[desc.id] ?? desc.default, (v: unknown) =>
-              onParamChange(desc.id, v as ParamValue),
-            )}
-          </div>
-        ))}
-      </div>
+      <ParamRows
+        ids={primaryIds}
+        params={params}
+        values={values}
+        onParamChange={onParamChange}
+        disabled={disabled}
+      />
+      {advanced.length > 0 && (
+        <div className="mt-3 border-t border-line pt-2">
+          <UiCollapsible label="Advanced">
+            <div className="pt-2">
+              <ParamRows
+                ids={advanced.map((p) => p.id)}
+                params={params}
+                values={values}
+                onParamChange={onParamChange}
+                disabled={disabled}
+              />
+            </div>
+          </UiCollapsible>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/cn.ts
+++ b/apps/web/src/components/cn.ts
@@ -1,0 +1,4 @@
+/** cn - tiny className combiner (no dependencies). */
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -120,3 +120,12 @@ export function IconMenu(props: IconProps) {
     </svg>
   )
 }
+
+export function IconConsole(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <path d="M4 5h16v14H4z" />
+      <path d="M7 9l3 3-3 3M12 15h5" />
+    </svg>
+  )
+}

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -1,0 +1,122 @@
+/**
+ * Icon set - hand-drawn inline SVG components (24x24, stroke-based).
+ *
+ * Presentation-layer only: no external icon dependency, styled with current
+ * color. Kept intentionally tiny and consistent with the WakeStudio logo
+ * language (rounded strokes).
+ */
+
+import type { SVGProps } from 'react'
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number }
+
+function base(props: IconProps) {
+  const { size = 18, ...rest } = props
+  return {
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 1.8,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+    ...rest,
+  }
+}
+
+export function IconWorkspace(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <rect x="3" y="3" width="7.5" height="7.5" rx="1.5" />
+      <rect x="13.5" y="3" width="7.5" height="7.5" rx="1.5" />
+      <rect x="3" y="13.5" width="7.5" height="7.5" rx="1.5" />
+      <path d="M13.5 17h7.5M17 13.5v7.5" />
+    </svg>
+  )
+}
+
+export function IconLibrary(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <path d="M4 4.5h16v15H4z" />
+      <path d="M8 9h8M8 13h5" />
+    </svg>
+  )
+}
+
+export function IconFolder(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <path d="M3 6.5a1.5 1.5 0 0 1 1.5-1.5h4l2 2h9A1.5 1.5 0 0 1 21 8.5v9a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 17.5z" />
+    </svg>
+  )
+}
+
+export function IconSettings(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.03 1.56V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1.11-1.56 1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.7 1.7 0 0 0 .34-1.87 1.7 1.7 0 0 0-1.56-1.03H3a2 2 0 1 1 0-4h.09a1.7 1.7 0 0 0 1.56-1.11 1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34h.08a1.7 1.7 0 0 0 1.03-1.56V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87v.08a1.7 1.7 0 0 0 1.56 1.03H21a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.56 1.03z" />
+    </svg>
+  )
+}
+
+export function IconChip(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <rect x="6" y="6" width="12" height="12" rx="2" />
+      <path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3" />
+    </svg>
+  )
+}
+
+export function IconMic(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <rect x="9" y="3" width="6" height="11" rx="3" />
+      <path d="M5 11a7 7 0 0 0 14 0M12 18v3" />
+    </svg>
+  )
+}
+
+export function IconStop(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+export function IconPlay(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <path d="M7 5.5v13l11-6.5z" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+export function IconSpinner(props: IconProps) {
+  return (
+    <svg {...base(props)} className={`animate-spin ${props.className ?? ''}`}>
+      <path d="M12 3a9 9 0 1 0 9 9" />
+    </svg>
+  )
+}
+
+export function IconChevronRight(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <path d="M9 6l6 6-6 6" />
+    </svg>
+  )
+}
+
+export function IconMenu(props: IconProps) {
+  return (
+    <svg {...base(props)}>
+      <path d="M4 7h16M4 12h16M4 17h16" />
+    </svg>
+  )
+}

--- a/apps/web/src/components/shell-nav.ts
+++ b/apps/web/src/components/shell-nav.ts
@@ -12,6 +12,7 @@ import {
   IconFolder,
   IconSettings,
   IconChip,
+  IconConsole,
 } from './icons'
 
 export interface NavItem {
@@ -25,6 +26,7 @@ export const PRIMARY_NAV: NavItem[] = [
   { route: 'workspace', label: 'Workspace', icon: IconWorkspace },
   { route: 'library', label: 'Model Library', icon: IconLibrary },
   { route: 'projects', label: 'Projects', icon: IconFolder },
+  { route: 'console', label: 'Console', icon: IconConsole },
 ]
 
 export const SECONDARY_NAV: NavItem[] = [

--- a/apps/web/src/components/shell-nav.ts
+++ b/apps/web/src/components/shell-nav.ts
@@ -1,0 +1,33 @@
+/**
+ * Sidebar navigation model (shell).
+ *
+ * Kept separate from the shell components so `react-refresh` doesn't warn
+ * about non-component exports in a component file.
+ */
+
+import type { ConsoleRoute } from '../router'
+import {
+  IconWorkspace,
+  IconLibrary,
+  IconFolder,
+  IconSettings,
+  IconChip,
+} from './icons'
+
+export interface NavItem {
+  route: ConsoleRoute
+  label: string
+  icon: React.ComponentType<{ size?: number; className?: string }>
+  badge?: string
+}
+
+export const PRIMARY_NAV: NavItem[] = [
+  { route: 'workspace', label: 'Workspace', icon: IconWorkspace },
+  { route: 'library', label: 'Model Library', icon: IconLibrary },
+  { route: 'projects', label: 'Projects', icon: IconFolder },
+]
+
+export const SECONDARY_NAV: NavItem[] = [
+  { route: 'device-sdk', label: 'Device SDK', icon: IconChip, badge: 'soon' },
+  { route: 'settings', label: 'Settings', icon: IconSettings },
+]

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -1,0 +1,218 @@
+/**
+ * Console shell: left sidebar + top bar + content (IDE-style, Q-C1).
+ *
+ * Layout (desktop): fixed left sidebar (logo + primary nav) + top bar
+ * (view title + global status) + scrollable content. Mobile: sidebar
+ * collapses into a Radix Dialog drawer.
+ *
+ * All shell interaction goes through Radix (tabs/dialog/tooltip); no
+ * hand-rolled nav state.
+ */
+
+import type { ConsoleRoute } from '../router'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui'
+import { PRIMARY_NAV, SECONDARY_NAV, type NavItem } from './shell-nav'
+import type { ConsoleStatus } from '../status'
+import { cn } from './cn'
+
+function Logo() {
+  return (
+    <svg viewBox="0 0 512 512" className="h-7 w-7" role="img" aria-label="WakeStudio logo">
+      <rect width="512" height="512" rx="96" fill="#0284c7" />
+      <g stroke="#e0f2fe" strokeLinecap="round" fill="none">
+        <line x1="160" y1="224" x2="160" y2="288" strokeWidth="20" />
+        <line x1="208" y1="176" x2="208" y2="336" strokeWidth="20" />
+        <line x1="256" y1="128" x2="256" y2="384" strokeWidth="24" />
+        <line x1="304" y1="176" x2="304" y2="336" strokeWidth="20" />
+        <line x1="352" y1="224" x2="352" y2="288" strokeWidth="20" />
+      </g>
+    </svg>
+  )
+}
+
+function NavButton({
+  item,
+  active,
+  onClick,
+}: {
+  item: NavItem
+  active: boolean
+  onClick: () => void
+}) {
+  const Icon = item.icon
+  return (
+    <Tooltip delayDuration={400}>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onClick}
+          aria-current={active ? 'page' : undefined}
+          className={cn(
+            'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors',
+            active
+              ? 'bg-brand-500/10 text-brand-700'
+              : 'text-ink-2 hover:bg-surface-3 hover:text-ink-1',
+          )}
+        >
+          <Icon className="h-[18px] w-[18px] shrink-0" />
+          <span className="flex-1 truncate text-left">{item.label}</span>
+          {item.badge && (
+            <span className="rounded bg-surface-4 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-ink-3">
+              {item.badge}
+            </span>
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">{item.label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function NavSection({ title, items, route, onNavigate }: {
+  title: string
+  items: NavItem[]
+  route: ConsoleRoute
+  onNavigate: (r: ConsoleRoute) => void
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-widest text-ink-3">
+        {title}
+      </div>
+      {items.map((item) => (
+        <NavButton
+          key={item.route}
+          item={item}
+          active={route === item.route}
+          onClick={() => onNavigate(item.route)}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function Sidebar({
+  route,
+  onNavigate,
+}: {
+  route: ConsoleRoute
+  onNavigate: (r: ConsoleRoute) => void
+}) {
+  return (
+    <div className="flex h-full w-full flex-col gap-1 overflow-y-auto p-3">
+      <div className="mb-2 flex items-center gap-2 px-1.5">
+        <Logo />
+        <div className="flex flex-col leading-tight">
+          <span className="text-sm font-semibold tracking-tight text-ink-1">
+            WakeStudio
+          </span>
+          <span className="text-[11px] text-ink-3">on-device KWS studio</span>
+        </div>
+      </div>
+
+      <NavSection title="Studio" items={PRIMARY_NAV} route={route} onNavigate={onNavigate} />
+      <NavSection title="Platform" items={SECONDARY_NAV} route={route} onNavigate={onNavigate} />
+
+      <div className="mt-auto px-2.5 pt-2 text-[11px] leading-relaxed text-ink-3">
+        <div className="rounded-lg border border-line bg-surface-2 px-2.5 py-2">
+          <span className="font-medium text-ink-2">v0.1.0</span>
+          <span className="ml-1">· console shell</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Global status indicator row (rendered in the top bar). */
+function StatusIndicators({ status }: { status: ConsoleStatus }) {
+  const micLabel =
+    status.mic === 'active'
+      ? 'Mic on'
+      : status.mic === 'requesting'
+        ? 'Requesting mic…'
+        : status.mic === 'error'
+          ? 'Mic error'
+          : 'Mic idle'
+  const modelLabel =
+    status.model === 'ready'
+      ? 'Model ready'
+      : status.model === 'loading'
+        ? 'Loading model…'
+        : status.model === 'error'
+          ? 'Model error'
+          : 'No model'
+  const detectionLabel =
+    status.detection === 'running'
+      ? 'Detecting'
+      : status.detection === 'stopped'
+        ? 'Detection stopped'
+        : 'No detection'
+  const workerLabel = status.worker === 'running' ? 'Worker on' : 'Worker idle'
+
+  const Chip = ({ color, label, pulse }: { color: string; label: string; pulse?: boolean }) => (
+    <span
+      className={cn(
+        'flex items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2.5 py-1 text-[11px] font-medium text-ink-2',
+      )}
+      title={label}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', color, pulse && 'animate-pulse')} />
+      {label}
+    </span>
+  )
+
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto">
+      <Chip
+        color={status.mic === 'active' ? 'bg-success' : status.mic === 'error' ? 'bg-danger' : 'bg-slate-400'}
+        label={micLabel}
+        pulse={status.mic === 'requesting'}
+      />
+      <Chip
+        color={status.model === 'ready' ? 'bg-success' : status.model === 'loading' ? 'bg-amber-400' : status.model === 'error' ? 'bg-danger' : 'bg-slate-400'}
+        label={modelLabel}
+        pulse={status.model === 'loading'}
+      />
+      <Chip
+        color={status.detection === 'running' ? 'bg-emerald-500' : 'bg-slate-400'}
+        label={detectionLabel}
+        pulse={status.detection === 'running'}
+      />
+      {status.worker && (
+        <Chip
+          color={status.worker === 'running' ? 'bg-brand-500' : status.worker === 'error' ? 'bg-danger' : 'bg-slate-400'}
+          label={workerLabel}
+        />
+      )}
+    </div>
+  )
+}
+
+export function TopBar({
+  title,
+  status,
+  onToggleSidebar,
+}: {
+  title: string
+  status: ConsoleStatus
+  onToggleSidebar: () => void
+}) {
+  return (
+    <header className="flex h-14 shrink-0 items-center gap-3 border-b border-line bg-surface-2/90 px-4 backdrop-blur">
+      <button
+        onClick={onToggleSidebar}
+        className="rounded-md p-1.5 text-ink-3 hover:bg-surface-3 hover:text-ink-1 lg:hidden"
+        aria-label="Toggle navigation"
+      >
+        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+          <path d="M4 7h16M4 12h16M4 17h16" />
+        </svg>
+      </button>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <h1 className="truncate text-sm font-semibold text-ink-1">{title}</h1>
+      </div>
+      <div className="hidden items-center gap-2 sm:flex">
+        <StatusIndicators status={status} />
+      </div>
+    </header>
+  )
+}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -1,0 +1,94 @@
+/**
+ * App-wide toast notifications (Radix Toast).
+ *
+ * `AppToastProvider` wraps the app and renders the viewport; `useToast()`
+ * returns `{ toast }` to push notifications from anywhere in the shell.
+ */
+
+import * as React from 'react'
+import {
+  Toast,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from './ui'
+
+interface ToastItem {
+  id: number
+  title: string
+  description?: string
+  variant?: 'default' | 'success' | 'error'
+}
+
+interface ToastContextValue {
+  toast: (opts: {
+    title: string
+    description?: string
+    variant?: ToastItem['variant']
+  }) => void
+}
+
+const ToastContext = React.createContext<ToastContextValue | null>(null)
+
+export function useToast(): ToastContextValue {
+  const ctx = React.useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within AppToastProvider')
+  return ctx
+}
+
+let nextId = 1
+
+export function AppToastProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = React.useState<ToastItem[]>([])
+
+  const toast = React.useCallback(
+    ({ title, description, variant = 'default' }: Omit<ToastItem, 'id'>) => {
+      const id = nextId++
+      setItems((prev) => [...prev, { id, title, description, variant }])
+      // Auto-dismiss after 5 s.
+      setTimeout(() => {
+        setItems((prev) => prev.filter((t) => t.id !== id))
+      }, 5000)
+    },
+    [],
+  )
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      <ToastProvider swipeDirection="right">
+        {children}
+        <ToastViewport>
+          {items.map((t) => (
+            <Toast
+              key={t.id}
+              className={
+                t.variant === 'error'
+                  ? 'border-danger/40'
+                  : t.variant === 'success'
+                    ? 'border-success/40'
+                    : undefined
+              }
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <ToastTitle>{t.title}</ToastTitle>
+                  {t.description && (
+                    <ToastDescription>{t.description}</ToastDescription>
+                  )}
+                </div>
+                <button
+                  onClick={() => setItems((prev) => prev.filter((x) => x.id !== t.id))}
+                  className="rounded p-0.5 text-ink-3 hover:text-ink-1"
+                  aria-label="Dismiss notification"
+                >
+                  ✕
+                </button>
+              </div>
+            </Toast>
+          ))}
+        </ToastViewport>
+      </ToastProvider>
+    </ToastContext.Provider>
+  )
+}

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -18,7 +18,7 @@ import { cn } from './cn'
 import { IconMenu } from './icons'
 
 // ---------------------------------------------------------------------------
-// Tabs
+// Tabs (tab-container style)
 // ---------------------------------------------------------------------------
 export const Tabs = TabsPrimitive.Root
 export const TabsList = React.forwardRef<
@@ -28,7 +28,7 @@ export const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex items-center gap-1 rounded-lg border border-line bg-surface-2 p-1',
+      'inline-flex items-center gap-1 border-b border-line px-2 pt-1.5 pb-0',
       className,
     )}
     {...props}
@@ -42,9 +42,10 @@ export const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'rounded-md px-3 py-1.5 text-sm font-medium text-ink-2 outline-none transition-colors',
+      'rounded-t-md border border-b-0 px-3 py-1.5 text-sm font-medium text-ink-2 outline-none transition-colors',
       'hover:text-ink-1 focus-visible:ring-2 focus-visible:ring-brand-400',
-      'data-[state=active]:bg-brand-500/10 data-[state=active]:text-brand-700',
+      'data-[state=active]:border-line data-[state=active]:bg-surface-2 data-[state=active]:text-brand-700',
+      'data-[state=inactive]:border-transparent data-[state=inactive]:bg-transparent',
       className,
     )}
     {...props}

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -1,0 +1,261 @@
+/**
+ * Radix shell components (App shell layer).
+ *
+ * Thin, styled adapters over Radix Primitives for the console shell ONLY -
+ * navigation, modals, menus, hints, notifications. These are NOT part of the
+ * spec-driven layer (ADR-025 keeps that pure in `module-kit`); they are the
+ * shell's own building blocks. Styling uses the WakeStudio semantic tokens
+ * (`--ws-*`, light theme; dark theme is a token swap).
+ */
+
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import * as DropdownPrimitive from '@radix-ui/react-dropdown-menu'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import * as ToastPrimitive from '@radix-ui/react-toast'
+import { cn } from './cn'
+import { IconMenu } from './icons'
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+export const Tabs = TabsPrimitive.Root
+export const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex items-center gap-1 rounded-lg border border-line bg-surface-2 p-1',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = 'TabsList'
+export const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'rounded-md px-3 py-1.5 text-sm font-medium text-ink-2 outline-none transition-colors',
+      'hover:text-ink-1 focus-visible:ring-2 focus-visible:ring-brand-400',
+      'data-[state=active]:bg-brand-500/10 data-[state=active]:text-brand-700',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = 'TabsTrigger'
+export const TabsContent = TabsPrimitive.Content
+
+// ---------------------------------------------------------------------------
+// Dialog
+// ---------------------------------------------------------------------------
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+export const DialogClose = DialogPrimitive.Close
+export const DialogPortal = DialogPrimitive.Portal
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-[2px]',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out',
+      className,
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = 'DialogOverlay'
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-[min(92vw,26rem)] -translate-x-1/2 -translate-y-1/2',
+        'rounded-xl border border-line bg-surface-2 p-6 shadow-2xl',
+        'outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+))
+DialogContent.displayName = 'DialogContent'
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-base font-semibold text-ink-1', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = 'DialogTitle'
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('mt-1 text-sm text-ink-2', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = 'DialogDescription'
+
+// ---------------------------------------------------------------------------
+// Dropdown menu
+// ---------------------------------------------------------------------------
+export const DropdownMenu = DropdownPrimitive.Root
+export const DropdownMenuTrigger = DropdownPrimitive.Trigger
+export const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownPrimitive.Portal>
+    <DropdownPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-44 overflow-hidden rounded-lg border border-line bg-surface-2 p-1 shadow-xl',
+        'animate-in fade-in-0 zoom-in-95',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownPrimitive.Portal>
+))
+DropdownMenuContent.displayName = 'DropdownMenuContent'
+export const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownPrimitive.Item
+    ref={ref}
+    className={cn(
+      'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-sm text-ink-2 outline-none',
+      'hover:bg-surface-3 hover:text-ink-1 focus:bg-surface-3 focus:text-ink-1',
+      'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = 'DropdownMenuItem'
+export const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownPrimitive.Separator
+    ref={ref}
+    className={cn('my-1 h-px bg-line', className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = 'DropdownMenuSeparator'
+
+// ---------------------------------------------------------------------------
+// Tooltip
+// ---------------------------------------------------------------------------
+export const TooltipProvider = TooltipPrimitive.Provider
+export const Tooltip = TooltipPrimitive.Root
+export const TooltipTrigger = TooltipPrimitive.Trigger
+export const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 rounded-md border border-line bg-ink-1 px-2.5 py-1 text-xs text-surface-2 shadow-lg',
+        'animate-in fade-in-0 zoom-in-95',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = 'TooltipContent'
+
+// ---------------------------------------------------------------------------
+// Toast
+// ---------------------------------------------------------------------------
+export const ToastProvider = ToastPrimitive.Provider
+export const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Viewport
+    ref={ref}
+    className={cn(
+      'fixed bottom-0 right-0 z-[60] flex w-full max-w-sm flex-col gap-2 p-4 outline-none',
+      className,
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = 'ToastViewport'
+export const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Root
+    ref={ref}
+    className={cn(
+      'rounded-lg border border-line bg-surface-2 p-4 shadow-xl',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out',
+      className,
+    )}
+    {...props}
+  />
+))
+Toast.displayName = 'Toast'
+export const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Title
+    ref={ref}
+    className={cn('text-sm font-semibold text-ink-1', className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = 'ToastTitle'
+export const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Description
+    ref={ref}
+    className={cn('mt-0.5 text-xs text-ink-2', className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = 'ToastDescription'
+
+// ---------------------------------------------------------------------------
+// Sidebar trigger (uses IconMenu)
+// ---------------------------------------------------------------------------
+export function SidebarTrigger({ className }: { className?: string }) {
+  return (
+    <IconMenu className={cn('h-4 w-4', className)} />
+  )
+}

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,0 +1,19 @@
+/**
+ * App base-path config (ADR-012).
+ *
+ * GitHub Pages project sites serve under a sub-path (`/<repo>/`), Cloudflare
+ * at root. Vite injects the base into `import.meta.env.BASE_URL`; all
+ * absolute app URLs (`/prebuilts/...`, `/sherpa-onnx-kws/...`, registry)
+ * must be built from this so they survive sub-path deployment.
+ */
+
+/** The deploy base path, e.g. `/` or `/wake-studio/`. */
+export const APP_BASE: string = import.meta.env.BASE_URL ?? '/'
+
+/** Resolve a root-relative URL against the deploy base. */
+export function resolveAsset(path: string): string {
+  if (path.startsWith('http://') || path.startsWith('https://')) return path
+  if (path.startsWith(APP_BASE)) return path
+  // Trim leading slash(es), join under the base (which ends with '/').
+  return `${APP_BASE}${path.replace(/^\/+/, '')}`
+}

--- a/apps/web/src/data/__tests__/registry.test.ts
+++ b/apps/web/src/data/__tests__/registry.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Model registry / probe unit tests.
+ *
+ * Covers the license gate (isCommerciallyUsable) and the reachability probe
+ * (HEAD against a mock fetch). The probe uses fetch, so we stub globalThis.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { isCommerciallyUsable, type RegistryModel } from '../registry'
+import { probeModelUrl } from '../probe'
+
+function model(partial: Partial<RegistryModel> = {}): RegistryModel {
+  return {
+    id: 'm',
+    name: 'Model',
+    tier: ['high-performance'],
+    source: 'src',
+    url: '/models/m.onnx',
+    format: 'onnx',
+    license: 'MIT',
+    commercial: true,
+    class: 'redistributable',
+    sha256: null,
+    sizeBytes: 100,
+    ...partial,
+  }
+}
+
+describe('isCommerciallyUsable (license gate)', () => {
+  it('true for redistributable + commercial', () => {
+    expect(isCommerciallyUsable(model())).toBe(true)
+  })
+
+  it('false when not explicitly commercial', () => {
+    expect(isCommerciallyUsable(model({ commercial: false }))).toBe(false)
+  })
+
+  it('false when demo-only', () => {
+    expect(isCommerciallyUsable(model({ class: 'demo-only' }))).toBe(false)
+  })
+
+  it('false when demo-only even if commercial flag set', () => {
+    expect(isCommerciallyUsable(model({ class: 'demo-only', commercial: true }))).toBe(false)
+  })
+})
+
+describe('probeModelUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns ok with content-length on a successful HEAD', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: (k: string) => (k === 'content-length' ? '2048' : null) },
+      }),
+    )
+    const r = await probeModelUrl('https://example.com/model.onnx')
+    expect(r.state).toBe('ok')
+    expect(r.sizeBytes).toBe(2048)
+  })
+
+  it('returns error state on HTTP failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404, headers: { get: () => null } }),
+    )
+    const r = await probeModelUrl('https://example.com/missing')
+    expect(r.state).toBe('error')
+    expect(r.status).toBe(404)
+  })
+
+  it('returns error state on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    const r = await probeModelUrl('https://example.com/x')
+    expect(r.state).toBe('error')
+    expect(r.error).toBe('network down')
+  })
+})

--- a/apps/web/src/data/probe.ts
+++ b/apps/web/src/data/probe.ts
@@ -1,0 +1,46 @@
+/**
+ * Model reachability probe.
+ *
+ * HEADs a model URL (resolved against the deploy base) to report reachable /
+ * actual content length. Used by the Model Library "Verify" action. Never
+ * downloads the body.
+ */
+
+import { resolveAsset } from '../config'
+
+export type ProbeState = 'idle' | 'probing' | 'ok' | 'error'
+
+export interface ProbeResult {
+  state: ProbeState
+  /** Actual bytes reported by the server, when known. */
+  sizeBytes: number | null
+  status?: number
+  error?: string
+}
+
+export async function probeModelUrl(url: string): Promise<ProbeResult> {
+  const target = resolveAsset(url)
+  try {
+    const res = await fetch(target, { method: 'HEAD', mode: 'cors' })
+    if (!res.ok) {
+      return {
+        state: 'error',
+        sizeBytes: null,
+        status: res.status,
+        error: `HTTP ${res.status}`,
+      }
+    }
+    const len = res.headers.get('content-length')
+    return {
+      state: 'ok',
+      sizeBytes: len ? Number(len) : null,
+      status: res.status,
+    }
+  } catch (err) {
+    return {
+      state: 'error',
+      sizeBytes: null,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/apps/web/src/data/registry.ts
+++ b/apps/web/src/data/registry.ts
@@ -37,12 +37,14 @@ export interface ModelRegistry {
   models: RegistryModel[]
 }
 
+import { resolveAsset } from '../config'
+
 const REGISTRY_URL = 'model-registry.json'
 
 export async function loadRegistry(
   signal?: AbortSignal,
 ): Promise<ModelRegistry> {
-  const res = await fetch(REGISTRY_URL, { signal })
+  const res = await fetch(resolveAsset(REGISTRY_URL), { signal })
   if (!res.ok) {
     throw new Error(`Failed to load model registry: HTTP ${res.status}`)
   }

--- a/apps/web/src/log.tsx
+++ b/apps/web/src/log.tsx
@@ -1,0 +1,152 @@
+/**
+ * Session log + trigger history (Phase 4).
+ *
+ * A lightweight, app-wide event log replacing scattered console.log/error
+ * calls. Panels and engines publish events here; the Session Console view
+ * renders them and exports triggers as CSV.
+ *
+ * No external deps. Ring-buffered (cap) so the console stays bounded.
+ */
+
+import * as React from 'react'
+import type { KWSTriggerEvent } from './kws'
+
+export type LogLevel = 'info' | 'warn' | 'error'
+
+export interface LogEntry {
+  id: number
+  at: number
+  level: LogLevel
+  source: string
+  message: string
+  /** Optional structured payload (e.g. a trigger). */
+  trigger?: KWSTriggerEvent
+}
+
+export const LOG_CAP = 500
+
+let nextId = 1
+
+// ---------------------------------------------------------------------------
+// Store (module-level, shared across views).
+// ---------------------------------------------------------------------------
+
+interface LogStore {
+  entries: LogEntry[]
+  /** Push an entry; returns its id. */
+  push: (entry: Omit<LogEntry, 'id' | 'at'>) => number
+  clear: () => void
+}
+
+const store: LogStore = {
+  entries: [],
+  push(entry) {
+    const e: LogEntry = { id: nextId++, at: Date.now(), ...entry }
+    store.entries.push(e)
+    if (store.entries.length > LOG_CAP) {
+      store.entries.splice(0, store.entries.length - LOG_CAP)
+    }
+    return e.id
+  },
+  clear() {
+    store.entries = []
+  },
+}
+
+// ---------------------------------------------------------------------------
+// React context so the console view re-renders on new entries.
+// ---------------------------------------------------------------------------
+
+const LogContext = React.createContext<LogEntry[]>([])
+
+/** Subscribe to the log. Re-renders the consumer on new entries. */
+export function LogProvider({ children }: { children: React.ReactNode }) {
+  const [entries, setEntries] = React.useState<LogEntry[]>(store.entries)
+
+  React.useEffect(() => {
+    // Poll the module store; simplest no-dep approach for a small app.
+    const id = setInterval(() => setEntries([...store.entries]), 500)
+    return () => clearInterval(id)
+  }, [])
+
+  return <LogContext.Provider value={entries}>{children}</LogContext.Provider>
+}
+
+export function useLogEntries(): LogEntry[] {
+  return React.useContext(LogContext)
+}
+
+// ---------------------------------------------------------------------------
+// Imperative publish API (no hook needed for non-React call sites).
+// ---------------------------------------------------------------------------
+
+/** Log an info event. */
+export function logInfo(source: string, message: string): void {
+  store.push({ level: 'info', source, message })
+}
+
+/** Log a warning. */
+export function logWarn(source: string, message: string): void {
+  store.push({ level: 'warn', source, message })
+}
+
+/** Log an error. */
+export function logError(source: string, message: string): void {
+  store.push({ level: 'error', source, message })
+}
+
+/** Log a KWS trigger event (also recorded for CSV export). */
+export function logTrigger(source: string, trigger: KWSTriggerEvent): void {
+  store.push({
+    level: 'info',
+    source,
+    message: `Trigger: ${trigger.word} (${trigger.peakScore.toFixed(3)})`,
+    trigger,
+  })
+}
+
+/** Current entries (non-React reads, e.g. CSV export). */
+export function getLogEntries(): LogEntry[] {
+  return [...store.entries]
+}
+
+/** Clear the log. */
+export function clearLog(): void {
+  store.clear()
+}
+
+/** Trigger-only entries (for the history table / CSV). */
+export function getTriggerEntries(): LogEntry[] {
+  return store.entries.filter((e) => e.trigger)
+}
+
+// ---------------------------------------------------------------------------
+// CSV export
+// ---------------------------------------------------------------------------
+
+function escapeCsv(value: string): string {
+  if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
+  return value
+}
+
+/** Build a CSV string of trigger history. */
+export function triggersToCsv(entries: LogEntry[]): string {
+  const header = ['time', 'word', 'peak_score'].join(',')
+  const rows = entries.map((e) => {
+    const t = e.trigger!
+    const time = new Date(e.at).toISOString()
+    return [escapeCsv(time), escapeCsv(t.word), t.peakScore.toFixed(3)].join(',')
+  })
+  return [header, ...rows].join('\n')
+}
+
+/** Download a CSV file client-side. */
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/apps/web/src/projects/__tests__/store.test.ts
+++ b/apps/web/src/projects/__tests__/store.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Projects store tests.
+ *
+ * The store wraps IndexedDB. Vitest runs in Node (no indexedDB), so these
+ * tests exercise the pure pieces and mock the IDB adapter through a minimal
+ * in-memory shim. This keeps the store logic (ordering, round-trips) tested
+ * without a browser; the browser path is covered by the e2e workspace flow.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { WakeWordProject } from '../types'
+import { saveProject, listProjects, getProject, deleteProject, clearProjects } from '../store'
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory IndexedDB shim (objectStore.put/get/getAll/delete/clear).
+// ---------------------------------------------------------------------------
+
+class MemoryObjectStore {
+  private map = new Map<string, unknown>()
+
+  /** IDBRequest-lookalike that fires onsuccess synchronously on attach. */
+  private req<T>(result: T) {
+    let onsuccess: (() => void) | null = null
+    const r = {
+      get result() {
+        return result
+      },
+      set onsuccess(cb: (() => void) | null) {
+        onsuccess = cb
+        cb?.()
+      },
+      get onsuccess() {
+        return onsuccess
+      },
+      onerror: null as (() => void) | null,
+    }
+    return r
+  }
+
+  put(v: { id: string }) {
+    this.map.set(v.id, v)
+    return this.req(undefined)
+  }
+  get(id: string) {
+    return this.req(this.map.get(id))
+  }
+  getAll() {
+    return this.req([...this.map.values()])
+  }
+  delete(id: string) {
+    this.map.delete(id)
+    return this.req(undefined)
+  }
+  clear() {
+    this.map.clear()
+    return this.req(undefined)
+  }
+}
+
+const stores = new Map<string, MemoryObjectStore>()
+
+const fakeIndexedDB = {
+  open() {
+    const req = {
+      result: {
+        transaction() {
+          return {
+            objectStore(storeName: string) {
+              if (!stores.has(storeName)) stores.set(storeName, new MemoryObjectStore())
+              return stores.get(storeName)!
+            },
+          }
+        },
+      },
+      onupgradeneeded: null,
+      onsuccess: null as (() => void) | null,
+      onerror: null,
+    }
+    // The store's openDb resolves on req.onsuccess. Fire it on the next tick
+    // so the caller has attached the handler.
+    queueMicrotask(() => req.onsuccess?.())
+    return req
+  },
+}
+
+let idbSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  stores.clear()
+  ;(globalThis as Record<string, unknown>).indexedDB = fakeIndexedDB
+  idbSpy = vi.fn()
+})
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).indexedDB
+})
+
+function makeProject(partial: Partial<WakeWordProject> = {}): WakeWordProject {
+  return {
+    id: partial.id ?? `p-${Math.random().toString(36).slice(2)}`,
+    name: partial.name ?? 'Test project',
+    targetWord: partial.targetWord ?? 'hey studio',
+    domain: 'high-performance',
+    config: {
+      afe: { topology: 'single-worklet', channels: 1, frameMs: { aec: 10, bss: 10, ns: 10 }, latencyBudgetMs: 150, vizFps: 30 },
+      kws: { backend: 'openwakeword', threshold: 0.5, minDurationMs: 300, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, cooldownMs: 2000, executionProvider: 'wasm' },
+      fewShot: { threshold: 0.7, minDurationMs: 300, cooldownMs: 2000, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, windowMs: 1500, hopMs: 80, useNegativePrototype: false },
+    },
+    sampleIds: [],
+    prototypeIds: [],
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    ...partial,
+  }
+}
+
+describe('projects store', () => {
+  it('saves and round-trips a project', async () => {
+    const p = makeProject({ id: 'a', name: 'My word' })
+    await saveProject(p)
+    const got = await getProject('a')
+    expect(got).toBeDefined()
+    expect(got!.name).toBe('My word')
+    expect(got!.config.kws.backend).toBe('openwakeword')
+    expect(idbSpy).toBeDefined()
+  })
+
+  it('lists projects most-recently-updated first', async () => {
+    const a = makeProject({ id: 'a', updatedAtMs: 100 })
+    const b = makeProject({ id: 'b', updatedAtMs: 200 })
+    await saveProject(a)
+    await saveProject(b)
+    const list = await listProjects()
+    expect(list.map((p) => p.id)).toEqual(['b', 'a'])
+  })
+
+  it('get returns undefined for unknown id', async () => {
+    expect(await getProject('missing')).toBeUndefined()
+  })
+
+  it('delete removes a project', async () => {
+    await saveProject(makeProject({ id: 'del' }))
+    await deleteProject('del')
+    expect(await getProject('del')).toBeUndefined()
+  })
+
+  it('clear empties the store', async () => {
+    await saveProject(makeProject({ id: 'x' }))
+    await clearProjects()
+    expect(await listProjects()).toEqual([])
+  })
+
+  it('overwrites an existing project on save', async () => {
+    await saveProject(makeProject({ id: 'a', name: 'v1' }))
+    await saveProject(makeProject({ id: 'a', name: 'v2' }))
+    const got = await getProject('a')
+    expect(got!.name).toBe('v2')
+  })
+})

--- a/apps/web/src/projects/context.tsx
+++ b/apps/web/src/projects/context.tsx
@@ -1,0 +1,143 @@
+/**
+ * Project context - the current project + CRUD surface for the workspace.
+ *
+ * Wraps the IndexedDB store so any view (project bar, pipeline canvas, config
+ * panels) reads/writes the same project. Phase 2 scope: create/select/save;
+ * delete + rename arrive with the fuller CRUD UI.
+ */
+
+import * as React from 'react'
+import type { WakeWordProject, ProjectDraft, ProjectConfigSnapshot } from './types'
+import { DEFAULT_PROJECT_NAME } from './types'
+import { DEFAULT_CONFIG as AFE_DEFAULTS } from '../afe'
+import { DEFAULT_CONFIG as KWS_DEFAULTS } from '../kws'
+import { DEFAULT_CONFIG as FS_DEFAULTS } from '../few-shot'
+import { listProjects, saveProject } from './store'
+
+const LAST_PROJECT_KEY = 'wake-studio:last-project'
+
+function uid(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID()
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export function defaultConfigSnapshot(): ProjectConfigSnapshot {
+  return {
+    afe: { ...AFE_DEFAULTS },
+    kws: { ...KWS_DEFAULTS },
+    fewShot: { ...FS_DEFAULTS },
+  }
+}
+
+interface ProjectContextValue {
+  projects: WakeWordProject[]
+  current: WakeWordProject | null
+  /** Load projects from the store (once on mount, then on demand). */
+  refresh: () => Promise<void>
+  /** Create a new project from a draft and select it. */
+  createProject: (draft: ProjectDraft) => Promise<WakeWordProject>
+  selectProject: (id: string) => void
+  /** Persist the current project (config snapshot + metadata). */
+  saveCurrent: (patch?: Partial<WakeWordProject>) => Promise<void>
+  busy: boolean
+}
+
+const ProjectContext = React.createContext<ProjectContextValue | null>(null)
+
+export function ProjectProvider({ children }: { children: React.ReactNode }) {
+  const [projects, setProjects] = React.useState<WakeWordProject[]>([])
+  const [current, setCurrent] = React.useState<WakeWordProject | null>(null)
+  const [busy, setBusy] = React.useState(false)
+
+  const refresh = React.useCallback(async () => {
+    try {
+      const all = await listProjects()
+      setProjects(all)
+      // Keep the current selection if it still exists; otherwise restore the
+      // last-selected project (persisted across reloads).
+      setCurrent((prev) => {
+        if (prev) {
+          const found = all.find((p) => p.id === prev.id)
+          return found ? { ...found } : null
+        }
+        const lastId = localStorage.getItem(LAST_PROJECT_KEY)
+        const found = lastId ? all.find((p) => p.id === lastId) : undefined
+        return found ? { ...found } : null
+      })
+    } catch (err) {
+      console.error('[projects] refresh failed:', err)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const createProject = React.useCallback(
+    async (draft: ProjectDraft): Promise<WakeWordProject> => {
+      const now = Date.now()
+      const project: WakeWordProject = {
+        id: uid(),
+        name: draft.name.trim() || DEFAULT_PROJECT_NAME,
+        targetWord: draft.targetWord.trim(),
+        domain: draft.domain,
+        targetChip: draft.targetChip?.trim() || undefined,
+        notes: draft.notes?.trim() || undefined,
+        config: defaultConfigSnapshot(),
+        sampleIds: [],
+        prototypeIds: [],
+        createdAtMs: now,
+        updatedAtMs: now,
+      }
+      setBusy(true)
+      try {
+        await saveProject(project)
+        localStorage.setItem(LAST_PROJECT_KEY, project.id)
+        setProjects((prev) => [project, ...prev])
+        setCurrent(project)
+        return project
+      } finally {
+        setBusy(false)
+      }
+    },
+    [],
+  )
+
+  const selectProject = React.useCallback((id: string) => {
+    localStorage.setItem(LAST_PROJECT_KEY, id)
+    setCurrent((prev) => {
+      if (prev && prev.id === id) return prev
+      const found = projects.find((p) => p.id === id)
+      return found ? { ...found } : prev
+    })
+  }, [projects])
+
+  const saveCurrent = React.useCallback(
+    async (patch?: Partial<WakeWordProject>) => {
+      setCurrent((prev) => {
+        if (!prev) return prev
+        const next = { ...prev, ...patch, updatedAtMs: Date.now() }
+        void saveProject(next)
+        setProjects((all) =>
+          all.map((p) => (p.id === next.id ? next : p)).sort((a, b) => b.updatedAtMs - a.updatedAtMs),
+        )
+        return next
+      })
+    },
+    [],
+  )
+
+  return (
+    <ProjectContext.Provider
+      value={{ projects, current, refresh, createProject, selectProject, saveCurrent, busy }}
+    >
+      {children}
+    </ProjectContext.Provider>
+  )
+}
+
+export function useProjects(): ProjectContextValue {
+  const ctx = React.useContext(ProjectContext)
+  if (!ctx) throw new Error('useProjects must be used within ProjectProvider')
+  return ctx
+}

--- a/apps/web/src/projects/index.ts
+++ b/apps/web/src/projects/index.ts
@@ -20,3 +20,4 @@ export {
   saveProject,
 } from './store'
 export { ProjectProvider, useProjects, defaultConfigSnapshot } from './context'
+export { useProjectStageConfig, type ProjectStage } from './useProjectStageConfig'

--- a/apps/web/src/projects/index.ts
+++ b/apps/web/src/projects/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Projects - public exports.
+ */
+
+export {
+  DEFAULT_PROJECT_NAME,
+  PROJECT_DOMAINS,
+} from './types'
+export type {
+  ProjectConfigSnapshot,
+  ProjectDomain,
+  ProjectDraft,
+  WakeWordProject,
+} from './types'
+export {
+  clearProjects,
+  deleteProject,
+  getProject,
+  listProjects,
+  saveProject,
+} from './store'
+export { ProjectProvider, useProjects, defaultConfigSnapshot } from './context'

--- a/apps/web/src/projects/store.ts
+++ b/apps/web/src/projects/store.ts
@@ -1,0 +1,73 @@
+/**
+ * Projects store - IndexedDB persistence for wake-word projects.
+ *
+ * Generalizes the Few-Shot storage pattern (src/few-shot/storage.ts) into a
+ * project-level store. Projects are small (config snapshots + id lists);
+ * audio samples and prototypes keep their own stores (the Few-Shot store).
+ *
+ * Phase 2 scope: minimal CRUD (create / list / get / update / delete) plus
+ * ordering by updatedAt. Samples/prototypes stay in the Few-Shot stores until
+ * the workspace wires them together.
+ */
+
+import type { WakeWordProject } from './types'
+
+const DB_NAME = 'wake-studio-console'
+const DB_VERSION = 1
+const PROJECT_STORE = 'projects'
+
+let dbPromise: Promise<IDBDatabase> | null = null
+
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(PROJECT_STORE)) {
+        // Keyed by project id; updatedAt index for "recent projects" list.
+        const store = db.createObjectStore(PROJECT_STORE, { keyPath: 'id' })
+        store.createIndex('updatedAt', 'updatedAtMs')
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  return dbPromise
+}
+
+function tx<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const t = db.transaction(PROJECT_STORE, mode)
+        const req = fn(t.objectStore(PROJECT_STORE))
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      }),
+  )
+}
+
+/** List projects, most recently updated first. */
+export async function listProjects(): Promise<WakeWordProject[]> {
+  const all = await tx('readonly', (store) => store.getAll())
+  return all.sort((a, b) => b.updatedAtMs - a.updatedAtMs)
+}
+
+export async function getProject(id: string): Promise<WakeWordProject | undefined> {
+  return tx('readonly', (store) => store.get(id))
+}
+
+/** Create or overwrite a project. Returns the stored project. */
+export async function saveProject(project: WakeWordProject): Promise<WakeWordProject> {
+  await tx('readwrite', (store) => store.put(project))
+  return project
+}
+
+export async function deleteProject(id: string): Promise<void> {
+  await tx('readwrite', (store) => store.delete(id))
+}
+
+export async function clearProjects(): Promise<void> {
+  await tx('readwrite', (store) => store.clear())
+}

--- a/apps/web/src/projects/types.ts
+++ b/apps/web/src/projects/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Project model - the unit of work in the WakeStudio console.
+ *
+ * A project captures everything needed to reproduce a wake-word effort:
+ * the target word, target domain/chip, config snapshots for each pipeline
+ * stage, enrolled samples, built prototypes, and an export record (Phase 4).
+ *
+ * Phase 2 scope: minimal model (config snapshots + samples + prototype ids);
+ * CRUD UI arrives with the workspace store. Persisted in IndexedDB via
+ * `store.ts` (generalizing the Few-Shot storage).
+ */
+
+import type { AFEConfig } from '../afe'
+import type { KWSConfig } from '../kws'
+import type { FewShotConfig } from '../few-shot'
+
+/** Target domain (mirrors the two-domain split in README / Domains). */
+export type ProjectDomain = 'low-power-mcu' | 'high-performance'
+
+/** Pipeline stage config snapshots (typed defaults from each module). */
+export interface ProjectConfigSnapshot {
+  afe: AFEConfig
+  kws: KWSConfig
+  fewShot: FewShotConfig
+}
+
+export interface WakeWordProject {
+  id: string
+  name: string
+  /** The wake word this project targets (free text for v1). */
+  targetWord: string
+  domain: ProjectDomain
+  /** Optional target chip hint (e.g. 'esp32-s3', 'rpi4', 'linux-x64'). */
+  targetChip?: string
+  config: ProjectConfigSnapshot
+  /** Enrolled sample ids (audio lives in the samples store). */
+  sampleIds: string[]
+  /** Built prototype ids. */
+  prototypeIds: string[]
+  /** Optional free-form notes. */
+  notes?: string
+  createdAtMs: number
+  updatedAtMs: number
+}
+
+/** A draft project (pre-persistence); id/createdAt assigned on save. */
+export interface ProjectDraft {
+  name: string
+  targetWord: string
+  domain: ProjectDomain
+  targetChip?: string
+  notes?: string
+}
+
+export const PROJECT_DOMAINS: ReadonlyArray<{ value: ProjectDomain; label: string }> = [
+  { value: 'low-power-mcu', label: 'Low-power / MCU' },
+  { value: 'high-performance', label: 'High-performance (Linux / Pi / Android)' },
+]
+
+export const DEFAULT_PROJECT_NAME = 'Untitled project'

--- a/apps/web/src/projects/useProjectStageConfig.ts
+++ b/apps/web/src/projects/useProjectStageConfig.ts
@@ -1,0 +1,49 @@
+/**
+ * Project-config bridge (Phase 2.2).
+ *
+ * Wires a panel's local config state to the active project's config snapshot:
+ *  - initial value comes from the project snapshot (per stage: afe/kws/fewShot)
+ *  - changes are written back to the project via saveCurrent (IndexedDB)
+ *  - switching projects remounts the panel (via key), so the new snapshot
+ *    becomes the initial value.
+ *
+ * The panel keeps its own state (no controlled refactor); this hook only
+ * seeds and syncs.
+ */
+
+import * as React from 'react'
+import { useProjects } from './context'
+import type { ProjectConfigSnapshot } from './types'
+
+/** Stage keys in the project config snapshot. */
+export type ProjectStage = keyof ProjectConfigSnapshot
+
+export function useProjectStageConfig<S extends ProjectStage>(
+  stage: S,
+): {
+  /** The stage snapshot from the active project (may be undefined). */
+  projectConfig: ProjectConfigSnapshot[S] | undefined
+  /** Call with a partial patch to persist into the project. */
+  persist: (patch: Partial<ProjectConfigSnapshot[S]>) => void
+  /** Whether an active project is selected. */
+  hasProject: boolean
+} {
+  const { current, saveCurrent } = useProjects()
+
+  const projectConfig = current?.config?.[stage]
+
+  const persist = React.useCallback(
+    (patch: Partial<ProjectConfigSnapshot[S]>) => {
+      if (!current) return
+      saveCurrent({
+        config: {
+          ...current.config,
+          [stage]: { ...current.config[stage], ...patch },
+        },
+      })
+    },
+    [current, saveCurrent, stage],
+  )
+
+  return { projectConfig, persist, hasProject: !!current }
+}

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,0 +1,77 @@
+/**
+ * Hash-based routing hook (zero dependencies; static-host safe).
+ *
+ * Views are keyed by hash path, e.g. `#/workspace`, `#/library`,
+ * `#/projects`, `#/playground/rnnoise`. Deep-linkable and bookmarkable.
+ * Unknown hashes fall back to the default view.
+ */
+
+import * as React from 'react'
+
+export type ConsoleRoute =
+  | 'workspace'
+  | 'library'
+  | 'projects'
+  | 'playground-rnnoise'
+  | 'settings'
+  | 'device-sdk'
+
+export const DEFAULT_ROUTE: ConsoleRoute = 'workspace'
+
+const ROUTE_BY_HASH: Record<string, ConsoleRoute> = {
+  '/workspace': 'workspace',
+  '/library': 'library',
+  '/projects': 'projects',
+  '/playground/rnnoise': 'playground-rnnoise',
+  '/settings': 'settings',
+  '/device-sdk': 'device-sdk',
+  '': 'workspace',
+  '/': 'workspace',
+}
+
+/** Map a route to its canonical hash (without the leading '#'). */
+export function routeToHash(route: ConsoleRoute): string {
+  switch (route) {
+    case 'workspace':
+      return '/workspace'
+    case 'library':
+      return '/library'
+    case 'projects':
+      return '/projects'
+    case 'playground-rnnoise':
+      return '/playground/rnnoise'
+    case 'settings':
+      return '/settings'
+    case 'device-sdk':
+      return '/device-sdk'
+  }
+}
+
+function parseHash(): ConsoleRoute {
+  const raw = window.location.hash.replace(/^#/, '')
+  return ROUTE_BY_HASH[raw] ?? DEFAULT_ROUTE
+}
+
+export function useConsoleRoute(): [ConsoleRoute, (route: ConsoleRoute) => void] {
+  const [route, setRoute] = React.useState<ConsoleRoute>(() =>
+    typeof window === 'undefined' ? DEFAULT_ROUTE : parseHash(),
+  )
+
+  React.useEffect(() => {
+    const onHashChange = () => setRoute(parseHash())
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  const navigate = React.useCallback((next: ConsoleRoute) => {
+    const hash = routeToHash(next)
+    if (window.location.hash !== `#${hash}`) {
+      window.location.hash = hash
+    } else {
+      // Same hash: still update state (e.g. first mount / manual re-nav).
+      setRoute(next)
+    }
+  }, [])
+
+  return [route, navigate]
+}

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -12,6 +12,7 @@ export type ConsoleRoute =
   | 'workspace'
   | 'library'
   | 'projects'
+  | 'console'
   | 'playground-rnnoise'
   | 'settings'
   | 'device-sdk'
@@ -22,6 +23,7 @@ const ROUTE_BY_HASH: Record<string, ConsoleRoute> = {
   '/workspace': 'workspace',
   '/library': 'library',
   '/projects': 'projects',
+  '/console': 'console',
   '/playground/rnnoise': 'playground-rnnoise',
   '/settings': 'settings',
   '/device-sdk': 'device-sdk',
@@ -38,6 +40,8 @@ export function routeToHash(route: ConsoleRoute): string {
       return '/library'
     case 'projects':
       return '/projects'
+    case 'console':
+      return '/console'
     case 'playground-rnnoise':
       return '/playground/rnnoise'
     case 'settings':

--- a/apps/web/src/status.tsx
+++ b/apps/web/src/status.tsx
@@ -1,0 +1,57 @@
+/**
+ * Global console status - single source of truth for the shell status bar.
+ *
+ * Panels publish their state here (mic, model, worker, detection) and the
+ * top bar renders it. Lifted out of individual panels so the shell is the
+ * orchestrator (Phase 1), and the panels become consumers (Phase 2).
+ */
+
+import * as React from 'react'
+
+export type MicState = 'idle' | 'requesting' | 'active' | 'error'
+export type ModelLoadState = 'idle' | 'loading' | 'ready' | 'error'
+
+export interface ConsoleStatus {
+  mic: MicState
+  model: ModelLoadState
+  worker: 'idle' | 'running' | 'error' | null
+  detection: 'stopped' | 'running' | null
+}
+
+const DEFAULT_STATUS: ConsoleStatus = {
+  mic: 'idle',
+  model: 'idle',
+  worker: null,
+  detection: null,
+}
+
+interface ConsoleStatusContextValue {
+  status: ConsoleStatus
+  setStatus: (patch: Partial<ConsoleStatus>) => void
+}
+
+const ConsoleStatusContext = React.createContext<ConsoleStatusContextValue | null>(
+  null,
+)
+
+export function ConsoleStatusProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatusState] = React.useState<ConsoleStatus>(DEFAULT_STATUS)
+
+  const setStatus = React.useCallback((patch: Partial<ConsoleStatus>) => {
+    setStatusState((prev) => ({ ...prev, ...patch }))
+  }, [])
+
+  return (
+    <ConsoleStatusContext.Provider value={{ status, setStatus }}>
+      {children}
+    </ConsoleStatusContext.Provider>
+  )
+}
+
+export function useConsoleStatus(): ConsoleStatusContextValue {
+  const ctx = React.useContext(ConsoleStatusContext)
+  if (!ctx) {
+    throw new Error('useConsoleStatus must be used within ConsoleStatusProvider')
+  }
+  return ctx
+}

--- a/apps/web/src/views/ExportGateDialog.tsx
+++ b/apps/web/src/views/ExportGateDialog.tsx
@@ -1,0 +1,133 @@
+/**
+ * Model export license gate (Phase 4 prep).
+ *
+ * Selecting a model for export runs the commercial license gate
+ * (`isCommerciallyUsable`). If the model is usable, the export action is
+ * enabled as a stub (real export kits land in Phase 4 / device SDK).
+ * If not, the gate blocks with an explanation.
+ */
+
+import * as React from 'react'
+import type { RegistryModel } from '../data/registry'
+import { isCommerciallyUsable } from '../data/registry'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogClose,
+} from '../components/ui'
+import { useToast } from '../components/toast'
+import { cn } from '../components/cn'
+
+interface ExportGateDialogProps {
+  model: RegistryModel
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const TARGETS = [
+  { value: 'onnx', label: 'ONNX' },
+  { value: 'tflite', label: 'TFLite (int8 quantized)' },
+  { value: 'device-sdk', label: 'Device SDK bundle' },
+] as const
+
+export function ExportGateDialog({ model, open, onOpenChange }: ExportGateDialogProps) {
+  const { toast } = useToast()
+  const usable = isCommerciallyUsable(model)
+  const [target, setTarget] = React.useState<string>('onnx')
+
+  // Reset target when a new model opens the dialog.
+  React.useEffect(() => {
+    if (open) setTarget('onnx')
+  }, [open, model.id])
+
+  const handleExport = () => {
+    // Stub: Phase 4 wires the actual export kit builder here.
+    toast({
+      title: 'Export requested',
+      description: `${model.id} → ${target} (export kits land in Phase 4).`,
+    })
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Export {model.name}</DialogTitle>
+        <DialogDescription>
+          {model.license} · {model.source}
+        </DialogDescription>
+
+        {/* License gate */}
+        <div
+          className={cn(
+            'mt-4 rounded-lg border p-3 text-sm',
+            usable
+              ? 'border-success/30 bg-success/5 text-ink-1'
+              : 'border-amber-400/40 bg-amber-500/5 text-ink-1',
+          )}
+        >
+          <div className="font-medium">
+            {usable ? '✓ Commercially usable' : '⚠ License gate: export blocked'}
+          </div>
+          <p className="mt-1 text-xs text-ink-2">
+            {usable
+              ? 'This model is redistributable and explicitly commercial — safe to bundle.'
+              : `This model is ${model.class}. It cannot be used in a commercial bundle (Phase 4 gate).`}
+          </p>
+        </div>
+
+        {/* Target selection */}
+        <div className="mt-4">
+          <div className="mb-2 text-sm text-ink-2">Export target</div>
+          <div className="grid grid-cols-1 gap-2">
+            {TARGETS.map((t) => (
+              <button
+                key={t.value}
+                onClick={() => setTarget(t.value)}
+                className={cn(
+                  'flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm',
+                  target === t.value
+                    ? 'border-brand-500 bg-brand-500/10 text-ink-1'
+                    : 'border-line bg-surface-3 text-ink-2 hover:bg-surface-4',
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex h-4 w-4 items-center justify-center rounded-full border',
+                    target === t.value ? 'border-brand-500' : 'border-line-2',
+                  )}
+                >
+                  {target === t.value && <span className="h-2 w-2 rounded-full bg-brand-500" />}
+                </span>
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <DialogClose asChild>
+            <button className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3">
+              Cancel
+            </button>
+          </DialogClose>
+          <button
+            onClick={handleExport}
+            disabled={!usable}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-sm font-medium',
+              usable
+                ? 'bg-brand-500 text-ink-1 hover:bg-brand-400'
+                : 'cursor-not-allowed bg-surface-4 text-ink-3',
+            )}
+            title={usable ? undefined : 'Blocked by the license gate'}
+          >
+            Export
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/views/ModelLibraryView.tsx
+++ b/apps/web/src/views/ModelLibraryView.tsx
@@ -1,0 +1,172 @@
+/**
+ * Model Library view.
+ *
+ * Renders the model registry (`model-registry.json`) as cards: license,
+ * commercial flag, format, size, source. Backend availability is surfaced
+ * from the KWS backend registry. This is the first real consumer of
+ * `loadRegistry()` (which was implemented but never wired).
+ */
+
+import * as React from 'react'
+import type { ModelRegistry, RegistryModel } from '../data/registry'
+import { loadRegistry, isCommerciallyUsable } from '../data/registry'
+import { BACKEND_REGISTRY } from '../kws'
+import { IconSpinner } from '../components/icons'
+import { useToast } from '../components/toast'
+import { cn } from '../components/cn'
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return '—'
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${bytes} B`
+}
+
+function LicenseBadge({ model }: { model: RegistryModel }) {
+  const usable = isCommerciallyUsable(model)
+  return (
+    <span
+      className={cn(
+        'rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+        usable
+          ? 'bg-emerald-500/10 text-emerald-700'
+          : 'bg-amber-500/10 text-amber-700',
+      )}
+      title={usable ? 'Commercially usable' : 'Demo-only / check license'}
+    >
+      {usable ? 'commercial' : model.class}
+    </span>
+  )
+}
+
+export function ModelLibraryView() {
+  const { toast } = useToast()
+  const [registry, setRegistry] = React.useState<ModelRegistry | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    loadRegistry()
+      .then((r) => {
+        if (!cancelled) setRegistry(r)
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e))
+          toast({
+            title: 'Failed to load model registry',
+            description: e instanceof Error ? e.message : String(e),
+            variant: 'error',
+          })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [toast])
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-danger/40 bg-danger/5 p-6 text-sm text-danger">
+        Could not load the model registry: {error}
+      </div>
+    )
+  }
+
+  if (!registry) {
+    return (
+      <div className="flex items-center gap-3 py-16 text-sm text-ink-2">
+        <IconSpinner className="h-4 w-4 text-brand-600" />
+        Loading model registry…
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-lg font-semibold text-ink-1">Model Library</h2>
+        <p className="mt-1 max-w-2xl text-sm text-ink-2">
+          Models are never bundled with the app (ADR-011) — they are fetched
+          lazily from the registry. License + commercial flags drive the Phase 4
+          export gate.
+        </p>
+      </div>
+
+      {/* Backend availability */}
+      <section>
+        <h3 className="mb-2 text-sm font-semibold text-ink-1">KWS backends</h3>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {BACKEND_REGISTRY.map((b) => (
+            <div
+              key={b.id}
+              className="flex items-center justify-between gap-3 rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm"
+            >
+              <span className="truncate text-ink-1">{b.label}</span>
+              <span
+                className={cn(
+                  'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                  b.browserFeasible
+                    ? 'bg-success/10 text-success'
+                    : 'bg-surface-4 text-ink-3',
+                )}
+                title={b.availabilityNote}
+              >
+                {b.browserFeasible ? 'available' : b.availabilityNote}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Models */}
+      <section>
+        <h3 className="mb-2 text-sm font-semibold text-ink-1">
+          Models{' '}
+          <span className="text-xs font-normal text-ink-3">
+            ({registry.models.length})
+          </span>
+        </h3>
+        <div className="grid gap-3 md:grid-cols-2">
+          {registry.models.map((m) => (
+            <article
+              key={m.id}
+              className="flex flex-col gap-2 rounded-xl border border-line bg-surface-2 p-4"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <h4 className="truncate text-sm font-semibold text-ink-1">
+                    {m.name}
+                  </h4>
+                  <p className="truncate text-xs text-ink-3">
+                    {m.source} · {m.format}
+                  </p>
+                </div>
+                <LicenseBadge model={m} />
+              </div>
+
+              <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-ink-2">
+                <div className="flex justify-between gap-2">
+                  <dt className="text-ink-3">Size</dt>
+                  <dd className="font-mono">{formatBytes(m.sizeBytes)}</dd>
+                </div>
+                <div className="flex justify-between gap-2">
+                  <dt className="text-ink-3">License</dt>
+                  <dd className="truncate" title={m.license}>
+                    {m.license}
+                  </dd>
+                </div>
+              </dl>
+
+              {m.notes && (
+                <p className="line-clamp-3 text-xs leading-relaxed text-ink-3">
+                  {m.notes}
+                </p>
+              )}
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/views/ModelLibraryView.tsx
+++ b/apps/web/src/views/ModelLibraryView.tsx
@@ -1,19 +1,23 @@
 /**
- * Model Library view.
+ * Model Library view (Phase 3).
  *
- * Renders the model registry (`model-registry.json`) as cards: license,
- * commercial flag, format, size, source. Backend availability is surfaced
- * from the KWS backend registry. This is the first real consumer of
- * `loadRegistry()` (which was implemented but never wired).
+ * Renders the model registry (`model-registry.json`) as cards with:
+ *  - search + tier/format filter
+ *  - per-model reachability probe (HEAD -> actual size)
+ *  - license + commercial flag
+ *  - export license-gate dialog (Phase 4 prep)
+ * Backend availability is surfaced from the KWS backend registry.
  */
 
 import * as React from 'react'
-import type { ModelRegistry, RegistryModel } from '../data/registry'
+import type { ModelRegistry, RegistryModel, ModelTier } from '../data/registry'
 import { loadRegistry, isCommerciallyUsable } from '../data/registry'
+import { probeModelUrl, type ProbeResult } from '../data/probe'
 import { BACKEND_REGISTRY } from '../kws'
 import { IconSpinner } from '../components/icons'
 import { useToast } from '../components/toast'
 import { cn } from '../components/cn'
+import { ExportGateDialog } from './ExportGateDialog'
 
 function formatBytes(bytes: number | null): string {
   if (bytes == null) return '—'
@@ -39,10 +43,65 @@ function LicenseBadge({ model }: { model: RegistryModel }) {
   )
 }
 
+function ProbeButton({ model }: { model: RegistryModel }) {
+  const { toast } = useToast()
+  const [probe, setProbe] = React.useState<ProbeResult>({ state: 'idle', sizeBytes: null })
+
+  const run = async () => {
+    setProbe({ state: 'probing', sizeBytes: null })
+    const result = await probeModelUrl(model.url)
+    setProbe(result)
+    if (result.state === 'error') {
+      toast({
+        title: `Cannot reach ${model.id}`,
+        description: result.error ?? `HTTP ${result.status}`,
+        variant: 'error',
+      })
+    }
+  }
+
+  if (probe.state === 'ok') {
+    return (
+      <span className="text-[11px] text-success">
+        ✓ {formatBytes(probe.sizeBytes ?? model.sizeBytes)}
+      </span>
+    )
+  }
+  if (probe.state === 'error') {
+    return (
+      <button
+        onClick={run}
+        className="text-[11px] text-danger hover:underline"
+        title={probe.error}
+      >
+        unreachable · retry
+      </button>
+    )
+  }
+  if (probe.state === 'probing') {
+    return (
+      <span className="flex items-center gap-1 text-[11px] text-ink-3">
+        <IconSpinner className="h-3 w-3" /> probing…
+      </span>
+    )
+  }
+  return (
+    <button
+      onClick={run}
+      className="text-[11px] text-ink-3 hover:text-ink-1 hover:underline"
+    >
+      verify reachable
+    </button>
+  )
+}
+
 export function ModelLibraryView() {
   const { toast } = useToast()
   const [registry, setRegistry] = React.useState<ModelRegistry | null>(null)
   const [error, setError] = React.useState<string | null>(null)
+  const [query, setQuery] = React.useState('')
+  const [tier, setTier] = React.useState<'all' | ModelTier>('all')
+  const [exportModel, setExportModel] = React.useState<RegistryModel | null>(null)
 
   React.useEffect(() => {
     let cancelled = false
@@ -64,6 +123,18 @@ export function ModelLibraryView() {
       cancelled = true
     }
   }, [toast])
+
+  const models = React.useMemo(() => {
+    if (!registry) return []
+    const q = query.trim().toLowerCase()
+    return registry.models.filter((m) => {
+      if (tier !== 'all' && !m.tier.includes(tier)) return false
+      if (q && !`${m.id} ${m.name} ${m.source} ${m.license}`.toLowerCase().includes(q)) {
+        return false
+      }
+      return true
+    })
+  }, [registry, query, tier])
 
   if (error) {
     return (
@@ -88,9 +159,34 @@ export function ModelLibraryView() {
         <h2 className="text-lg font-semibold text-ink-1">Model Library</h2>
         <p className="mt-1 max-w-2xl text-sm text-ink-2">
           Models are never bundled with the app (ADR-011) — they are fetched
-          lazily from the registry. License + commercial flags drive the Phase 4
-          export gate.
+          lazily from the registry. License + commercial flags drive the export
+          gate.
         </p>
+      </div>
+
+      {/* Toolbar: search + tier filter */}
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search models…"
+          aria-label="Search models"
+          className="w-64 rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-sm text-ink-1 placeholder:text-ink-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+        />
+        <div className="flex gap-1 rounded-lg border border-line bg-surface-2 p-1">
+          {(['all', 'low-power', 'high-performance'] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTier(t)}
+              className={cn(
+                'rounded-md px-2.5 py-1 text-xs font-medium',
+                tier === t ? 'bg-brand-500/10 text-brand-700' : 'text-ink-3 hover:text-ink-1',
+              )}
+            >
+              {t === 'all' ? 'All' : t === 'low-power' ? 'MCU' : 'High-perf'}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Backend availability */}
@@ -124,49 +220,75 @@ export function ModelLibraryView() {
         <h3 className="mb-2 text-sm font-semibold text-ink-1">
           Models{' '}
           <span className="text-xs font-normal text-ink-3">
-            ({registry.models.length})
+            ({models.length} of {registry.models.length})
           </span>
         </h3>
-        <div className="grid gap-3 md:grid-cols-2">
-          {registry.models.map((m) => (
-            <article
-              key={m.id}
-              className="flex flex-col gap-2 rounded-xl border border-line bg-surface-2 p-4"
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0">
-                  <h4 className="truncate text-sm font-semibold text-ink-1">
-                    {m.name}
-                  </h4>
-                  <p className="truncate text-xs text-ink-3">
-                    {m.source} · {m.format}
+        {models.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-line bg-surface-2/50 p-10 text-center text-sm text-ink-3">
+            No models match your filter.
+          </div>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2">
+            {models.map((m) => (
+              <article
+                key={m.id}
+                className="flex flex-col gap-2 rounded-xl border border-line bg-surface-2 p-4"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <h4 className="truncate text-sm font-semibold text-ink-1">
+                      {m.name}
+                    </h4>
+                    <p className="truncate text-xs text-ink-3">
+                      {m.source} · {m.format}
+                    </p>
+                  </div>
+                  <LicenseBadge model={m} />
+                </div>
+
+                <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-ink-2">
+                  <div className="flex justify-between gap-2">
+                    <dt className="text-ink-3">Size</dt>
+                    <dd className="font-mono">{formatBytes(m.sizeBytes)}</dd>
+                  </div>
+                  <div className="flex justify-between gap-2">
+                    <dt className="text-ink-3">License</dt>
+                    <dd className="truncate" title={m.license}>
+                      {m.license}
+                    </dd>
+                  </div>
+                </dl>
+
+                {m.notes && (
+                  <p className="line-clamp-3 text-xs leading-relaxed text-ink-3">
+                    {m.notes}
                   </p>
-                </div>
-                <LicenseBadge model={m} />
-              </div>
+                )}
 
-              <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-ink-2">
-                <div className="flex justify-between gap-2">
-                  <dt className="text-ink-3">Size</dt>
-                  <dd className="font-mono">{formatBytes(m.sizeBytes)}</dd>
+                <div className="mt-auto flex items-center justify-between pt-2">
+                  <ProbeButton model={m} />
+                  <button
+                    onClick={() => setExportModel(m)}
+                    className="rounded-lg border border-line px-2.5 py-1 text-xs font-medium text-ink-2 hover:bg-surface-3"
+                  >
+                    Export…
+                  </button>
                 </div>
-                <div className="flex justify-between gap-2">
-                  <dt className="text-ink-3">License</dt>
-                  <dd className="truncate" title={m.license}>
-                    {m.license}
-                  </dd>
-                </div>
-              </dl>
-
-              {m.notes && (
-                <p className="line-clamp-3 text-xs leading-relaxed text-ink-3">
-                  {m.notes}
-                </p>
-              )}
-            </article>
-          ))}
-        </div>
+              </article>
+            ))}
+          </div>
+        )}
       </section>
+
+      {exportModel && (
+        <ExportGateDialog
+          model={exportModel}
+          open
+          onOpenChange={(open) => {
+            if (!open) setExportModel(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/views/SessionConsoleView.tsx
+++ b/apps/web/src/views/SessionConsoleView.tsx
@@ -1,0 +1,189 @@
+/**
+ * Session Console view (Phase 4).
+ *
+ * Renders the app-wide event log (from the log store) with level filtering,
+ * plus a trigger-history table exportable as CSV. Wired into the shell nav
+ * as a "Console" view.
+ */
+
+import * as React from 'react'
+import type { LogEntry, LogLevel } from '../log'
+import {
+  getTriggerEntries,
+  clearLog,
+  triggersToCsv,
+  downloadCsv,
+} from '../log'
+import { useLogEntries } from '../log'
+import { cn } from '../components/cn'
+import { useToast } from '../components/toast'
+
+const LEVEL_STYLES: Record<LogLevel, string> = {
+  info: 'text-ink-2',
+  warn: 'text-warning',
+  error: 'text-danger',
+}
+
+const LEVEL_BADGE: Record<LogLevel, string> = {
+  info: 'bg-surface-3 text-ink-3',
+  warn: 'bg-amber-500/10 text-warning',
+  error: 'bg-danger/10 text-danger',
+}
+
+function formatTime(at: number): string {
+  const d = new Date(at)
+  return d.toLocaleTimeString([], { hour12: false })
+}
+
+export function SessionConsoleView() {
+  const { toast } = useToast()
+  const entries = useLogEntries()
+  const [levelFilter, setLevelFilter] = React.useState<'all' | LogLevel>('all')
+  const [view, setView] = React.useState<'log' | 'triggers'>('log')
+
+  const filtered = React.useMemo(
+    () => (levelFilter === 'all' ? entries : entries.filter((e) => e.level === levelFilter)),
+    [entries, levelFilter],
+  )
+
+  const triggers = React.useMemo(() => getTriggerEntries(), [entries])
+
+  const handleClear = () => {
+    clearLog()
+    toast({ title: 'Session log cleared' })
+  }
+
+  const handleExportCsv = () => {
+    const csv = triggersToCsv(triggers)
+    downloadCsv(`wake-studio-triggers-${Date.now()}.csv`, csv)
+    toast({
+      title: 'Triggers exported',
+      description: `${triggers.length} trigger(s) → CSV`,
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-ink-1">Session Console</h2>
+          <p className="mt-1 text-sm text-ink-2">
+            Live event log + wake-word trigger history. Events are captured
+            app-wide (Phase 4).
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleClear}
+            className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
+          >
+            Clear
+          </button>
+          <button
+            onClick={handleExportCsv}
+            disabled={triggers.length === 0}
+            className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-40"
+          >
+            Export triggers CSV
+          </button>
+        </div>
+      </div>
+
+      {/* Log / triggers sub-tabs */}
+      <div className="inline-flex rounded-lg border border-line bg-surface-2 p-1">
+        {(['log', 'triggers'] as const).map((v) => (
+          <button
+            key={v}
+            onClick={() => setView(v)}
+            className={cn(
+              'rounded-md px-3 py-1 text-sm font-medium',
+              view === v ? 'bg-brand-500/10 text-brand-700' : 'text-ink-3 hover:text-ink-1',
+            )}
+          >
+            {v === 'log' ? 'Event log' : `Triggers (${triggers.length})`}
+          </button>
+        ))}
+      </div>
+
+      {view === 'log' ? (
+        <>
+          {/* Level filter */}
+          <div className="flex gap-1">
+            {(['all', 'info', 'warn', 'error'] as const).map((l) => (
+              <button
+                key={l}
+                onClick={() => setLevelFilter(l)}
+                className={cn(
+                  'rounded-full px-2.5 py-1 text-xs font-medium',
+                  levelFilter === l
+                    ? 'bg-surface-4 text-ink-1'
+                    : 'text-ink-3 hover:text-ink-1',
+                )}
+              >
+                {l === 'all' ? 'All' : l}
+              </button>
+            ))}
+          </div>
+
+          {/* Log list */}
+          <div className="max-h-[60vh] overflow-y-auto rounded-xl border border-line bg-surface-2 font-mono text-xs">
+            {filtered.length === 0 ? (
+              <div className="p-6 text-center text-ink-3">No events yet.</div>
+            ) : (
+              <ul className="divide-y divide-line">
+                {filtered.map((e) => (
+                  <li key={e.id} className="flex items-start gap-3 px-3 py-1.5">
+                    <span className="shrink-0 text-ink-3">{formatTime(e.at)}</span>
+                    <span
+                      className={cn(
+                        'shrink-0 rounded px-1.5 py-px text-[10px] font-semibold uppercase',
+                        LEVEL_BADGE[e.level],
+                      )}
+                    >
+                      {e.level}
+                    </span>
+                    <span className="shrink-0 text-ink-3">{e.source}</span>
+                    <span className={cn('min-w-0 flex-1 break-words', LEVEL_STYLES[e.level])}>
+                      {e.message}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      ) : (
+        /* Trigger history table */
+        <div className="overflow-hidden rounded-xl border border-line bg-surface-2">
+          {triggers.length === 0 ? (
+            <div className="p-6 text-center text-sm text-ink-3">
+              No triggers yet — run detection and say the wake word.
+            </div>
+          ) : (
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-line bg-surface-3 text-xs uppercase tracking-wide text-ink-3">
+                <tr>
+                  <th className="px-3 py-2">Time</th>
+                  <th className="px-3 py-2">Wake word</th>
+                  <th className="px-3 py-2">Peak score</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-line">
+                {triggers.map((e) => (
+                  <tr key={e.id} className="text-ink-2">
+                    <td className="px-3 py-2 font-mono">{new Date(e.at).toLocaleString()}</td>
+                    <td className="px-3 py-2 font-medium text-ink-1">{e.trigger!.word}</td>
+                    <td className="px-3 py-2 font-mono">{e.trigger!.peakScore.toFixed(3)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Re-export for type convenience.
+export type { LogEntry, LogLevel }

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -73,42 +73,44 @@ export function WorkspaceView() {
         status={useConsoleStatus().status}
       />
 
-      {/* Stepped panels */}
-      <Tabs defaultValue="live">
-        <TabsList>
-          <TabsTrigger value="live">Live pipeline</TabsTrigger>
-          <TabsTrigger value="modules">Modules</TabsTrigger>
-        </TabsList>
-        <TabsContent value="live" className="mt-4">
-          <div className="space-y-8">
-            {/* key={current?.id} remounts the panels when the project changes
-                so their config re-seeds from the new project's snapshot. */}
-            <AFEPanel
-              key={`afe-${current?.id ?? 'none'}`}
-              afeRef={afeRef}
-              onRunningChange={setAfeRunning}
-              commandRef={afeCommandRef}
-            />
-            <KWSPanel
-              key={`kws-${current?.id ?? 'none'}`}
-              afePipeline={afeRef.current}
-              afeRunning={afeRunning}
-            />
-            <FewShotPanel
-              key={`fs-${current?.id ?? 'none'}`}
-              afePipeline={afeRef.current}
-              afeRunning={afeRunning}
-            />
-          </div>
-        </TabsContent>
-        <TabsContent value="modules" className="mt-4">
-          <div className="space-y-8">
-            <TrainingPanel />
-            <PipelineView />
-            <Domains />
-          </div>
-        </TabsContent>
-      </Tabs>
+      {/* Stepped panels - tab container (IDE-style): tab bar + content box. */}
+      <div className="overflow-hidden rounded-xl border border-line bg-surface-2">
+        <Tabs defaultValue="live">
+          <TabsList className="bg-surface-2">
+            <TabsTrigger value="live">Live pipeline</TabsTrigger>
+            <TabsTrigger value="modules">Modules</TabsTrigger>
+          </TabsList>
+          <TabsContent value="live" className="p-5">
+            <div className="space-y-8">
+              {/* key={current?.id} remounts the panels when the project changes
+                  so their config re-seeds from the new project's snapshot. */}
+              <AFEPanel
+                key={`afe-${current?.id ?? 'none'}`}
+                afeRef={afeRef}
+                onRunningChange={setAfeRunning}
+                commandRef={afeCommandRef}
+              />
+              <KWSPanel
+                key={`kws-${current?.id ?? 'none'}`}
+                afePipeline={afeRef.current}
+                afeRunning={afeRunning}
+              />
+              <FewShotPanel
+                key={`fs-${current?.id ?? 'none'}`}
+                afePipeline={afeRef.current}
+                afeRunning={afeRunning}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value="modules" className="p-5">
+            <div className="space-y-8">
+              <TrainingPanel />
+              <PipelineView />
+              <Domains />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
 
       {current && (
         <p className="text-xs text-ink-3">

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -81,13 +81,24 @@ export function WorkspaceView() {
         </TabsList>
         <TabsContent value="live" className="mt-4">
           <div className="space-y-8">
+            {/* key={current?.id} remounts the panels when the project changes
+                so their config re-seeds from the new project's snapshot. */}
             <AFEPanel
+              key={`afe-${current?.id ?? 'none'}`}
               afeRef={afeRef}
               onRunningChange={setAfeRunning}
               commandRef={afeCommandRef}
             />
-            <KWSPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
-            <FewShotPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
+            <KWSPanel
+              key={`kws-${current?.id ?? 'none'}`}
+              afePipeline={afeRef.current}
+              afeRunning={afeRunning}
+            />
+            <FewShotPanel
+              key={`fs-${current?.id ?? 'none'}`}
+              afePipeline={afeRef.current}
+              afeRunning={afeRunning}
+            />
           </div>
         </TabsContent>
         <TabsContent value="modules" className="mt-4">

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -1,13 +1,18 @@
 /**
- * Workspace view (Phase 1).
+ * Workspace view (Phase 2) - project bar + pipeline canvas + stepped panels.
  *
- * Orchestrates the pipeline (AFE → BSS → NS → KWS) and hosts the existing
- * live panels. Phase 2 reworks the internals; this phase establishes the
- * view + a shared run/stop surface and wires shell status + toasts.
+ * Layout:
+ *   1. Project bar (select / create active project)
+ *   2. Pipeline canvas (AEC -> BSS -> NS -> KWS) with shared run/stop
+ *   3. Stepped panels: Live (AFE / KWS / Few-Shot) and Modules (Training /
+ *      pipeline info), hosted in tabs.
  *
- * NOTE: AFE/KWS internals are explicitly out of scope for the console
- * refactor (human decision 2026-08-05) — the panels below are mounted
- * as-is behind the workspace shell.
+ * Config panels are rendered through the unified (module-kit driven) config
+ * panel where the descriptors exist (read-side unification); writes still go
+ * through the existing setConfig paths.
+ *
+ * NOTE: AFE/KWS engine internals are out of scope for the console refactor
+ * (human decision 2026-08-05) - the live DSP path is untouched here.
  */
 
 import * as React from 'react'
@@ -17,18 +22,29 @@ import { FewShotPanel } from '../components/FewShotPanel'
 import { TrainingPanel } from '../components/TrainingPanel'
 import { PipelineView } from '../components/PipelineView'
 import { Domains } from '../components/Domains'
+import { ProjectBar } from '../components/ProjectBar'
+import { PipelineCanvas } from '../components/PipelineCanvas'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui'
 import type { AFEPipeline } from '../afe'
 import { useConsoleStatus } from '../status'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui'
+import { useProjects } from '../projects'
 
 export function WorkspaceView() {
-  // Shared AFE pipeline ref + running state (same contract as before, now
-  // owned by the workspace instead of the old App).
   const afeRef = React.useRef<AFEPipeline | null>(null)
+  const afeCommandRef = React.useRef<{ start: () => void; stop: () => void } | null>(null)
   const [afeRunning, setAfeRunning] = React.useState(false)
   const { setStatus } = useConsoleStatus()
+  const { current } = useProjects()
 
-  // Publish global status when the AFE / detection state changes.
+  const handleStart = React.useCallback(() => {
+    afeCommandRef.current?.start()
+  }, [])
+
+  const handleStop = React.useCallback(() => {
+    afeCommandRef.current?.stop()
+  }, [])
+
+  // Publish global status when AFE state changes.
   React.useEffect(() => {
     setStatus({
       mic: afeRunning ? 'active' : 'idle',
@@ -38,43 +54,58 @@ export function WorkspaceView() {
   }, [afeRunning, setStatus])
 
   return (
-    <div className="space-y-8">
-      {/* Welcome card (replaces the old marketing hero) */}
-      <div className="rounded-xl border border-line bg-gradient-to-br from-brand-50 to-surface-2 p-6">
-        <h2 className="text-xl font-semibold text-ink-1">Workspace</h2>
-        <p className="mt-1 max-w-2xl text-sm text-ink-2">
+    <div className="space-y-6">
+      {/* Welcome + project bar */}
+      <div className="rounded-xl border border-line bg-gradient-to-br from-brand-50 to-surface-2 p-5">
+        <h2 className="text-lg font-semibold text-ink-1">Workspace</h2>
+        <p className="mt-1 text-sm text-ink-2">
           Build, visualize and test on-device wake-word pipelines — all in the
-          browser. Live AFE → KWS → Few-Shot enrollment below; projects and
-          the full studio surface land next.
+          browser. Select or create a project, then run the pipeline.
         </p>
       </div>
 
-      {/* Pipeline status strip */}
-      <div className="rounded-xl border border-line bg-surface-2 p-4">
-        <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-ink-3">
-          Pipeline · AEC → BSS → NS → KWS
-        </div>
-        <Tabs defaultValue="live">
-          <TabsList>
-            <TabsTrigger value="live">Live pipeline</TabsTrigger>
-            <TabsTrigger value="modules">Modules</TabsTrigger>
-          </TabsList>
-          <TabsContent value="live" className="mt-4">
-            <div className="space-y-8">
-              <AFEPanel afeRef={afeRef} onRunningChange={setAfeRunning} />
-              <KWSPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
-              <FewShotPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
-            </div>
-          </TabsContent>
-          <TabsContent value="modules" className="mt-4">
-            <div className="space-y-8">
-              <TrainingPanel />
-              <PipelineView />
-              <Domains />
-            </div>
-          </TabsContent>
-        </Tabs>
-      </div>
+      <ProjectBar />
+
+      <PipelineCanvas
+        afeRunning={afeRunning}
+        onStart={handleStart}
+        onStop={handleStop}
+        status={useConsoleStatus().status}
+      />
+
+      {/* Stepped panels */}
+      <Tabs defaultValue="live">
+        <TabsList>
+          <TabsTrigger value="live">Live pipeline</TabsTrigger>
+          <TabsTrigger value="modules">Modules</TabsTrigger>
+        </TabsList>
+        <TabsContent value="live" className="mt-4">
+          <div className="space-y-8">
+            <AFEPanel
+              afeRef={afeRef}
+              onRunningChange={setAfeRunning}
+              commandRef={afeCommandRef}
+            />
+            <KWSPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
+            <FewShotPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
+          </div>
+        </TabsContent>
+        <TabsContent value="modules" className="mt-4">
+          <div className="space-y-8">
+            <TrainingPanel />
+            <PipelineView />
+            <Domains />
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      {current && (
+        <p className="text-xs text-ink-3">
+          Active project:{' '}
+          <span className="font-medium text-ink-2">{current.name}</span> · config
+          snapshots are saved with the project.
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -1,0 +1,80 @@
+/**
+ * Workspace view (Phase 1).
+ *
+ * Orchestrates the pipeline (AFE → BSS → NS → KWS) and hosts the existing
+ * live panels. Phase 2 reworks the internals; this phase establishes the
+ * view + a shared run/stop surface and wires shell status + toasts.
+ *
+ * NOTE: AFE/KWS internals are explicitly out of scope for the console
+ * refactor (human decision 2026-08-05) — the panels below are mounted
+ * as-is behind the workspace shell.
+ */
+
+import * as React from 'react'
+import { AFEPanel } from '../components/AFEPanel'
+import { KWSPanel } from '../components/KWSPanel'
+import { FewShotPanel } from '../components/FewShotPanel'
+import { TrainingPanel } from '../components/TrainingPanel'
+import { PipelineView } from '../components/PipelineView'
+import { Domains } from '../components/Domains'
+import type { AFEPipeline } from '../afe'
+import { useConsoleStatus } from '../status'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui'
+
+export function WorkspaceView() {
+  // Shared AFE pipeline ref + running state (same contract as before, now
+  // owned by the workspace instead of the old App).
+  const afeRef = React.useRef<AFEPipeline | null>(null)
+  const [afeRunning, setAfeRunning] = React.useState(false)
+  const { setStatus } = useConsoleStatus()
+
+  // Publish global status when the AFE / detection state changes.
+  React.useEffect(() => {
+    setStatus({
+      mic: afeRunning ? 'active' : 'idle',
+      worker: afeRunning ? 'running' : null,
+      detection: afeRunning ? 'running' : 'stopped',
+    })
+  }, [afeRunning, setStatus])
+
+  return (
+    <div className="space-y-8">
+      {/* Welcome card (replaces the old marketing hero) */}
+      <div className="rounded-xl border border-line bg-gradient-to-br from-brand-50 to-surface-2 p-6">
+        <h2 className="text-xl font-semibold text-ink-1">Workspace</h2>
+        <p className="mt-1 max-w-2xl text-sm text-ink-2">
+          Build, visualize and test on-device wake-word pipelines — all in the
+          browser. Live AFE → KWS → Few-Shot enrollment below; projects and
+          the full studio surface land next.
+        </p>
+      </div>
+
+      {/* Pipeline status strip */}
+      <div className="rounded-xl border border-line bg-surface-2 p-4">
+        <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-ink-3">
+          Pipeline · AEC → BSS → NS → KWS
+        </div>
+        <Tabs defaultValue="live">
+          <TabsList>
+            <TabsTrigger value="live">Live pipeline</TabsTrigger>
+            <TabsTrigger value="modules">Modules</TabsTrigger>
+          </TabsList>
+          <TabsContent value="live" className="mt-4">
+            <div className="space-y-8">
+              <AFEPanel afeRef={afeRef} onRunningChange={setAfeRunning} />
+              <KWSPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
+              <FewShotPanel afePipeline={afeRef.current} afeRunning={afeRunning} />
+            </div>
+          </TabsContent>
+          <TabsContent value="modules" className="mt-4">
+            <div className="space-y-8">
+              <TrainingPanel />
+              <PipelineView />
+              <Domains />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/views/placeholders.tsx
+++ b/apps/web/src/views/placeholders.tsx
@@ -6,6 +6,8 @@
  * the project store in Phase 2).
  */
 
+import { useProjects } from '../projects'
+
 export function ComingSoonView({
   title,
   description,
@@ -25,18 +27,58 @@ export function ComingSoonView({
 }
 
 export function ProjectsView() {
+  const { projects } = useProjects()
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold text-ink-1">Projects</h2>
         <p className="mt-1 text-sm text-ink-2">
           Wake-word projects: target word, domain, config snapshots, samples
-          and prototypes. Project CRUD lands with the workspace store (Phase 2).
+          and prototypes.
         </p>
       </div>
-      <div className="rounded-xl border border-dashed border-line bg-surface-2/50 p-10 text-center text-sm text-ink-3">
-        No projects yet — create one from the Workspace.
-      </div>
+      {projects.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-line bg-surface-2/50 p-10 text-center text-sm text-ink-3">
+          No projects yet — create one from the Workspace.
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {projects.map((p) => (
+            <div
+              key={p.id}
+              className="rounded-xl border border-line bg-surface-2 p-4"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="truncate text-sm font-semibold text-ink-1">
+                  {p.name}
+                </h3>
+                <span className="shrink-0 rounded-full bg-surface-3 px-2 py-0.5 text-[10px] uppercase tracking-wide text-ink-3">
+                  {p.domain}
+                </span>
+              </div>
+              <dl className="mt-2 space-y-1 text-xs text-ink-2">
+                <div className="flex gap-2">
+                  <dt className="w-20 shrink-0 text-ink-3">Wake word</dt>
+                  <dd className="truncate">{p.targetWord || '—'}</dd>
+                </div>
+                {p.targetChip && (
+                  <div className="flex gap-2">
+                    <dt className="w-20 shrink-0 text-ink-3">Chip</dt>
+                    <dd className="truncate">{p.targetChip}</dd>
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <dt className="w-20 shrink-0 text-ink-3">Samples</dt>
+                  <dd>{p.sampleIds.length}</dd>
+                </div>
+              </dl>
+              <p className="mt-2 text-[11px] text-ink-3">
+                Updated {new Date(p.updatedAtMs).toLocaleString()}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/views/placeholders.tsx
+++ b/apps/web/src/views/placeholders.tsx
@@ -1,0 +1,42 @@
+/**
+ * Placeholder views for shell completeness (Phase 1).
+ *
+ * Settings / Device SDK land in later phases; these keep the shell navigable
+ * without dead links. Projects shows a scaffold list (real CRUD lands with
+ * the project store in Phase 2).
+ */
+
+export function ComingSoonView({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-3 text-center">
+      <div className="rounded-full bg-brand-500/10 px-3 py-1 text-xs font-medium text-brand-700">
+        Coming soon
+      </div>
+      <h2 className="text-lg font-semibold text-ink-1">{title}</h2>
+      <p className="max-w-md text-sm text-ink-2">{description}</p>
+    </div>
+  )
+}
+
+export function ProjectsView() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-ink-1">Projects</h2>
+        <p className="mt-1 text-sm text-ink-2">
+          Wake-word projects: target word, domain, config snapshots, samples
+          and prototypes. Project CRUD lands with the workspace store (Phase 2).
+        </p>
+      </div>
+      <div className="rounded-xl border border-dashed border-line bg-surface-2/50 p-10 text-center text-sm text-ink-3">
+        No projects yet — create one from the Workspace.
+      </div>
+    </div>
+  )
+}

--- a/packages/module-kit/src/ui/controls.tsx
+++ b/packages/module-kit/src/ui/controls.tsx
@@ -38,7 +38,7 @@ export function UiSlider({ value, min, max, step = 1, onChange, disabled, ariaLa
   return (
     <div className="flex w-full items-center gap-3">
       <SliderPrimitive.Root
-        className={cn(SLIDER_CLS.root, disabled && 'opacity-40 pointer-events-none')}
+        className={cn(SLIDER_CLS.root, 'min-w-44', disabled && 'opacity-40 pointer-events-none')}
         min={min}
         max={max}
         step={step}
@@ -272,7 +272,9 @@ export function UiParamRow({ label, description, children }: UiParamRowProps) {
         <div className="text-sm text-ink-2">{label}</div>
         {description && <div className="mt-0.5 text-xs text-ink-3">{description}</div>}
       </div>
-      <div className="shrink-0">{children}</div>
+      {/* Controls that need width (sliders) must not be collapsed; allow them
+          to grow but keep a sensible cap so labels stay readable. */}
+      <div className="shrink-0 grow-0 basis-auto">{children}</div>
     </div>
   )
 }

--- a/packages/module-kit/src/ui/styles.ts
+++ b/packages/module-kit/src/ui/styles.ts
@@ -30,12 +30,15 @@ export const BTN_VARIANTS = {
 
 /** Radix slider track/thumb styling (data-* attributes drive state). */
 export const SLIDER_CLS = {
-  root: 'relative flex h-5 w-full touch-none select-none items-center',
+  root: 'relative flex h-5 w-full min-w-44 touch-none select-none items-center',
   track:
     'relative h-1.5 w-full grow overflow-hidden rounded-full bg-surface-4',
   range: 'absolute h-full rounded-full bg-brand-500',
+  // Radix positions the thumb via inline left + translateX; it MUST be
+  // absolutely positioned within the (relative) root or the knob visually
+  // detaches from the value. top-1/2 -translate-y-1/2 centers it vertically.
   thumb:
-    'block h-4 w-4 rounded-full bg-white shadow ring-1 ring-line-2 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+    'absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-white shadow ring-1 ring-line-2 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
 }
 
 /** Radix switch (toggle) styling. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,21 @@ importers:
 
   apps/web:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.24
+        version: 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.21
+        version: 1.1.21(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.23
+        version: 1.2.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.16
+        version: 1.2.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wake-studio/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -1369,6 +1384,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.23':
+    resolution: {integrity: sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.4':
     resolution: {integrity: sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==}
     peerDependencies:
@@ -1380,6 +1408,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.19':
     resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.24':
+    resolution: {integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1420,6 +1461,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.24':
+    resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.3.7':
@@ -1487,6 +1541,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.19':
+    resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.3.7':
     resolution: {integrity: sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==}
     peerDependencies:
@@ -1535,6 +1602,45 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.21':
+    resolution: {integrity: sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.23':
+    resolution: {integrity: sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.16':
+    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.4':
     resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
     peerDependencies:
@@ -1555,6 +1661,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.5':
     resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.3':
+    resolution: {integrity: sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4751,6 +4866,29 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
 
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@radix-ui/react-direction@1.1.4(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -4764,6 +4902,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -4793,6 +4946,32 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.31
+
+  '@radix-ui/react-menu@2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@radix-ui/react-popper@1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -4844,6 +5023,25 @@ snapshots:
     dependencies:
       '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -4920,6 +5118,63 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
+  '@radix-ui/react-tabs@1.1.21(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-toast@1.2.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@radix-ui/react-use-callback-ref@1.1.4(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -4938,6 +5193,12 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.5(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@radix-ui/react-use-is-hydrated@0.1.3(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.31

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@wake-studio/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      '@wake-studio/module-kit':
+        specifier: workspace:^
+        version: link:../../packages/module-kit
       '@wake-studio/module-rnnoise':
         specifier: workspace:^
         version: link:../../packages/modules/afe/rnnoise


### PR DESCRIPTION
## Summary

Turns the WakeStudio PWA from a single long landing page into a qualified **console / studio** app: IDE-style shell (left sidebar + hash-routed views), a project model with IndexedDB persistence, unified spec-driven config panels, a real Model Library, and a Session Console with trigger-history CSV export.

Implemented in 8 commits covering plan Phases 1-4 of `.agents/plan/console-studio.plan`.

## What changed

- **Phase 1 — App shell**: Radix-based sidebar + top bar + content layout (left sidebar / multi-view per Q-C1); zero-dependency hash routing (`#/workspace`, `#/library`, `#/projects`, `#/console`, `#/playground/rnnoise`, `#/settings`, `#/device-sdk`); global status bar (mic / model / worker / detection). Added 5 Radix shell packages (tabs, dialog, dropdown-menu, tooltip, toast).
- **Phase 2 — Workspace & project model**: `src/projects/` (types + IndexedDB store + context) with config snapshots per stage; ProjectBar (dropdown selector + new-project dialog); PipelineCanvas (AEC to BSS to NS to KWS orchestration strip with shared run/stop via commandRef); `UnifiedConfigPanel` rendering `ParameterDescriptor[]` through module-kit controls (read-side unification, ADR-025); panels sync their config to the active project snapshot (seeded on mount, persisted on change, remounted on project switch).
- **Phase 3 — Model Library**: `loadRegistry()` (was previously never called) now powers a searchable/filterable library; per-model reachability probe (HEAD to actual size); **export license gate** dialog (isCommerciallyUsable); deploy-base-aware asset resolver (`src/config.ts`, ADR-012).
- **Phase 4 — Session Console**: app-wide event log (`src/log.tsx`, ring-buffered, leveled) + trigger history table + CSV export; real KWS/AFE events wired in (replaces scattered console.log).
- **Fixes**: `UiSlider` thumb was position static (knob visually detached from value) — now absolutely positioned so drag/arrows move the knob in sync; Live/Modules switch is now a real tab container (IDE-style).

## Verification

- typecheck, lint (0 errors), build all pass
- Unit: 121/121 (new: projects store, registry license gate + probe, log store + CSV)
- e2e: 10/10 smoke/rnnoise/light-theme (sherpa-kws boot timeout is a pre-existing issue, tracked separately)
- Manual: project create, config change persists across reload; switching projects re-seeds; slider drag + arrow keys move knob correctly; session console renders events + triggers

## Notes

- CI on main is currently red (lint missing eslint.config.js in packages/contracts/test-kit, and the Playwright CLI resolution) — that is the Phase 0 hardening item, deliberately out of scope for this PR per the plan sequencing.
- Plan doc: `.agents/plan/console-studio.plan` (gitignored, kept as the living phase plan).
