### PR TITLE
fix(p0): delivery-chain blockers — lint configs, playwright CI, deploy wasm fetch, offline ort wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
         run: |
           pnpm --filter @wake-studio/web fetch-sherpa-kws-assets || echo "sherpa wasm fetch failed; sherpa-kws spec will be skipped"
 
+      - name: Build PWA (for preview server)
+        # `pnpm preview` serves dist/; the e2e job must build it first (the
+        # lint-build job's dist artifact is not shared).
+        run: pnpm build
+
       - name: Run e2e tests
         run: pnpm test:e2e
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,17 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright browser
-        run: pnpm exec playwright install --with-deps chromium
+        # `playwright` is a devDependency of apps/web; resolve its CLI through
+        # the package so `pnpm exec` finds it (root `pnpm exec` does not see
+        # child-package bins - P0-2).
+        run: pnpm --filter @wake-studio/web exec playwright install --with-deps chromium
+
+      - name: Fetch runtime assets (sherpa wasm for e2e)
+        # The sherpa-kws e2e boots the 53 MB wasm; fetch it into the module
+        # assets dir (gitignored). Non-fatal: the spec skips if the file is
+        # absent (see sherpa-kws.spec.ts).
+        run: |
+          pnpm --filter @wake-studio/web fetch-sherpa-kws-assets || echo "sherpa wasm fetch failed; sherpa-kws spec will be skipped"
 
       - name: Run e2e tests
         run: pnpm test:e2e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ name: Deploy
 #   - Settings -> Pages -> Source = "GitHub Actions"
 #   - Settings -> Environments -> create "github-pages"
 #   - Secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
-#   - A Cloudflare Pages project named "wave-studio"
+#   - A Cloudflare Pages project named "wake-studio" (ADR-014)
 on:
   workflow_dispatch:
 
@@ -39,6 +39,13 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Fetch the sherpa KWS wasm + plixkws onnx into the module assets dirs
+      # (gitignored, ADR-011). The build copies them into dist/ (P0-3).
+      - name: Fetch runtime assets
+        run: |
+          pnpm --filter @wake-studio/web fetch-sherpa-kws-assets || echo "sherpa wasm fetch failed (non-fatal for deploy; backend will 404 until built)"
+          node scripts/fetch-artifact.mjs kws-plix || echo "plixkws fetch failed (non-fatal)"
 
       # Project-page sites need a sub-path (ADR-012).
       - name: Build PWA (GitHub Pages base)
@@ -80,6 +87,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Fetch runtime assets into module assets dirs before build (P0-3).
+      - name: Fetch runtime assets
+        run: |
+          pnpm --filter @wake-studio/web fetch-sherpa-kws-assets || echo "sherpa wasm fetch failed (non-fatal for deploy; backend will 404 until built)"
+          node scripts/fetch-artifact.mjs kws-plix || echo "plixkws fetch failed (non-fatal)"
+
       # Cloudflare Pages serves at root (ADR-012).
       - name: Build PWA (Cloudflare base)
         env:
@@ -91,4 +104,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=wave-studio
+          # ADR-014: the project name is wake-studio (was wave-studio).
+          command: pages deploy dist --project-name=wake-studio

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ packages/modules/*/*/assets/*
 packages/modules/*/*/train/.venv/
 packages/modules/*/*/train/out/
 packages/modules/*/*/train/*.egg-info/
+
+# onnxruntime-web wasm runtime (copied from node_modules at build, P0-4)
+apps/web/public/ort/

--- a/apps/local-service/eslint.config.js
+++ b/apps/local-service/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+/**
+ * local-service eslint config (flat, ESLint 9).
+ * Node-only service (HTTP server + train runner); no browser globals.
+ */
+export default tseslint.config(
+  { ignores: ['node_modules', 'dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+)

--- a/apps/local-service/package.json
+++ b/apps/local-service/package.json
@@ -24,6 +24,10 @@
     "@wake-studio/module-rnnoise": "workspace:^"
   },
   "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "eslint": "^9.16.0",
+    "globals": "^15.13.0",
+    "typescript-eslint": "^8.16.0",
     "@types/node": "^20.17.6",
     "tsx": "^4.19.2",
     "typescript": "~5.6.3",

--- a/apps/web/e2e/sherpa-kws.spec.ts
+++ b/apps/web/e2e/sherpa-kws.spec.ts
@@ -1,4 +1,27 @@
 import { test, expect } from '@playwright/test'
+import { existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The ~53 MB wasm is gitignored (ADR-011) and fetched in CI; skip the spec
+// when it is absent (e.g. a fetch failure) rather than fail the suite.
+const here = dirname(fileURLToPath(import.meta.url))
+const sherpaWasm = resolve(
+  here,
+  '..',
+  '..',
+  '..',
+  'packages',
+  'modules',
+  'kws',
+  'sherpa',
+  'assets',
+  'sherpa-onnx-kws',
+  'sherpa-onnx-wasm-kws-main.wasm',
+)
+const SKIP_REASON = existsSync(sherpaWasm)
+  ? null
+  : 'sherpa-onnx KWS wasm not present; run `pnpm --filter @wake-studio/web fetch-sherpa-kws-assets`'
 
 /**
  * Verifies the sherpa-onnx KWS WebAssembly backend actually boots in the
@@ -14,6 +37,10 @@ import { test, expect } from '@playwright/test'
 test('sherpa-onnx-kws backend loads (wasm boots + spotter created)', async ({
   page,
 }) => {
+  test.skip(Boolean(SKIP_REASON), SKIP_REASON ?? '')
+  // The ~53 MB wasm boot can take > 30 s; the default test timeout (30 s)
+  // would fire before the 'ready' assertion. Extend per-test.
+  test.setTimeout(240_000)
   await page.goto('/')
 
   // Pick the sherpa-onnx-kws backend before loading (now in the top controls).

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -72,10 +72,10 @@ test('live workspace panels still render (AFE/KWS/Few-Shot/Training)', async ({ 
   // Few-Shot enrollment (h2 in the panel).
   await expect(page.getByRole('main').getByRole('heading', { name: 'Few-Shot enrollment' })).toBeVisible()
 
-  // Training is under the "Modules" tab.
+  // Training is under the "Modules" tab (spec-driven panel, ADR-025).
   await page.getByRole('tab', { name: 'Modules' }).click()
   await expect(
-    page.getByRole('heading', { name: /Traditional KWS — Training/i }),
+    page.getByRole('heading', { name: 'Training (custom wake-word)' }),
   ).toBeVisible()
 })
 
@@ -100,16 +100,17 @@ test('Few-Shot enrollment panel renders (Phase 3)', async ({ page }) => {
   await expect(page.getByRole('button', { name: /Load PLiX encoder/i })).toBeVisible()
 })
 
-test('Traditional KWS Training panel renders (§4.2)', async ({ page }) => {
+test('Traditional KWS Training panel renders (§4.2, spec-driven)', async ({ page }) => {
   await page.goto('/#/workspace')
 
   await page.getByRole('tab', { name: 'Modules' }).click()
   await expect(
-    page.getByRole('heading', { name: /Traditional KWS — Training/i }),
+    page.getByRole('heading', { name: 'Training (custom wake-word)' }),
   ).toBeVisible()
-  await expect(page.getByText(/Network architecture/i)).toBeVisible()
-  await expect(page.getByText(/Target keyword list/i)).toBeVisible()
+  await expect(page.getByText(/Wake phrase/i)).toBeVisible()
+  await expect(page.getByText(/Target tier/i)).toBeVisible()
 
+  // Advanced params collapse under the dual-layer "Advanced" section (ADR-024).
   await expect(page.getByText(/Audio augmentation/i)).toBeHidden()
   await page.getByRole('button', { name: /Advanced/i }).first().click()
   await expect(page.getByText(/Audio augmentation/i)).toBeVisible()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,6 +62,7 @@
     "typescript-eslint": "^8.16.0",
     "vite": "^5.4.11",
     "vite-plugin-pwa": "^0.21.1",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "playwright": "^1.49.0"
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig, type ViteDevServer, type PreviewServer } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
-import { createReadStream, statSync } from 'node:fs'
-import { resolve, dirname, extname } from 'node:path'
+import { createReadStream, statSync, cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs'
+import { resolve, dirname, extname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Plugin } from 'vite'
 
 const projectRoot = dirname(fileURLToPath(import.meta.url))
 const prebuiltsRoot = resolve(projectRoot, 'prebuilts')
@@ -12,6 +13,90 @@ const prebuiltsRoot = resolve(projectRoot, 'prebuilts')
 // Served at /modules/<category>/<module>/assets/... (ADR-025 - a module's
 // binary artifacts live with the module, not in a central prebuilts/ pool).
 const modulesRoot = resolve(projectRoot, '../../packages/modules')
+
+/**
+ * Copy each module's assets/ dir into the build output at
+ * dist/modules/<category>/<module>/assets/... (Q-K2 / ADR-025), and copy the
+ * onnxruntime-web WASM runtime from node_modules into dist/ort/ (P0-4; the
+ * wasm is a pinned npm artifact, gitignored, not committed).
+ */
+function copyModuleAssets(): Plugin {
+  return {
+    name: 'wake-studio:copy-module-assets',
+    apply: 'build',
+    closeBundle() {
+      const distModules = resolve(projectRoot, 'dist', 'modules')
+      if (existsSync(modulesRoot)) {
+        const copyTree = (src: string, dest: string) => {
+          if (!existsSync(src)) return
+          mkdirSync(dest, { recursive: true })
+          for (const entry of readdirSafe(src)) {
+            const s = join(src, entry)
+            const d = join(dest, entry)
+            if (isDir(s)) copyTree(s, d)
+            else cpSync(s, d)
+          }
+        }
+        // Copy <category>/<module>/assets -> dist/modules/<category>/<module>/assets
+        for (const category of readdirSafe(modulesRoot)) {
+          const catPath = join(modulesRoot, category)
+          if (!isDir(catPath)) continue
+          for (const mod of readdirSafe(catPath)) {
+            const assetsDir = join(catPath, mod, 'assets')
+            if (isDir(assetsDir)) {
+              copyTree(assetsDir, join(distModules, category, mod, 'assets'))
+            }
+          }
+        }
+      }
+      // Copy onnxruntime-web wasm runtime (P0-4 offline): node_modules -> dist/ort/
+      const ortDist = join(
+        projectRoot,
+        '..',
+        '..',
+        'node_modules',
+        '.pnpm',
+      )
+      const ortWasmDir = findOrtDist(ortDist)
+      if (ortWasmDir) {
+        const dest = resolve(projectRoot, 'dist', 'ort')
+        mkdirSync(dest, { recursive: true })
+        for (const f of readdirSafe(ortWasmDir)) {
+          if (f.endsWith('.wasm') && f.startsWith('ort-wasm-simd-threaded')) {
+            cpSync(join(ortWasmDir, f), join(dest, f))
+          }
+        }
+      }
+    },
+  }
+}
+
+/** Locate the onnxruntime-web dist dir in the pnpm store (first match). */
+function findOrtDist(pnpmRoot: string): string | null {
+  const versions = readdirSafe(pnpmRoot).filter((v) =>
+    v.startsWith('onnxruntime-web@'),
+  )
+  for (const v of versions) {
+    const cand = join(pnpmRoot, v, 'node_modules', 'onnxruntime-web', 'dist')
+    if (isDir(cand)) return cand
+  }
+  return null
+}
+
+function readdirSafe(p: string): string[] {
+  try {
+    return readdirSync(p) as string[]
+  } catch {
+    return []
+  }
+}
+function isDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory()
+  } catch {
+    return false
+  }
+}
 
 /**
  * Dev/preview plugin: serve the local `prebuilts/` directory at `/prebuilts/`
@@ -82,9 +167,16 @@ function servePrebuilts() {
   // -> packages/modules/<category>/<module>/assets/<rel>. A module declares its
   // artifact URLs in spec/module.spec.json runtime.web.wasm.url.
   const modulesHandler = makeHandler('/modules/', modulesRoot, '/modules/')
+  // onnxruntime-web wasm runtime (P0-4): /ort/<rel> -> node_modules dist.
+  const ortDist = findOrtDist(resolve(projectRoot, '..', '..', 'node_modules', '.pnpm'))
+  const ortHandler = ortDist
+    ? makeHandler('/ort/', ortDist)
+    : (_req: IncomingMessage, _res: ServerResponse, next: () => void) => next()
 
   const handler = (req: IncomingMessage, res: ServerResponse, next: () => void) => {
-    prebuiltsHandler(req, res, () => modulesHandler(req, res, next))
+    prebuiltsHandler(req, res, () =>
+      modulesHandler(req, res, () => ortHandler(req, res, next)),
+    )
   }
   return {
     name: 'wake-studio:serve-prebuilts',
@@ -120,6 +212,7 @@ export default defineConfig({
   plugins: [
     react(),
     servePrebuilts(),
+    copyModuleAssets(),
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['icon.svg', 'model-registry.json'],

--- a/packages/contracts/eslint.config.js
+++ b/packages/contracts/eslint.config.js
@@ -1,0 +1,26 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+/**
+ * contracts package eslint config (flat, ESLint 9).
+ * Pure types + schemas; Node environment (vitest runs in Node).
+ */
+export default tseslint.config(
+  { ignores: ['node_modules', 'dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+    rules: {
+      // Allow intentionally-unused params prefixed with '_'.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+)

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -17,6 +17,10 @@
     "fetch:all": "echo 'no artifacts'"
   },
   "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "eslint": "^9.16.0",
+    "globals": "^15.13.0",
+    "typescript-eslint": "^8.16.0",
     "typescript": "~5.6.3",
     "vitest": "^2.1.9"
   }

--- a/packages/module-kit/eslint.config.js
+++ b/packages/module-kit/eslint.config.js
@@ -1,0 +1,26 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+/**
+ * module-kit package eslint config (flat, ESLint 9).
+ * Has JSX/React (panel generator + Ui controls); vitest runs in Node, so
+ * both browser and node globals are needed.
+ */
+export default tseslint.config(
+  { ignores: ['node_modules', 'dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: { ...globals.browser, ...globals.node },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+)

--- a/packages/module-kit/package.json
+++ b/packages/module-kit/package.json
@@ -28,6 +28,10 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "eslint": "^9.16.0",
+    "globals": "^15.13.0",
+    "typescript-eslint": "^8.16.0",
     "@types/react": "^18.3.12",
     "typescript": "~5.6.3",
     "vitest": "^2.1.9"

--- a/packages/module-kit/src/ui/canvas.tsx
+++ b/packages/module-kit/src/ui/canvas.tsx
@@ -28,7 +28,7 @@ function useCanvas(
     canvas.height = Math.round(height * dpr)
     ctx.scale(dpr, dpr)
     draw(ctx, width, height)
-  }, deps) // eslint-disable-line react-hooks/exhaustive-deps
+  }, deps)
   return ref
 }
 
@@ -103,7 +103,8 @@ export function UiWaveform({
       for (let i = 0; i < n; i++) {
         const x = (i / (n - 1)) * w
         const y = mid - series[i] * (h / 2 - 2)
-        i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
+        if (i === 0) ctx.moveTo(x, y)
+        else ctx.lineTo(x, y)
       }
       ctx.stroke()
     }
@@ -160,7 +161,8 @@ export function UiCurve({ data, threshold, height = 64, color = '#38bdf8', class
     for (let i = 0; i < n; i++) {
       const x = (i / Math.max(1, n - 1)) * w
       const y = h - data[i] * h
-      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)
+      if (i === 0) ctx.moveTo(x, y)
+      else ctx.lineTo(x, y)
     }
     ctx.stroke()
   }

--- a/packages/modules/kws/openwakeword/core/backend.ts
+++ b/packages/modules/kws/openwakeword/core/backend.ts
@@ -29,12 +29,11 @@
 import * as ort from 'onnxruntime-web'
 import type { BackendModelUrls, KWSBackend } from '@wake-studio/module-kws-engine'
 import { MEL_OVERLAP, MEL_WINDOW_SIZE } from '@wake-studio/module-kws-engine'
+import { resolveAsset } from '@wake-studio/platform'
 
-// Use the CDN for the onnxruntime-web WASM runtime files (Phase 6 will vendor
-// these for offline support, consistent with the RNNoise vendoring in Phase 1).
-// Set once at module load; shared with any other backend in this worker.
-ort.env.wasm.wasmPaths =
-  'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/'
+// onnxruntime-web WASM runtime served locally from /ort/ (public dir, copied
+// into dist/ by vite - P0-4 offline support). base-aware (ADR-012).
+ort.env.wasm.wasmPaths = resolveAsset('/ort/')
 
 /** Fetch a model URL and create an InferenceSession. */
 async function loadModel(

--- a/packages/modules/kws/plix/encoders/plix-onnx.ts
+++ b/packages/modules/kws/plix/encoders/plix-onnx.ts
@@ -20,6 +20,7 @@
  */
 
 import * as ort from 'onnxruntime-web'
+import { resolveAsset } from '@wake-studio/platform'
 import type { PlixEncoder } from './plix-encoder'
 import {
   PLIX_SAMPLE_RATE,
@@ -31,13 +32,9 @@ import {
   fitFrames,
 } from './plix-frontend'
 
-// Serve the onnxruntime-web WASM runtime from the jsDelivr CDN (consistent with
-// the OpenWakeWord backend, which does the same). Without this, the WASM files
-// are fetched from a path relative to the worker/module URL and the session
-// build fails (the failure is otherwise swallowed by the caller). Set once at
-// module load; shared with any other backend in this worker.
-ort.env.wasm.wasmPaths =
-  'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/'
+// onnxruntime-web WASM runtime served locally from /ort/ (public dir, copied
+// into dist/ by vite - P0-4 offline support). base-aware (ADR-012).
+ort.env.wasm.wasmPaths = resolveAsset('/ort/')
 
 export class PlixOnnxEncoder implements PlixEncoder {
   readonly runtime = 'onnx' as const

--- a/packages/test-kit/eslint.config.js
+++ b/packages/test-kit/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+/**
+ * test-kit package eslint config (flat, ESLint 9).
+ * L2 wasm-runner helpers; Node environment.
+ */
+export default tseslint.config(
+  { ignores: ['node_modules', 'dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+)

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -17,6 +17,10 @@
     "fetch:all": "echo 'no artifacts'"
   },
   "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "eslint": "^9.16.0",
+    "globals": "^15.13.0",
+    "typescript-eslint": "^8.16.0",
     "@types/node": "^20.17.6",
     "typescript": "~5.6.3",
     "vitest": "^2.1.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,15 +24,27 @@ importers:
         specifier: workspace:^
         version: link:../../packages/modules/afe/rnnoise
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.16.0
+        version: 9.39.5
       '@types/node':
         specifier: ^20.17.6
         version: 20.19.43
+      eslint:
+        specifier: ^9.16.0
+        version: 9.39.5(jiti@1.21.7)
+      globals:
+        specifier: ^15.13.0
+        version: 15.15.0
       tsx:
         specifier: ^4.19.2
         version: 4.23.6
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.16.0
+        version: 8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.6.3)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)
@@ -137,6 +149,9 @@ importers:
       globals:
         specifier: ^15.13.0
         version: 15.15.0
+      playwright:
+        specifier: ^1.49.0
+        version: 1.62.0
       postcss:
         specifier: ^8.4.49
         version: 8.5.23
@@ -161,9 +176,21 @@ importers:
 
   packages/contracts:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.16.0
+        version: 9.39.5
+      eslint:
+        specifier: ^9.16.0
+        version: 9.39.5(jiti@1.21.7)
+      globals:
+        specifier: ^15.13.0
+        version: 15.15.0
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.16.0
+        version: 8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.6.3)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)
@@ -195,12 +222,24 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.16.0
+        version: 9.39.5
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.31
+      eslint:
+        specifier: ^9.16.0
+        version: 9.39.5(jiti@1.21.7)
+      globals:
+        specifier: ^15.13.0
+        version: 15.15.0
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.16.0
+        version: 8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.6.3)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)
@@ -575,12 +614,24 @@ importers:
 
   packages/test-kit:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.16.0
+        version: 9.39.5
       '@types/node':
         specifier: ^20.17.6
         version: 20.19.43
+      eslint:
+        specifier: ^9.16.0
+        version: 9.39.5(jiti@1.21.7)
+      globals:
+        specifier: ^15.13.0
+        version: 15.15.0
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.16.0
+        version: 8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.6.3)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)


### PR DESCRIPTION
## Summary

Closes the P0 delivery-chain blockers (goal.plan §8.1) that gate every later
phase: the remaining red on `pnpm lint`, the broken `pnpm exec playwright` in
CI, the deploy building without the KWS wasm, and the onnxruntime wasm being
fetched from jsDelivr CDN.

## Changes

**P0-1 — lint red**
- Add `eslint.config.js` (flat, ESLint 9) to `contracts`, `test-kit`,
  `module-kit`, and `local-service` (all were missing it).
- `module-kit/src/ui/canvas.tsx`: two ternary-as-statement expressions fixed
  (`no-unused-expressions`).
- `pnpm -r lint` is now fully green (was red on 2 packages).

**P0-2 — playwright unresolvable in CI**
- `playwright` added as an explicit `apps/web` devDependency.
- `ci.yml` e2e uses `pnpm --filter @wake-studio/web exec playwright` (root
  `pnpm exec` cannot see child-package bins).
- `sherpa-kws` e2e: skips when the gitignored 53 MB wasm is absent; gets a
  240 s test timeout (wasm boot can exceed the 30 s default).
- `smoke` Training assertions updated for the spec-driven panel (ADR-025).

**P0-3 — deploy without the KWS wasm**
- `deploy.yml`: both jobs fetch sherpa + plixkws assets before build (with
  non-fatal guards).
- vite build copies module `assets/` into `dist/modules/...` (new plugin), so
  deployed KWS backends have their wasm/onnx.
- Cloudflare `--project-name` `wave-studio` → `wake-studio` (ADR-014).

**P0-4 — onnxruntime wasm from CDN**
- Removed the jsDelivr CDN override in `openwakeword` + `plix-onnx`.
- ort wasm runtime served locally from `/ort/`: vite copies the pinned npm
  wasm into `dist/ort/` at build; dev middleware serves it from the pnpm
  store. Base-aware via `resolveAsset` (ADR-012). Offline-capable.

## Validation

- `pnpm -r typecheck` / `test:unit` / `lint` — all green locally.
- `pnpm --filter @wake-studio/web build` — dist contains `/ort/*.wasm` (4
  files) + `dist/modules/**/assets/` (sherpa wasm + plixkws onnx).
- Dev + preview serve `/ort/` and `/modules/.../assets/...` (200s).
- Local e2e: smoke suite green (8 tests); sherpa-kws boots when wasm present
  (240 s timeout).

## Notes

- `sherpa-kws` e2e can be flaky on a cold cache (37 MB .data boot); the skip
  guard + retries (CI sets retries: 2) keep the suite green.
- Actual `deploy` still requires the human to configure Pages/Cloudflare
  secrets (ADR-015); this PR makes the workflow correct when that happens.