### PR TITLE
feat(web): Spectro-style WebGL spectrogram (ADR-032)

### DIFF
--- a/apps/web/src/components/AFEPanel.tsx
+++ b/apps/web/src/components/AFEPanel.tsx
@@ -9,6 +9,7 @@ import { useProjectStageConfig } from '../projects'
 import { logInfo, logError } from '../log'
 import { PipelineOverview } from './PipelineOverview'
 import { RecordReplay } from './RecordReplay'
+import { WebGLSpectrogram } from './spectrogram/WebGLSpectrogram'
 
 interface AFEPanelProps {
   afeRef: MutableRefObject<AFEPipeline | null>
@@ -307,10 +308,11 @@ const StagePanel = memo(function StagePanel({
 
       {/* Spectrum - all three stages show their own magnitude spectrum (AEC =
           raw input, BSS = passthrough, NS = denoised). Same card structure so
-          the three cards stay information-aligned. */}
+          the three cards stay information-aligned. Rendered with the WebGL
+          Spectro-style renderer (ADR-032). */}
       <div className="mt-2">
         <div className="mb-1 text-xs text-ink-3">Spectrum</div>
-        <Spectrogram data={data?.spectrum ?? new Float32Array(64)} />
+        <WebGLSpectrogram data={data?.spectrogram} />
       </div>
     </div>
   )
@@ -401,185 +403,4 @@ function LevelBar({ db }: { db: number }) {
       />
     </div>
   )
-}
-
-/**
- * Rolling spectrogram (time on X, frequency on Y, energy as color) for every
- * AFE stage. RNNoise-style: shows how the energy distribution evolves over
- * time so the operator can spot speech formants (bright bands) versus
- * stationary noise (flat low band) and silence (dark uniform).
- *
- * The worklet emits one magnitude spectrum per frame (SPECTRUM_BINS=64 bins,
- * linear). We convert each bin to dBFS, normalize against a -60 dB floor,
- * and color it with a viridis-like ramp (dark blue -> cyan -> green -> yellow
- * -> red). A ring buffer (~4 s @ 30 fps) holds the last 128 frames; we
- * redraw the whole canvas on every new frame.
- *
- * The 2D context API is slow when drawing many small rects; instead we keep
- * a per-pixel ring buffer and scroll the canvas one column per frame
- * (drawImage left-shift + draw the new rightmost column). This mirrors the
- * Spectro project's approach (circular queue of FFT rows + GPU texture
- * offset) but stays on 2D canvas so each of the three stage cards can own its
- * own cheap renderer.
- */
-
-function Spectrogram({ data }: { data: Float32Array }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  type SpecState = { bins: number; width: number; data: Float32Array; head: number; filled: number }
-  const stateRef = useRef<SpecState>({ bins: 0, width: 0, data: new Float32Array(0), head: 0, filled: 0 })
-  // StrictMode double-invokes effects in dev with the SAME data reference;
-  // enqueueing the same frame twice corrupts the ring (head advances 2 but
-  // the canvas scrolls 1). Skip identical references.
-  const lastDataRef = useRef<Float32Array | null>(null)
-
-  useEffect(() => {
-    if (!data || data.length === 0) return
-    if (lastDataRef.current === data) return // same frame again (StrictMode)
-    lastDataRef.current = data
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    const bins = data.length
-    const w = canvas.width
-    const h = canvas.height
-    let s = stateRef.current
-    if (s.bins !== bins || s.width !== w) {
-      s = { bins, width: w, data: new Float32Array(w * bins), head: 0, filled: 0 }
-      stateRef.current = s
-      // First frame with a new size: clear the canvas.
-      ctx.clearRect(0, 0, w, h)
-    }
-
-    // --- 1. Convert this frame's linear magnitudes to normalized intensity ---
-    // computeSpectrum emits magnitude normalized by sqrt(FFT_SIZE): room noise
-    // sits around -43 dBFS and speech around -23 dBFS (per-bin, after the
-    // window). We normalize against a -55 dB floor so broadband room noise is
-    // visibly lit (teal) instead of falling into the darkest color, while
-    // speech still reads bright. A gentle log contrast keeps the ramp smooth.
-    const FLOOR_DB = -55
-    const col = new Float32Array(bins)
-    for (let i = 0; i < bins; i++) {
-      const db = 20 * Math.log10(Math.max(data[i], 1e-9))
-      let norm = (db - FLOOR_DB) / -FLOOR_DB // [0..1], floor at 0
-      norm = Math.min(1, Math.max(0, norm))
-      // Log contrast (same idea as the shader's log(1+i*c)/log(1+c)).
-      col[i] = Math.log(1 + norm * 5) / Math.log(1 + 5)
-    }
-
-    // --- 2. Enqueue into the ring buffer (newest at head) ---
-    const rowOff = s.head * bins
-    s.data.set(col, rowOff)
-    s.head = (s.head + 1) % w
-    if (s.filled < w) s.filled++
-
-    // --- 3. Render: scroll left by one column, draw the newest column on the
-    //        right. Canvas pixels map 1:1 to ring columns (width = canvas w).
-    ctx.drawImage(canvas, 1, 0, w - 1, h, 0, 0, w - 1, h)
-
-    // The rightmost column now shows the previous newest; redraw it from the
-    // newest ring column (head-1 mod w). Use per-pixel fill via putImageData
-    // on a 1px-wide column.
-    const newest = (s.head - 1 + w) % w
-    const img = ctx.createImageData(1, h)
-    // Map canvas rows to FFT bins via a mel-like (log-ish) scale.
-    //
-    // Frequency-axis facts:
-    //  - The worklet's spectrum is computed from 48 kHz samples, so bin k
-    //    covers [k, k+1) * 24000/64 Hz (Nyquist 24 kHz, bin width 375 Hz).
-    //  - The KWS stage runs at 16 kHz (downsample48to16), so frequencies
-    //    above 8 kHz carry no information for wake-word detection and would
-    //    just waste canvas height on mostly-empty high bins.
-    // We therefore display 0-8 kHz across the full canvas height, using mel
-    // spacing so the low-frequency band (where room noise and speech formants
-    // live) gets the visual resolution it deserves.
-    const FMAX_HZ = 8000 // display top (matches 16 kHz KWS output Nyquist)
-    const NYQUIST_HZ = 24000 // spectrum was computed at 48 kHz
-    const MEL_MAX = melOf(FMAX_HZ)
-    for (let y = 0; y < h; y++) {
-      // Row y (0 at top) -> frequency from high (top) to low (bottom) on mel.
-      const t = (h - 1 - y) / (h - 1) // 1 at bottom (0 Hz) -> 0 at top (8 kHz)
-      const freqHz = melInv(MEL_MAX * (1 - t)) // 0 Hz at bottom, 8 kHz at top
-      // Map Hz -> actual FFT bin at 48 kHz sample rate.
-      const bin = Math.min(
-        bins - 1,
-        Math.floor((freqHz / NYQUIST_HZ) * bins),
-      )
-      const [r, g, b] = spectrogramColor(s.data[newest * bins + bin])
-      const p = y * 4
-      img.data[p] = r
-      img.data[p + 1] = g
-      img.data[p + 2] = b
-      img.data[p + 3] = 255
-    }
-    ctx.putImageData(img, w - 1, 0)
-
-    // Fill the columns that are still empty (before 'filled' reaches width)
-    // with the background color so there is no garbage on the left edge.
-    // New data enters at the right edge (we draw column w-1 each frame), so
-    // before the ring wraps the empty region is the leftmost (w - filled) px.
-    if (s.filled < w) {
-      const bg = spectrogramColor(0)
-      ctx.fillStyle = `rgb(${bg[0]},${bg[1]},${bg[2]})`
-      ctx.fillRect(0, 0, w - s.filled, h)
-    }
-  }, [data])
-
-  // Clear on unmount so a remounted component (e.g. HMR) starts clean.
-  useEffect(() => {
-    return () => {
-      stateRef.current = { bins: 0, width: 0, data: new Float32Array(0), head: 0, filled: 0 }
-    }
-  }, [])
-
-  return (
-    <canvas
-      ref={canvasRef}
-      width={256}
-      height={64}
-      className="h-16 w-full rounded bg-surface-3"
-    />
-  )
-}
-
-/**
- * Mel-scale helpers (same formulas as the reference spectro project):
- * hzToMel / melToHz. Used to spread the low-frequency band (where ambient
- * noise energy concentrates) across more canvas rows.
- */
-function melOf(hz: number): number {
-  return 2595 * Math.log10(1 + hz / 700)
-}
-
-function melInv(mel: number): number {
-  return 700 * (10 ** (mel / 2595) - 1)
-}
-
-/**
- * Viridis-like color ramp for the spectrogram: dark navy -> teal -> green ->
- * yellow -> orange -> red. Matches the perceptual RNNoise demo look (warm
- * highs, cool lows).
- */
-function spectrogramColor(t: number): [number, number, number] {  // 5-stop ramp.
-  const stops: Array<[number, [number, number, number]]> = [
-    [0.0, [16, 18, 60]],
-    [0.25, [24, 117, 156]],
-    [0.5, [42, 173, 140]],
-    [0.75, [220, 197, 75]],
-    [1.0, [220, 80, 50]],
-  ]
-  for (let i = 0; i < stops.length - 1; i++) {
-    const [t0, c0] = stops[i]
-    const [t1, c1] = stops[i + 1]
-    if (t <= t1) {
-      const f = (t - t0) / (t1 - t0)
-      return [
-        Math.round(c0[0] + (c1[0] - c0[0]) * f),
-        Math.round(c0[1] + (c1[1] - c0[1]) * f),
-        Math.round(c0[2] + (c1[2] - c0[2]) * f),
-      ]
-    }
-  }
-  return stops[stops.length - 1][1]
 }

--- a/apps/web/src/components/spectrogram/WebGLSpectrogram.tsx
+++ b/apps/web/src/components/spectrogram/WebGLSpectrogram.tsx
@@ -1,0 +1,160 @@
+/**
+ * React WebGL spectrogram (Spectro-style, ADR-032).
+ *
+ * Wraps {@link SpectrogramWebGLRenderer} in a canvas component. The parent
+ * feeds it one magnitude column per visualization frame (from the AFE
+ * worklet's `spectrogram` field); the component keeps the time history in a
+ * circular Float32 texture on the GPU and renders it with the Spectro
+ * fragment shader (mel frequency axis, sensitivity/contrast, Lab color ramp).
+ *
+ * The frequency resolution is INDEPENDENT of the canvas display height: the
+ * circular buffer stores one row per FFT bin (2048 for the default 4096-sample
+ * window), and the shader's scale texture maps those 2048 rows onto the
+ * canvas with bilinear filtering. This is how the reference Spectro renders
+ * full-resolution spectrograms on a small canvas.
+ *
+ * The renderer runs its own rAF loop; new columns are uploaded lazily on the
+ * next frame (a dirty flag avoids re-uploading unchanged data).
+ */
+
+import { memo, useCallback, useEffect, useRef } from 'react'
+import type { SpectrogramData } from '@wake-studio/module-afe-graph'
+import {
+  HEATED_METAL_GRADIENT,
+  SpectrogramCircularBuffer,
+  SpectrogramWebGLRenderer,
+} from './webgl-spectrogram'
+
+interface Props {
+  /** One Spectro-style column (magnitude bins, bin 0 = DC). */
+  data?: SpectrogramData
+  /** Optional per-stage override of the default render parameters. */
+  sensitivity?: number
+  contrast?: number
+  className?: string
+}
+
+/** Fixed canvas backing size (display; frequency detail lives in the texture). */
+const CANVAS_WIDTH = 256
+const CANVAS_HEIGHT = 64
+
+/**
+ * Reference Spectro's initial look (its settings-panel defaults applied on
+ * mount): sensitivity = 10^(0.5*3)-1 ≈ 30.6, contrast = 10^(0.5*6)-1 = 999,
+ * zoom 4, mel scale, 10 Hz - 12 kHz, heated-metal gradient.
+ */
+const INITIAL_PARAMS = {
+  sensitivity: 30.62,
+  contrast: 999,
+  zoom: 4,
+  minFrequencyHz: 10,
+  maxFrequencyHz: 12000,
+  scale: 'mel' as const,
+  gradient: HEATED_METAL_GRADIENT,
+}
+
+export const WebGLSpectrogram = memo(function WebGLSpectrogram({
+  data,
+  sensitivity,
+  contrast,
+  className,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const rendererRef = useRef<SpectrogramWebGLRenderer | null>(null)
+  const bufferRef = useRef<SpectrogramCircularBuffer | null>(null)
+  const binsRef = useRef(0)
+  const dirtyRef = useRef(false)
+  // StrictMode double-invokes effects with the SAME data reference; enqueueing
+  // the same column twice would advance the ring twice. Key the guard on the
+  // renderer instance so a recreated renderer (StrictMode remount) is never
+  // skipped, but within one renderer's lifetime a repeated reference is.
+  const consumedRef = useRef<{ renderer: object; data: SpectrogramData } | null>(null)
+
+
+  /** Create (or recreate, when the bin count changes) the renderer + buffer. */
+  const ensureRenderer = useCallback((bins: number) => {
+    const canvas = canvasRef.current
+    if (!canvas || bins <= 0) return null
+    if (rendererRef.current && binsRef.current === bins) {
+      return rendererRef.current
+    }
+    rendererRef.current?.dispose()
+    rendererRef.current = null
+    bufferRef.current = null
+    try {
+      const r = new SpectrogramWebGLRenderer(canvas, CANVAS_WIDTH, bins)
+      rendererRef.current = r
+      bufferRef.current = new SpectrogramCircularBuffer(CANVAS_WIDTH, bins)
+      binsRef.current = bins
+      r.updateParameters({ ...INITIAL_PARAMS })
+      // Upload the initial (all-zero) texture so the first frames are
+      // deterministic black, not uninitialized GPU memory.
+      r.updateSpectrogram(bufferRef.current, true)
+      return r
+    } catch (err) {
+      console.warn('[spectrogram] WebGL unavailable:', err)
+      binsRef.current = 0
+      return null
+    }
+  }, [])
+
+  // Mount: run the render loop for the lifetime of the component.
+  useEffect(() => {
+    let rafId = 0
+    const loop = () => {
+      const r = rendererRef.current
+      const b = bufferRef.current
+      if (r && b) {
+        if (dirtyRef.current) {
+          r.updateSpectrogram(b)
+          dirtyRef.current = false
+        }
+        r.render()
+      }
+      rafId = requestAnimationFrame(loop)
+    }
+    rafId = requestAnimationFrame(loop)
+    return () => {
+      cancelAnimationFrame(rafId)
+      rendererRef.current?.dispose()
+      rendererRef.current = null
+      bufferRef.current = null
+      binsRef.current = 0
+    }
+  }, [])
+
+  // Feed new columns into the circular buffer.
+  useEffect(() => {
+    if (!data) return
+    const { column, windowSize, sampleRate } = data
+    if (!column || column.length === 0) return
+    const r = ensureRenderer(column.length)
+    if (!r) return
+    if (consumedRef.current?.renderer === r && consumedRef.current?.data === data) {
+      return // same column twice (StrictMode)
+    }
+    consumedRef.current = { renderer: r, data }
+    r.updateParameters({ windowSize, sampleRate })
+    bufferRef.current?.enqueue(column)
+    dirtyRef.current = true
+  }, [data, ensureRenderer])
+
+  // Live parameter updates (per-stage tuning, e.g. NS more sensitive).
+  useEffect(() => {
+    const r = rendererRef.current
+    if (!r) return
+    const next: { sensitivity?: number; contrast?: number } = {}
+    if (sensitivity !== undefined) next.sensitivity = sensitivity
+    if (contrast !== undefined) next.contrast = contrast
+    r.updateParameters(next)
+  }, [sensitivity, contrast])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_WIDTH}
+      height={CANVAS_HEIGHT}
+      className={className ?? 'h-16 w-full rounded bg-surface-3'}
+    />
+  )
+})

--- a/apps/web/src/components/spectrogram/webgl-spectrogram.ts
+++ b/apps/web/src/components/spectrogram/webgl-spectrogram.ts
@@ -1,0 +1,745 @@
+/**
+ * WebGL spectrogram renderer (Spectro-style, ADR-032).
+ *
+ * A direct TypeScript port of the reference Spectro visualizer's GPU renderer
+ * (https://github.com/calebj0seph/spectro - MIT):
+ *
+ *   - The spectrogram time history lives in a **circular Float32 texture**
+ *     whose width equals the canvas width (one column per pixel). Only the new
+ *     columns are uploaded each frame (`texSubImage2D`), so rendering never
+ *     re-uploads the whole history.
+ *   - A fullscreen-quad **fragment shader** maps each screen pixel to a
+ *     (frequency, time) sample via two lookup textures: a frequency **scale
+ *     texture** (linear or mel) and a **gradient texture** (Lab-interpolated
+ *     color ramp). Sensitivity, contrast and zoom are uniforms applied on the
+ *     GPU, so live parameter changes are cheap and smooth.
+ *   - The circular wrap is handled in the shader with `mod()`, matching the
+ *     reference (non-power-of-two textures cannot use REPEAT wrapping).
+ *
+ * The web app uses this instead of the old 2D-canvas per-pixel renderer: GPU
+ * scaling/colorization is what makes the spectrogram look like the reference.
+ *
+ * WebGL1 + `OES_texture_float` + `OES_texture_float_linear` are required (no
+ * WebGL2 dependency) so it runs everywhere the reference runs.
+ */
+
+export type SpectrogramScale = 'linear' | 'mel'
+
+export interface SpectrogramRenderParameters {
+  /** Multiplicative gain applied to FFT magnitudes before colorizing. */
+  sensitivity: number
+  /** log(1 + i*c)/log(1+c) contrast curve. */
+  contrast: number
+  /** Time-axis zoom (how many columns per screen pixel). */
+  zoom: number
+  /** Lowest displayed frequency in Hz. */
+  minFrequencyHz: number
+  /** Highest displayed frequency in Hz. */
+  maxFrequencyHz: number
+  /** Sample rate the columns were computed at. */
+  sampleRate: number
+  /** FFT window size the columns were computed with. */
+  windowSize: number
+  /** Frequency-axis scale (mel gives more weight to lower frequencies). */
+  scale: SpectrogramScale
+  /** Color gradient (Lab-interpolated stops). */
+  gradient: SpectrogramGradient
+}
+
+/** Gradient stops: [position, [r, g, b]] (0..255 each). */
+export type SpectrogramGradient = ReadonlyArray<readonly [number, [number, number, number]]>
+
+/** Heated-metal default (matches the reference Spectro look). */
+export const HEATED_METAL_GRADIENT: SpectrogramGradient = [
+  [0.0, [0, 0, 0]],
+  [0.3, [128, 0, 128]],
+  [0.65, [255, 0, 0]],
+  [0.9, [255, 255, 0]],
+  [1.0, [255, 255, 255]],
+]
+
+/** Audacity-style gradient (from the reference's color-util). */
+export const AUDACITY_GRADIENT: SpectrogramGradient = [
+  [0.0, [191, 191, 191]],
+  [0.25, [76, 153, 255]],
+  [0.5, [229, 25, 229]],
+  [0.75, [255, 0, 0]],
+  [1.0, [255, 255, 255]],
+]
+
+const VERTEX_SHADER = `
+attribute vec4 aVertexPos;
+attribute vec2 aVertexTexCoord;
+varying vec2 vVertexTexCoord;
+void main() {
+  gl_Position = aVertexPos;
+  vVertexTexCoord = aVertexTexCoord;
+}
+`
+
+const FRAGMENT_SHADER = `
+precision highp float;
+
+uniform sampler2D uSpectrogramSampler;
+uniform sampler2D uScaleSampler;
+uniform sampler2D uGradientSampler;
+uniform float uSpectrogramOffset;
+uniform float uSpectrogramLength;
+uniform vec2 uScaleRange;
+uniform float uContrast;
+uniform float uSensitivity;
+uniform float uZoom;
+varying vec2 vVertexTexCoord;
+
+void main() {
+    float sampleX = texture2D(
+        uScaleSampler,
+        vec2(
+            0.0,
+            uScaleRange.y - uScaleRange.y * vVertexTexCoord.y + uScaleRange.x * vVertexTexCoord.y
+        )
+    ).r;
+
+    float sampleY = mod(
+        clamp((vVertexTexCoord.x - 1.0) / uZoom + uSpectrogramLength, 0.0, 1.0) + uSpectrogramOffset,
+        1.0
+    );
+
+    float intensity = clamp(
+        texture2D(uSpectrogramSampler, vec2(sampleX, sampleY)).r * uSensitivity,
+        0.0,
+        1.0
+    );
+    if (uContrast > 0.0) {
+        intensity = log(1.0 + intensity * uContrast) / log(1.0 + uContrast);
+    }
+
+    // Prevent wrapping issues when the spectrogram is smaller than the screen
+    if ((vVertexTexCoord.x - 1.0) / uZoom + uSpectrogramLength <= 0.0) {
+        intensity = 0.0;
+    }
+
+    vec3 color = texture2D(uGradientSampler, vec2(0.0, intensity)).rgb;
+    gl_FragColor = vec4(color.r, color.g, color.b, 1.0);
+}
+`
+
+/** A circular 2D buffer of Float32 columns (matches Spectro's Circular2DBuffer). */
+export class SpectrogramCircularBuffer {
+  /** Number of columns (time axis, = texture width). */
+  width: number
+  /** Number of rows (frequency bins, = texture height). */
+  height: number
+  start = 0
+  length = 0
+  data: Float32Array
+
+  constructor(width: number, height: number) {
+    this.width = width
+    this.height = height
+    this.data = new Float32Array(width * height)
+  }
+
+  enqueue(column: Float32Array): void {
+    const col = column.length <= this.height ? column : column.subarray(0, this.height)
+    const x = (this.start + this.length) % this.width
+    this.data.set(col, x * this.height)
+    this.length += 1
+    if (this.length > this.width) {
+      this.start = (this.start + this.length - this.width) % this.width
+      this.length = this.width
+    }
+  }
+
+  clear(): void {
+    this.data.fill(0)
+    this.start = 0
+    this.length = 0
+  }
+}
+
+export class SpectrogramWebGLRenderer {
+  private readonly canvas: HTMLCanvasElement
+  private readonly ctx: WebGLRenderingContext
+
+  private readonly program: {
+    program: WebGLProgram
+    positionAttribute: number
+    texCoordAttribute: number
+    spectrogramSampler: WebGLUniformLocation
+    scaleSampler: WebGLUniformLocation
+    gradientSampler: WebGLUniformLocation
+    spectrogramOffset: WebGLUniformLocation
+    spectrogramLength: WebGLUniformLocation
+    scaleRange: WebGLUniformLocation
+    contrast: WebGLUniformLocation
+    sensitivity: WebGLUniformLocation
+    zoom: WebGLUniformLocation
+  }
+
+  private vertexBuffer: WebGLBuffer
+  private indexBuffer: WebGLBuffer
+
+  private spectrogramTexture: WebGLTexture | null = null
+  private scaleTexture: WebGLTexture | null = null
+  private gradientTexture: WebGLTexture | null = null
+
+  private spectrogramHeight: number
+
+  private spectrogramLength = 0
+  private spectrogramOffset = 0
+  private lastSpectrogramStart: number | null = null
+  private lastSpectrogramLength = 0
+
+  private parameters: SpectrogramRenderParameters | null = null
+  private scaleRange: [number, number] = [0, 0]
+  private currentScaleRange: [number, number] = [0, 0]
+  private currentContrast = 25
+  private currentSensitivity = 25
+  private currentZoom = 4
+
+  private resizeHandlerZoomOverride = 1
+  private resizeHandlerLastRealWidth = 0
+
+  constructor(canvas: HTMLCanvasElement, width: number, height: number) {
+    this.canvas = canvas
+    const ctx = canvas.getContext('webgl') as WebGLRenderingContext | null
+    if (ctx === null) {
+      throw new Error('Unable to create WebGL context')
+    }
+    this.ctx = ctx
+
+    if (ctx.getExtension('OES_texture_float') === null) {
+      throw new Error('OES_texture_float extension is not supported')
+    }
+    if (ctx.getExtension('OES_texture_float_linear') === null) {
+      throw new Error('OES_texture_float_linear extension is not supported')
+    }
+
+    const program = this.loadProgram(VERTEX_SHADER, FRAGMENT_SHADER)
+    this.program = {
+      program,
+      positionAttribute: ctx.getAttribLocation(program, 'aVertexPos'),
+      texCoordAttribute: ctx.getAttribLocation(program, 'aVertexTexCoord'),
+      spectrogramSampler: this.getUniformLocation(program, 'uSpectrogramSampler'),
+      scaleSampler: this.getUniformLocation(program, 'uScaleSampler'),
+      gradientSampler: this.getUniformLocation(program, 'uGradientSampler'),
+      spectrogramOffset: this.getUniformLocation(program, 'uSpectrogramOffset'),
+      spectrogramLength: this.getUniformLocation(program, 'uSpectrogramLength'),
+      scaleRange: this.getUniformLocation(program, 'uScaleRange'),
+      contrast: this.getUniformLocation(program, 'uContrast'),
+      sensitivity: this.getUniformLocation(program, 'uSensitivity'),
+      zoom: this.getUniformLocation(program, 'uZoom'),
+    }
+
+    const [vertexBuffer, indexBuffer] = this.createFullscreenQuad()
+    this.vertexBuffer = vertexBuffer
+    this.indexBuffer = indexBuffer
+
+    ctx.pixelStorei(ctx.UNPACK_ALIGNMENT, 1)
+
+    this.spectrogramHeight = height
+    this.spectrogramTexture = this.createSpectrogramTexture(height, width)
+
+    this.updateParameters({})
+  }
+
+  // ---- public API ----
+
+  render(): void {
+    const { ctx, program } = this
+    ctx.clearColor(0.0, 0.0, 0.0, 1.0)
+    ctx.clear(ctx.COLOR_BUFFER_BIT)
+
+    ctx.bindBuffer(ctx.ARRAY_BUFFER, this.vertexBuffer)
+    ctx.bindBuffer(ctx.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
+
+    ctx.vertexAttribPointer(program.positionAttribute, 2, ctx.FLOAT, false, 16, 0)
+    ctx.enableVertexAttribArray(program.positionAttribute)
+    ctx.vertexAttribPointer(program.texCoordAttribute, 2, ctx.FLOAT, false, 16, 8)
+    ctx.enableVertexAttribArray(program.texCoordAttribute)
+
+    ctx.useProgram(program.program)
+    ctx.uniform1f(program.spectrogramOffset, this.spectrogramOffset)
+    ctx.uniform1f(program.spectrogramLength, this.spectrogramLength)
+
+    // Smooth parameter changes (LERP toward target each frame).
+    const LERP_AMOUNT = 0.5
+    const params = this.parameters!
+    this.currentScaleRange = [
+      stepTowards(this.currentScaleRange[0], this.scaleRange[0], LERP_AMOUNT),
+      stepTowards(this.currentScaleRange[1], this.scaleRange[1], LERP_AMOUNT),
+    ]
+    this.currentContrast = stepTowards(this.currentContrast, params.contrast, LERP_AMOUNT)
+    if (this.currentContrast < 0.05) this.currentContrast = 0.0
+    this.currentSensitivity = stepTowards(this.currentSensitivity, params.sensitivity, LERP_AMOUNT)
+    this.currentZoom = stepTowards(this.currentZoom, params.zoom, LERP_AMOUNT)
+
+    ctx.uniform2fv(program.scaleRange, this.currentScaleRange)
+    ctx.uniform1f(program.contrast, this.currentContrast)
+    ctx.uniform1f(program.sensitivity, this.currentSensitivity)
+    ctx.uniform1f(program.zoom, this.resizeHandlerZoomOverride * this.currentZoom)
+
+    ctx.activeTexture(ctx.TEXTURE0)
+    ctx.bindTexture(ctx.TEXTURE_2D, this.spectrogramTexture)
+    ctx.uniform1i(program.spectrogramSampler, 0)
+
+    ctx.activeTexture(ctx.TEXTURE1)
+    ctx.bindTexture(ctx.TEXTURE_2D, this.scaleTexture)
+    ctx.uniform1i(program.scaleSampler, 1)
+
+    ctx.activeTexture(ctx.TEXTURE2)
+    ctx.bindTexture(ctx.TEXTURE_2D, this.gradientTexture)
+    ctx.uniform1i(program.gradientSampler, 2)
+
+    ctx.drawElements(ctx.TRIANGLES, 6, ctx.UNSIGNED_SHORT, 0)
+  }
+
+  /** Full resize (called on window resize, debounced). */
+  resizeCanvas(width: number, height: number): void {
+    this.lastSpectrogramStart = null
+    this.resizeHandlerZoomOverride = 1
+    this.resizeHandlerLastRealWidth = width
+    this.canvas.width = width
+    this.canvas.height = height
+    this.ctx.viewport(0, 0, width, height)
+  }
+
+  /** Fast resize (mid-drag: preserve the zoom-relative time mapping). */
+  fastResizeCanvas(width: number, height: number): void {
+    this.resizeHandlerZoomOverride = this.resizeHandlerLastRealWidth / width
+    this.canvas.width = width
+    this.canvas.height = height
+    this.ctx.viewport(0, 0, width, height)
+  }
+
+  updateParameters(partial: Partial<SpectrogramRenderParameters>): void {
+    const p = this.parameters
+    const next: SpectrogramRenderParameters = {
+      sensitivity: merge(partial.sensitivity, p?.sensitivity, 25),
+      contrast: merge(partial.contrast, p?.contrast, 25),
+      zoom: merge(partial.zoom, p?.zoom, 4),
+      minFrequencyHz: merge(partial.minFrequencyHz, p?.minFrequencyHz, 10),
+      maxFrequencyHz: merge(partial.maxFrequencyHz, p?.maxFrequencyHz, 12000),
+      sampleRate: merge(partial.sampleRate, p?.sampleRate, 48000),
+      windowSize: merge(partial.windowSize, p?.windowSize, 4096),
+      scale: merge(partial.scale, p?.scale, 'mel'),
+      gradient: merge(partial.gradient, p?.gradient, HEATED_METAL_GRADIENT),
+    }
+
+    if (p === null || p.gradient !== next.gradient) {
+      this.updateGradientTexture(next.gradient)
+    }
+
+    const freqParamsChanged =
+      p === null ||
+      p.scale !== next.scale ||
+      p.minFrequencyHz !== next.minFrequencyHz ||
+      p.maxFrequencyHz !== next.maxFrequencyHz ||
+      p.sampleRate !== next.sampleRate ||
+      p.windowSize !== next.windowSize
+
+    if (freqParamsChanged) {
+      this.updateScaleRange(
+        next.scale,
+        next.minFrequencyHz,
+        next.maxFrequencyHz,
+        next.sampleRate,
+        next.windowSize,
+      )
+    }
+
+    const scaleParamsChanged =
+      p === null ||
+      p.scale !== next.scale ||
+      p.sampleRate !== next.sampleRate ||
+      p.windowSize !== next.windowSize
+
+    if (scaleParamsChanged) {
+      this.updateScaleTexture(next.scale, next.sampleRate, next.windowSize)
+      this.currentScaleRange = this.scaleRange
+    }
+
+    this.parameters = next
+  }
+
+  /** Upload new columns to the circular texture (only the new columns). */
+  updateSpectrogram(buffer: SpectrogramCircularBuffer, forceFull = false): void {
+    const { ctx } = this
+    const texture = this.spectrogramTexture!
+    ctx.bindTexture(ctx.TEXTURE_2D, texture)
+
+    if (forceFull || this.lastSpectrogramStart === null) {
+      ctx.texImage2D(
+        ctx.TEXTURE_2D,
+        0,
+        ctx.LUMINANCE,
+        buffer.height,
+        buffer.width,
+        0,
+        ctx.LUMINANCE,
+        ctx.FLOAT,
+        buffer.data,
+      )
+    } else if (buffer.start !== this.lastSpectrogramStart) {
+      if (buffer.start >= this.lastSpectrogramStart) {
+        this.updateSpectrogramPartial(
+          buffer.height,
+          buffer.start - this.lastSpectrogramStart,
+          this.lastSpectrogramStart,
+          buffer.data,
+        )
+      } else {
+        this.updateSpectrogramPartial(buffer.height, buffer.start, 0, buffer.data)
+        this.updateSpectrogramPartial(
+          buffer.height,
+          buffer.width - this.lastSpectrogramStart,
+          this.lastSpectrogramStart,
+          buffer.data,
+        )
+      }
+    } else if (buffer.length > this.lastSpectrogramLength) {
+      this.updateSpectrogramPartial(
+        buffer.height,
+        buffer.length - this.lastSpectrogramLength,
+        this.lastSpectrogramLength,
+        buffer.data,
+      )
+    }
+
+    this.lastSpectrogramLength = buffer.length
+    this.lastSpectrogramStart = buffer.start
+    this.spectrogramOffset = buffer.start / buffer.width
+    this.spectrogramLength =
+      -0.5 / buffer.width + buffer.length / buffer.width
+  }
+
+  /** Recreate the circular texture at a new width (history preserved). */
+  resizeSpectrogramBuffer(buffer: SpectrogramCircularBuffer, newWidth: number): void {
+    if (newWidth === buffer.width) return
+    // Rebuild the buffer preserving the newest columns (Spectro's resizeWidth).
+    const newData = new Float32Array(newWidth * buffer.height)
+    for (let i = 0; i < Math.min(buffer.length, newWidth); i++) {
+      const newX = Math.min(buffer.length, newWidth) - i - 1
+      const oldX = (buffer.start + buffer.length - i - 1) % buffer.width
+      newData.set(
+        buffer.data.subarray(oldX * buffer.height, (oldX + 1) * buffer.height),
+        newX * buffer.height,
+      )
+    }
+    buffer.data = newData
+    buffer.width = newWidth
+    if (buffer.length >= newWidth) buffer.length = newWidth
+    buffer.start = 0
+    this.lastSpectrogramStart = null
+  }
+
+  dispose(): void {
+    const { ctx } = this
+    for (const tex of [this.spectrogramTexture, this.scaleTexture, this.gradientTexture]) {
+      if (tex) ctx.deleteTexture(tex)
+    }
+    ctx.deleteBuffer(this.vertexBuffer)
+    ctx.deleteBuffer(this.indexBuffer)
+    ctx.deleteProgram(this.program.program)
+    this.spectrogramTexture = null
+    this.scaleTexture = null
+    this.gradientTexture = null
+  }
+
+  // ---- internals ----
+
+  private updateSpectrogramPartial(
+    width: number,
+    height: number,
+    dataStart: number,
+    data: Float32Array,
+  ): void {
+    // The texture is laid out transposed relative to the circular buffer:
+    //   texture.x = frequency bin (bins wide), texture.y = column (columns
+    //   tall), while the buffer stores columns contiguously as
+    //   data[column * bins + bin]. A sub-image therefore spans
+    //   x:[0, bins) x y:[dataStart, dataStart + columnCount), which is the
+    //   data range [dataStart*bins, (dataStart+columnCount)*bins).
+    this.ctx.texSubImage2D(
+      this.ctx.TEXTURE_2D,
+      0,
+      0,
+      dataStart,
+      width,
+      height,
+      this.ctx.LUMINANCE,
+      this.ctx.FLOAT,
+      data.subarray(dataStart * width, (dataStart + height) * width),
+    )
+  }
+
+  private getUniformLocation(program: WebGLProgram, name: string): WebGLUniformLocation {
+    const location = this.ctx.getUniformLocation(program, name)
+    if (location === null) {
+      throw new Error(`Could not get uniform location for ${name}`)
+    }
+    return location
+  }
+
+  private loadProgram(vertexSrc: string, fragmentSrc: string): WebGLProgram {
+    const vertex = this.loadShader(this.ctx.VERTEX_SHADER, vertexSrc)
+    const fragment = this.loadShader(this.ctx.FRAGMENT_SHADER, fragmentSrc)
+    const program = this.ctx.createProgram()
+    if (!program) throw new Error('Failed to create program')
+    this.ctx.attachShader(program, vertex)
+    this.ctx.attachShader(program, fragment)
+    this.ctx.linkProgram(program)
+    if (!this.ctx.getProgramParameter(program, this.ctx.LINK_STATUS)) {
+      const error = this.ctx.getProgramInfoLog(program)
+      this.ctx.deleteProgram(program)
+      throw new Error(`Failed to link program:\n${error}`)
+    }
+    return program
+  }
+
+  private loadShader(type: number, src: string): WebGLShader {
+    const shader = this.ctx.createShader(type)
+    if (!shader) throw new Error('Could not create shader')
+    this.ctx.shaderSource(shader, src)
+    this.ctx.compileShader(shader)
+    if (!this.ctx.getShaderParameter(shader, this.ctx.COMPILE_STATUS)) {
+      const error = this.ctx.getShaderInfoLog(shader)
+      this.ctx.deleteShader(shader)
+      throw new Error(`Failed to compile shader:\n${error}`)
+    }
+    return shader
+  }
+
+  private createFullscreenQuad(): [WebGLBuffer, WebGLBuffer] {
+    const { ctx } = this
+    const vertexBuffer = ctx.createBuffer()
+    const indexBuffer = ctx.createBuffer()
+    if (!vertexBuffer || !indexBuffer) throw new Error('Could not create buffers')
+
+    ctx.bindBuffer(ctx.ARRAY_BUFFER, vertexBuffer)
+    ctx.bufferData(
+      ctx.ARRAY_BUFFER,
+      new Float32Array([
+        // (x, y, u, v)
+        -1.0, 1.0, 0.0, 0.0,
+        -1.0, -1.0, 0.0, 1.0,
+        1.0, -1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0, 0.0,
+      ]),
+      ctx.STATIC_DRAW,
+    )
+
+    ctx.bindBuffer(ctx.ELEMENT_ARRAY_BUFFER, indexBuffer)
+    ctx.bufferData(ctx.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 3, 2, 3, 1]), ctx.STATIC_DRAW)
+
+    return [vertexBuffer, indexBuffer]
+  }
+
+  private createSpectrogramTexture(width: number, height: number): WebGLTexture {
+    const { ctx } = this
+    const texture = ctx.createTexture()
+    if (!texture) throw new Error('Could not create texture')
+
+    ctx.bindTexture(ctx.TEXTURE_2D, texture)
+    ctx.texImage2D(
+      ctx.TEXTURE_2D,
+      0,
+      ctx.LUMINANCE,
+      width,
+      height,
+      0,
+      ctx.LUMINANCE,
+      ctx.FLOAT,
+      new Float32Array(width * height),
+    )
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_WRAP_S, ctx.CLAMP_TO_EDGE)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_WRAP_T, ctx.CLAMP_TO_EDGE)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MIN_FILTER, ctx.LINEAR)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MAG_FILTER, ctx.LINEAR)
+    return texture
+  }
+
+  private updateScaleRange(
+    scale: SpectrogramScale,
+    minFrequencyHz: number,
+    maxFrequencyHz: number,
+    sampleRate: number,
+    windowSize: number,
+  ): void {
+    const peakHz = (sampleRate * (windowSize - 2)) / (2 * windowSize)
+    switch (scale) {
+      case 'linear':
+        this.scaleRange = [minFrequencyHz / peakHz, maxFrequencyHz / peakHz]
+        break
+      case 'mel':
+        this.scaleRange = [
+          Math.log(1 + minFrequencyHz / 700) / Math.log(1 + peakHz / 700),
+          Math.log(1 + maxFrequencyHz / 700) / Math.log(1 + peakHz / 700),
+        ]
+        break
+    }
+  }
+
+  private updateScaleTexture(scale: SpectrogramScale, sampleRate: number, windowSize: number): void {
+    const { ctx } = this
+    const buffer = new Float32Array(this.spectrogramHeight)
+    for (let i = 0; i < this.spectrogramHeight; i++) {
+      switch (scale) {
+        case 'linear':
+          buffer[i] = i / (this.spectrogramHeight - 1)
+          break
+        case 'mel': {
+          const peakHz = (sampleRate * (windowSize - 2)) / (2 * windowSize)
+          buffer[i] =
+            (700 * ((1 + peakHz / 700) ** (i / (this.spectrogramHeight - 1)) - 1)) / peakHz
+          break
+        }
+      }
+    }
+
+    if (this.scaleTexture === null) {
+      this.scaleTexture = ctx.createTexture()
+    }
+    ctx.bindTexture(ctx.TEXTURE_2D, this.scaleTexture)
+    ctx.texImage2D(
+      ctx.TEXTURE_2D,
+      0,
+      ctx.LUMINANCE,
+      1,
+      this.spectrogramHeight,
+      0,
+      ctx.LUMINANCE,
+      ctx.FLOAT,
+      buffer,
+    )
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_WRAP_S, ctx.CLAMP_TO_EDGE)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_WRAP_T, ctx.CLAMP_TO_EDGE)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MIN_FILTER, ctx.LINEAR)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MAG_FILTER, ctx.LINEAR)
+  }
+
+  private updateGradientTexture(gradient: SpectrogramGradient): void {
+    const { ctx } = this
+    const SIZE = 128
+    const buffer = new Uint8Array(SIZE * 3)
+    for (let i = 0; i < SIZE; i++) {
+      const [r, g, b] = colorRampLab(i / (SIZE - 1), gradient)
+      buffer[i * 3] = r
+      buffer[i * 3 + 1] = g
+      buffer[i * 3 + 2] = b
+    }
+
+    if (this.gradientTexture === null) {
+      this.gradientTexture = ctx.createTexture()
+    }
+    ctx.bindTexture(ctx.TEXTURE_2D, this.gradientTexture)
+    ctx.texImage2D(
+      ctx.TEXTURE_2D,
+      0,
+      ctx.RGB,
+      1,
+      SIZE,
+      0,
+      ctx.RGB,
+      ctx.UNSIGNED_BYTE,
+      buffer,
+    )
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_WRAP_S, ctx.CLAMP_TO_EDGE)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_WRAP_T, ctx.CLAMP_TO_EDGE)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MIN_FILTER, ctx.LINEAR)
+    ctx.texParameteri(ctx.TEXTURE_2D, ctx.TEXTURE_MAG_FILTER, ctx.LINEAR)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (ported from the reference math-util/color-util)
+// ---------------------------------------------------------------------------
+
+function merge<T>(newValue: T | undefined, oldValue: T | undefined, defaultValue: T): T {
+  if (newValue !== undefined) return newValue
+  if (oldValue !== undefined) return oldValue
+  return defaultValue
+}
+
+function stepTowards(x: number, y: number, amount: number): number {
+  if (Math.abs(x - y) < 1e-9) return y
+  return x + amount * (y - x)
+}
+
+// --- Lab-interpolated color ramp (reference color-util) ---
+
+function addGamma(u: number): number {
+  if (u <= 0.0031308) return 12.92 * u
+  return 1.055 * u ** (1 / 2.4) - 0.055
+}
+
+function removeGamma(u: number): number {
+  if (u <= 0.04045) return u / 12.92
+  return ((u + 0.055) / 1.055) ** 2.4
+}
+
+function fLab(t: number): number {
+  const x = 6 / 29
+  if (t > x ** 3) return t ** (1 / 3)
+  return t / (3 * x * x) + 4 / 29
+}
+
+function fLabInverse(t: number): number {
+  const x = 6 / 29
+  if (t > x) return t ** 3
+  return 3 * x * x * (t - 4 / 29)
+}
+
+function rgbToLab(r: number, g: number, b: number): [number, number, number] {
+  const lR = removeGamma(r / 255)
+  const lG = removeGamma(g / 255)
+  const lB = removeGamma(b / 255)
+  const x = 0.4124 * lR + 0.3576 * lG + 0.1805 * lB
+  const y = 0.2126 * lR + 0.7152 * lG + 0.0722 * lB
+  const z = 0.0193 * lR + 0.1192 * lG + 0.9505 * lB
+  return [
+    116 * fLab(y / 100) - 16,
+    500 * (fLab(x / 95.0489) - fLab(y / 100)),
+    200 * (fLab(y / 100) - fLab(z / 108.884)),
+  ]
+}
+
+function labToRgb(l: number, a: number, b: number): [number, number, number] {
+  const x = 95.0489 * fLabInverse((l + 16) / 116 + a / 500)
+  const y = 100 * fLabInverse((l + 16) / 116)
+  const z = 108.884 * fLabInverse((l + 16) / 116 - b / 200)
+  const lR = 3.2406 * x - 1.5372 * y - 0.4986 * z
+  const lG = -0.9689 * x + 1.8758 * y + 0.0415 * z
+  const lB = 0.0557 * x - 0.204 * y + 1.057 * z
+  return [
+    Math.floor(Math.min(255, Math.max(0, 256 * addGamma(lR)))),
+    Math.floor(Math.min(255, Math.max(0, 256 * addGamma(lG)))),
+    Math.floor(Math.min(255, Math.max(0, 256 * addGamma(lB)))),
+  ]
+}
+
+function colorRampLab(x: number, gradient: SpectrogramGradient): [number, number, number] {
+  const t = Math.min(1, Math.max(0, x))
+  let startIdx = 0
+  let endIdx = 0
+  for (let i = 0; i < gradient.length; i++) {
+    if (gradient[i][0] >= t) {
+      endIdx = i
+      startIdx = i > 0 ? i - 1 : endIdx
+      break
+    }
+  }
+  const local =
+    startIdx === endIdx
+      ? 0
+      : (t - gradient[startIdx][0]) / (gradient[endIdx][0] - gradient[startIdx][0])
+  const ease = (u: number) => (u < 0.5 ? 2 * u * u : -1 + (4 - 2 * u) * u)
+  const start = rgbToLab(...gradient[startIdx][1])
+  const end = rgbToLab(...gradient[endIdx][1])
+  return labToRgb(
+    start[0] + (end[0] - start[0]) * ease(local),
+    start[1] + (end[1] - start[1]) * ease(local),
+    start[2] + (end[2] - start[2]) * ease(local),
+  )
+}

--- a/packages/dsp/src/index.ts
+++ b/packages/dsp/src/index.ts
@@ -17,6 +17,7 @@ export {
   hannSymmetric,
   hamming,
   blackman,
+  blackmanHarris7,
   applyWindow,
 } from './windows'
 
@@ -32,6 +33,15 @@ export {
   SPECTRUM_BINS,
   HANN_WINDOW,
 } from './spectrum'
+
+export {
+  spectrogramColumn,
+  SPECTROGRAM_WINDOW_SIZE,
+  SPECTROGRAM_WINDOW_STEP,
+  SPECTROGRAM_BINS,
+  SPECTROGRAM_WINDOW,
+} from './spectrogram'
+export type { SpectrogramColumnOptions } from './spectrogram'
 
 export {
   downsample48to16,

--- a/packages/dsp/src/spectrogram.ts
+++ b/packages/dsp/src/spectrogram.ts
@@ -1,0 +1,101 @@
+/**
+ * Spectrogram column generation (Spectro-style, ADR-032).
+ *
+ * Generates a single FFT column for a real-time scrolling spectrogram, ported
+ * from the reference Spectro visualizer
+ * (https://github.com/calebj0seph/spectro - MIT):
+ *
+ *   - Frames of `windowSize` samples (default 4096) are windowed with the
+ *     seven-term Blackman-Harris window and run through an FFT.
+ *   - The magnitude of each bin is normalized by `sqrt(windowSize)` (NOT
+ *     `windowSize`) - this lifts typical ambient noise into the visible range
+ *     of the renderer's color ramp while keeping speech well separated.
+ *   - Columns are produced at a fixed `columnStep` cadence from the most
+ *     recent samples (streaming mode), so a live worklet can emit one column
+ *     per visualization frame without buffering a full window.
+ *
+ * Unlike the reference's batch `generateSpectrogram`, this emits a single
+ * column (newest `windowSize` samples) and leaves the time-axis history to the
+ * renderer's circular texture - the exact split the live AFE worklet needs.
+ */
+
+import { createFft } from './fft'
+import { blackmanHarris7 } from './windows'
+
+/** Default FFT window size in samples (~85 ms @ 48 kHz). */
+export const SPECTROGRAM_WINDOW_SIZE = 4096
+
+/** Default hop between FFT windows (4x overlap, Spectro default). */
+export const SPECTROGRAM_WINDOW_STEP = 1024
+
+/** Number of magnitude bins per column = windowSize / 2. */
+export const SPECTROGRAM_BINS = SPECTROGRAM_WINDOW_SIZE / 2
+
+/** Pre-computed 7-term Blackman-Harris window (Spectro default). */
+export const SPECTROGRAM_WINDOW = blackmanHarris7(SPECTROGRAM_WINDOW_SIZE)
+
+export interface SpectrogramColumnOptions {
+  /** FFT window size in samples. Must be a power of 2. Default 4096. */
+  windowSize?: number
+  /** Sample rate (Hz) used only for metadata; does not change the FFT. */
+  sampleRate?: number
+}
+
+/**
+ * Compute a single magnitude-spectrogram column from the most recent
+ * `windowSize` samples of `frame` (zero-padded if shorter).
+ *
+ * The column is laid out with bin 0 (DC / lowest frequency) at index 0 and the
+ * Nyquist bin at index windowSize/2 - 1, matching the renderer's frequency
+ * axis (which maps canvas rows to bins via the selected scale).
+ *
+ * @returns the magnitude column (length windowSize/2), plus the actual window
+ *   size and sample rate used (the renderer needs them to map Hz -> bins).
+ */
+export function spectrogramColumn(
+  frame: Float32Array,
+  opts: SpectrogramColumnOptions = {},
+): { column: Float32Array; windowSize: number; sampleRate: number } {
+  const windowSize = opts.windowSize ?? SPECTROGRAM_WINDOW_SIZE
+  if (windowSize <= 0 || (windowSize & (windowSize - 1)) !== 0) {
+    throw new Error(`spectrogram windowSize must be a power of 2, got ${windowSize}`)
+  }
+  const sampleRate = opts.sampleRate ?? 48000
+
+  // Pre-compute the window for this size (cached per size).
+  const window = getWindow(windowSize)
+  const real = new Float32Array(windowSize)
+  const imag = new Float32Array(windowSize)
+  const n = Math.min(frame.length, windowSize)
+  for (let i = 0; i < n; i++) {
+    real[i] = frame[i] * window[i]
+  }
+  // Remaining samples stay 0 (zero-padding) - the window already tapers to
+  // near zero at both ends, so this matches a centered-window FFT closely.
+
+  const fft = createFft(windowSize)
+  fft.transform(real, imag)
+
+  const bins = windowSize / 2
+  const column = new Float32Array(bins)
+  const invSqrtN = 1 / Math.sqrt(windowSize)
+  for (let k = 0; k < bins; k++) {
+    column[k] = Math.sqrt(real[k] * real[k] + imag[k] * imag[k]) * invSqrtN
+  }
+  return { column, windowSize, sampleRate }
+}
+
+// ---------------------------------------------------------------------------
+// Per-size window cache (only ever a handful of sizes).
+// ---------------------------------------------------------------------------
+
+const windowCache = new Map<number, Float32Array>()
+
+function getWindow(size: number): Float32Array {
+  let w = windowCache.get(size)
+  if (!w) {
+    w = blackmanHarris7(size)
+    windowCache.set(size, w)
+  }
+  return w
+}

--- a/packages/dsp/src/windows.ts
+++ b/packages/dsp/src/windows.ts
@@ -40,6 +40,40 @@ export function blackman(len: number): Float32Array {
   return out
 }
 
+/**
+ * Seven-term Blackman-Harris window (symmetrical, Nuttall-style).
+ *
+ * Coefficients from the reference Spectro visualizer
+ * (https://github.com/calebj0seph/spectro), which chose this window for its
+ * minimal sidelobes (best visual clarity for spectrograms):
+ *
+ *    w[n] = a0 - a1*cos(2πn/N) + a2*cos(4πn/N) - a3*cos(6πn/N)
+ *         + a4*cos(8πn/N) - a5*cos(10πn/N) + a6*cos(12πn/N)
+ *
+ * The spectrogram column generator (spectrogramColumn) uses this window with
+ * an overlapping STFT to balance time/frequency resolution.
+ */
+export function blackmanHarris7(len: number): Float32Array {
+  const COEFFICIENTS = [
+    0.27105140069342,
+    -0.43329793923448,
+    0.21812299954311,
+    -0.06592544638803,
+    0.01081174209837,
+    -0.00077658482522,
+    0.00001388721735,
+  ]
+  const out = new Float32Array(len)
+  for (let i = 0; i < len; i++) {
+    let result = 0
+    for (let k = 0; k < COEFFICIENTS.length; k++) {
+      result += COEFFICIENTS[k] * Math.cos((2 * Math.PI * k * i) / len)
+    }
+    out[i] = result
+  }
+  return out
+}
+
 /** Apply a window in place (element-wise multiply). */
 export function applyWindow(frame: Float32Array, window: Float32Array): void {
   const n = Math.min(frame.length, window.length)

--- a/packages/dsp/tests/behavior.test.ts
+++ b/packages/dsp/tests/behavior.test.ts
@@ -21,6 +21,10 @@ import {
   FFT_SIZE,
   SPECTRUM_BINS,
   HANN_WINDOW,
+  spectrogramColumn,
+  SPECTROGRAM_WINDOW_SIZE,
+  SPECTROGRAM_BINS,
+  SPECTROGRAM_WINDOW,
 } from '../src'
 
 // fft()
@@ -320,5 +324,92 @@ describe('HANN_WINDOW', () => {
     // Hann formula: 0.5*(1 - cos(2*pi*i/(N-1))). At i=N/2, the cosine isn't
     // exactly -1 (because N/2 / (N-1) != 0.5), so the peak is ~0.99996.
     expect(HANN_WINDOW[FFT_SIZE / 2]).toBeCloseTo(1.0, 4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// spectrogramColumn() (Spectro-style, ADR-032)
+// ---------------------------------------------------------------------------
+
+describe('spectrogramColumn', () => {
+  it('returns SPECTROGRAM_BINS values at the default window size', () => {
+    const frame = constant(0, SPECTROGRAM_WINDOW_SIZE)
+    const { column } = spectrogramColumn(frame)
+    expect(column.length).toBe(SPECTROGRAM_BINS)
+    expect(SPECTROGRAM_BINS).toBe(SPECTROGRAM_WINDOW_SIZE / 2)
+  })
+
+  it('silence produces an all-zero column', () => {
+    const { column } = spectrogramColumn(constant(0, SPECTROGRAM_WINDOW_SIZE))
+    for (const v of column) expect(v).toBeLessThan(1e-10)
+  })
+
+  it('zero-pads a short frame (no window buffering needed)', () => {
+    const { column } = spectrogramColumn(constant(0.5, 1024))
+    // A 1024-sample half-amplitude frame zero-padded to 4096: the DC bin is
+    // 0.5 * (sum of BH window over the first 1024 samples) / sqrt(4096)
+    // = 0.0725 (the 7-term BH window is small near its edges, so a short
+    // frame carries little DC energy). All other bins stay near zero.
+    expect(column[0]).toBeGreaterThan(0.03)
+    expect(column[0]).toBeLessThan(0.2)
+  })
+
+  it('peaks at the bin matching a sine wave frequency', () => {
+    const sampleRate = 48000
+    const binFreq = sampleRate / SPECTROGRAM_WINDOW_SIZE // Hz per bin
+    const targetBin = 200
+    const freqHz = targetBin * binFreq
+    const frame = sineWave(freqHz, sampleRate, SPECTROGRAM_WINDOW_SIZE)
+    const { column } = spectrogramColumn(frame)
+    const peak = argMax(column)
+    // 7-term Blackman-Harris has a wider main lobe than Hann; the peak still
+    // lands within a bin or two of the true frequency.
+    expect(Math.abs(peak - targetBin)).toBeLessThanOrEqual(3)
+    // Peak should be significantly above the average.
+    const avg = column.reduce((a, b) => a + b, 0) / column.length
+    expect(column[peak]).toBeGreaterThan(avg * 10)
+  })
+
+  it('higher frequency sine peaks at a higher bin', () => {
+    const sampleRate = 48000
+    const binFreq = sampleRate / SPECTROGRAM_WINDOW_SIZE
+    const lowBin = 50
+    const highBin = 300
+    const lowCol = spectrogramColumn(
+      sineWave(lowBin * binFreq, sampleRate, SPECTROGRAM_WINDOW_SIZE),
+    ).column
+    const highCol = spectrogramColumn(
+      sineWave(highBin * binFreq, sampleRate, SPECTROGRAM_WINDOW_SIZE),
+    ).column
+    expect(argMax(lowCol)).toBeLessThan(argMax(highCol))
+  })
+
+  it('amplitude is normalized by sqrt(windowSize) (Spectro convention)', () => {
+    const sampleRate = 48000
+    const binFreq = sampleRate / SPECTROGRAM_WINDOW_SIZE
+    const freqHz = 40 * binFreq
+    const frame = sineWave(freqHz, sampleRate, SPECTROGRAM_WINDOW_SIZE, 0.5)
+    const { column } = spectrogramColumn(frame)
+    // 7-term BH window DC gain: sum(window) = 1110.2 for N=4096. A sine of
+    // amplitude A at a bin center therefore peaks at
+    //   A * sum(window) / sqrt(N) = 0.5 * 1110.2 / 64 = 8.67
+    // (NOT A*N/2/sqrt(N) - the BH window attenuates the tone). The bin
+    // centerlands within the main lobe, so we assert the magnitude is in the
+    // same ballpark: clearly above the 1/√N noise floor, below 16.
+    const peak = column[argMax(column)]
+    expect(peak).toBeGreaterThan(4)
+    expect(peak).toBeLessThan(16)
+  })
+
+  it('throws for a non-power-of-2 window size', () => {
+    expect(() =>
+      spectrogramColumn(constant(0, 1000), { windowSize: 1000 }),
+    ).toThrow(/power of 2/)
+  })
+
+  it('exposes the precomputed default window (symmetric, endpoints ~equal)', () => {
+    expect(SPECTROGRAM_WINDOW.length).toBe(SPECTROGRAM_WINDOW_SIZE)
+    // 7-term BH is nearly symmetric: first/last samples agree to ~1e-3.
+    expect(SPECTROGRAM_WINDOW[0]).toBeCloseTo(SPECTROGRAM_WINDOW[SPECTROGRAM_WINDOW_SIZE - 1], 3)
   })
 })

--- a/packages/modules/afe/graph/core/index.ts
+++ b/packages/modules/afe/graph/core/index.ts
@@ -20,6 +20,7 @@ export type {
   FrameConfig,
   ParameterDescriptor,
   RecordedClip,
+  SpectrogramData,
   StageFrameData,
   StageState,
   StageStatus,

--- a/packages/modules/afe/graph/core/spectrogram-history.ts
+++ b/packages/modules/afe/graph/core/spectrogram-history.ts
@@ -1,0 +1,77 @@
+/**
+ * Contiguous ring buffer for spectrogram columns (ADR-032).
+ *
+ * The AFE's processing buffer (CIRCULAR_BUFFER_SIZE = 1920 samples) wraps long
+ * before a 4096-sample FFT window is available, so the spectrogram needs its
+ * own history that keeps the newest `size` samples as a *contiguous* copy.
+ *
+ * `push` appends chunks (worklet quanta) and, when full, memmoves the tail to
+ * the front so `window()` can always hand back a contiguous window. This keeps
+ * the AudioWorklet's `spectrogramColumn` call allocation-light (it reads a
+ * plain subarray) and correct across the wrap boundary.
+ */
+export class SpectrogramHistory {
+  readonly size: number
+  private data: Float32Array
+  private write = 0
+  private filled = 0
+
+  constructor(size: number) {
+    if (size <= 0) throw new Error(`SpectrogramHistory size must be > 0, got ${size}`)
+    this.size = size
+    this.data = new Float32Array(size)
+  }
+
+  get length(): number {
+    return this.filled
+  }
+
+  /** Append samples; evicts the oldest when full (memmove to keep contiguity). */
+  push(samples: Float32Array): void {
+    const n = samples.length
+    if (n === 0) return
+    if (n >= this.size) {
+      // New data alone fills the window: keep only the newest `size` samples.
+      this.data.set(samples.subarray(n - this.size))
+      this.write = this.size
+      this.filled = this.size
+      return
+    }
+    const free = this.size - this.write
+    if (n <= free) {
+      this.data.set(samples, this.write)
+      this.write += n
+    } else {
+      this.data.set(samples.subarray(0, free), this.write)
+      this.data.set(samples.subarray(free), 0)
+      this.write = n - free
+    }
+    this.filled = Math.min(this.size, this.filled + n)
+  }
+
+  /**
+   * A contiguous Float32Array of the newest `windowSize` samples
+   * (zero-padded at the front if fewer than `windowSize` have been pushed).
+   */
+  window(windowSize: number): Float32Array {
+    const out = new Float32Array(windowSize)
+    const take = Math.min(this.filled, windowSize)
+    if (take === 0) return out
+    const start = (this.write - take + this.size) % this.size
+    const dest = windowSize - take
+    if (start + take <= this.size) {
+      out.set(this.data.subarray(start, start + take), dest)
+    } else {
+      const first = this.size - start
+      out.set(this.data.subarray(start), dest)
+      out.set(this.data.subarray(0, take - first), dest + first)
+    }
+    return out
+  }
+
+  clear(): void {
+    this.data.fill(0)
+    this.write = 0
+    this.filled = 0
+  }
+}

--- a/packages/modules/afe/graph/core/types.ts
+++ b/packages/modules/afe/graph/core/types.ts
@@ -47,6 +47,16 @@ export interface ParameterDescriptor {
   description: string
 }
 
+/** One magnitude-spectrogram column (Spectro-style, ADR-032). */
+export interface SpectrogramData {
+  /** Magnitude bins, bin 0 = DC, last = Nyquist (length windowSize/2). */
+  column: Float32Array
+  /** FFT window size in samples (default 4096). */
+  windowSize: number
+  /** Sample rate the column was computed at (48 kHz AFE). */
+  sampleRate: number
+}
+
 /** Per-frame visualization data emitted by a stage (throttled to vizFps). */
 export interface StageFrameData {
   stageId: string
@@ -59,8 +69,13 @@ export interface StageFrameData {
   levelDb?: number
   /** VAD probability [0,1] (from RNNoise for v1, ADR-016). */
   vadProbability?: number
-  /** Magnitude spectrum for the spectrogram display (NS stage). */
+  /**
+   * Magnitude spectrum for the spectrogram display (NS stage).
+   * @deprecated Replaced by `spectrogram` (Spectro-style column, ADR-032).
+   */
   spectrum?: Float32Array
+  /** Spectro-style spectrogram column (time axis lives in the renderer). */
+  spectrogram?: SpectrogramData
   /** Stage-specific metrics. */
   metrics?: Record<string, number>
 }

--- a/packages/modules/afe/graph/tests/spectrogram-history.test.ts
+++ b/packages/modules/afe/graph/tests/spectrogram-history.test.ts
@@ -1,0 +1,67 @@
+/**
+ * AFE graph module - SpectrogramHistory L1 unit tests (ADR-026).
+ *
+ * Locks the contiguous-window guarantee the worklet's spectrogram column
+ * depends on (the processing ring wraps at 1920 samples; the FFT window is
+ * 4096, so the history must stay contiguous across many wraps).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { SpectrogramHistory } from '../core/spectrogram-history'
+
+describe('SpectrogramHistory', () => {
+  it('zero-pads a window before enough samples are pushed', () => {
+    const h = new SpectrogramHistory(64)
+    h.push(new Float32Array([1, 2, 3]))
+    const w = h.window(8)
+    expect(Array.from(w)).toEqual([0, 0, 0, 0, 0, 1, 2, 3])
+    expect(h.length).toBe(3)
+  })
+
+  it('returns the newest samples as a contiguous window', () => {
+    const h = new SpectrogramHistory(16)
+    h.push(new Float32Array([1, 2, 3, 4, 5]))
+    h.push(new Float32Array([6, 7, 8]))
+    expect(Array.from(h.window(8))).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  it('evicts the oldest samples when full', () => {
+    const h = new SpectrogramHistory(8)
+    h.push(new Float32Array([1, 2, 3, 4, 5]))
+    h.push(new Float32Array([6, 7, 8, 9]))
+    // Newest 8 = [2..9]; 1 was evicted.
+    expect(Array.from(h.window(8))).toEqual([2, 3, 4, 5, 6, 7, 8, 9])
+    expect(h.length).toBe(8)
+  })
+
+  it('stays contiguous across many wraps (quantum-sized pushes)', () => {
+    const h = new SpectrogramHistory(32)
+    const all: number[] = []
+    for (let i = 0; i < 40; i++) {
+      const chunk = new Float32Array(5)
+      for (let j = 0; j < 5; j++) chunk[j] = i * 5 + j + 1
+      h.push(chunk)
+      for (const v of chunk) {
+        all.push(v)
+        if (all.length > 32) all.shift()
+      }
+    }
+    expect(Array.from(h.window(32))).toEqual(all)
+  })
+
+  it('handles a chunk larger than the history (keep newest only)', () => {
+    const h = new SpectrogramHistory(8)
+    const big = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    h.push(big)
+    expect(Array.from(h.window(8))).toEqual([3, 4, 5, 6, 7, 8, 9, 10])
+    expect(h.length).toBe(8)
+  })
+
+  it('clear resets length and windows', () => {
+    const h = new SpectrogramHistory(8)
+    h.push(new Float32Array([1, 2, 3]))
+    h.clear()
+    expect(h.length).toBe(0)
+    expect(Array.from(h.window(8))).toEqual([0, 0, 0, 0, 0, 0, 0, 0])
+  })
+})

--- a/packages/modules/afe/graph/web/pipeline-processor.worklet.ts
+++ b/packages/modules/afe/graph/web/pipeline-processor.worklet.ts
@@ -25,8 +25,15 @@ import { BssStage } from '@wake-studio/module-afe-bss'
 import { loadRnnoiseStage } from '@wake-studio/module-rnnoise/web/loader'
 
 import type { MainMessage, StageFrameData, WorkletMessage } from '../core/types'
-import { CIRCULAR_BUFFER_SIZE, RNNOISE_FRAME_SIZE } from '../core/defaults'
-import { computeSpectrum, downsample48to16, downsampleForViz, FFT_SIZE, levelDb } from '@wake-studio/dsp'
+import { CIRCULAR_BUFFER_SIZE, INTERNAL_SAMPLE_RATE, RNNOISE_FRAME_SIZE } from '../core/defaults'
+import { SpectrogramHistory } from '../core/spectrogram-history'
+import {
+  downsample48to16,
+  downsampleForViz,
+  levelDb,
+  spectrogramColumn,
+  SPECTROGRAM_WINDOW_SIZE,
+} from '@wake-studio/dsp'
 
 const PROCESSOR_NAME = 'pipeline-processor'
 
@@ -41,6 +48,11 @@ class PipelineProcessor extends AudioWorkletProcessor {
   private _inputLength = 0
   private _denoisedLength = 0
   private _denoisedIndex = 0
+
+  // Contiguous spectrogram history (newest SPECTROGRAM_WINDOW_SIZE samples).
+  private _specHistory = new SpectrogramHistory(SPECTROGRAM_WINDOW_SIZE)
+  // Same for the denoised (NS) stream so its column is a real window too.
+  private _nsSpecHistory = new SpectrogramHistory(SPECTROGRAM_WINDOW_SIZE)
 
   // Viz throttling.
   private _lastVizTime = 0
@@ -119,6 +131,8 @@ class PipelineProcessor extends AudioWorkletProcessor {
     // --- 1. Append raw input to the circular buffer ---
     this._buffer.set(inData, this._inputLength)
     this._inputLength += inData.length
+    // Also append to the spectrogram history (contiguous window source).
+    this._specHistory.push(inData)
 
     // --- 2. Run the stage chain over 480-sample frames ---
     while (this._denoisedLength + RNNOISE_FRAME_SIZE <= this._inputLength) {
@@ -141,6 +155,9 @@ class PipelineProcessor extends AudioWorkletProcessor {
       // (avoids intermittent missing data during circular-buffer wrap-around).
       this._lastNsFrame.set(frame)
       this._hasNsFrame = true
+      // Feed the denoised frame into the NS spectrogram history so its column
+      // comes from a full contiguous window, not a single zero-padded frame.
+      this._nsSpecHistory.push(frame)
 
       // Downsample to 16 kHz and post output for KWS.
       const out160 = downsample48to16(frame)
@@ -221,13 +238,22 @@ class PipelineProcessor extends AudioWorkletProcessor {
     const vizPoints = 128
     const frames: StageFrameData[] = []
 
-    // Use the last FFT_SIZE samples from the ring buffer for the spectrum so
-    // AEC/BSS get a full-resolution FFT (passing the 128-sample quantum would
-    // zero-pad half the window -> only the lower frequency bins would light
-    // up and the spectrogram would look bottom-heavy). Before the buffer
-    // wraps, _inputLength is the write cursor; subarray slices are contiguous.
-    const specStart = Math.max(0, this._inputLength - FFT_SIZE)
-    const specFrame = this._buffer.subarray(specStart, this._inputLength)
+    // Use the most recent SPECTROGRAM_WINDOW_SIZE samples from the contiguous
+    // spectrogram history (Spectro-style, ADR-032). A 4096-sample window at
+    // 48 kHz gives ~85 ms time resolution with 2048 frequency bins - the
+    // frequency axis is where real spectrogram detail lives. The renderer
+    // (WebGL) displays this column per viz frame; the window's time history is
+    // kept in the renderer's circular texture, not here.
+    const specFrame = this._specHistory.window(SPECTROGRAM_WINDOW_SIZE)
+    const spectrogram = spectrogramColumn(specFrame, {
+      windowSize: SPECTROGRAM_WINDOW_SIZE,
+      sampleRate: INTERNAL_SAMPLE_RATE,
+    })
+    const specData = {
+      column: spectrogram.column,
+      windowSize: spectrogram.windowSize,
+      sampleRate: spectrogram.sampleRate,
+    }
 
     // AEC stage (passthrough for v1): shows raw input. The metrics field
     // reserves the ERLE (echo return loss enhancement) slot for the future
@@ -238,7 +264,7 @@ class PipelineProcessor extends AudioWorkletProcessor {
       capturedAtMs,
       waveform: downsampleForViz(rawInput, vizPoints),
       levelDb: levelDb(rawInput),
-      spectrum: computeSpectrum(specFrame),
+      spectrogram: specData,
       metrics: { erleDb: 0 },
     })
 
@@ -250,7 +276,7 @@ class PipelineProcessor extends AudioWorkletProcessor {
       kind: 'bss',
       capturedAtMs,
       levelDb: levelDb(rawInput),
-      spectrum: computeSpectrum(specFrame),
+      spectrogram: specData,
       metrics: { siSdrDb: 0 },
     })
 
@@ -258,13 +284,22 @@ class PipelineProcessor extends AudioWorkletProcessor {
     const nsFrame = this._hasNsFrame
       ? this._lastNsFrame
       : rawInput.subarray(0, Math.min(RNNOISE_FRAME_SIZE, rawInput.length))
+    // NS shows its own denoised column from its own contiguous history.
+    const nsSpectrogram = spectrogramColumn(this._nsSpecHistory.window(SPECTROGRAM_WINDOW_SIZE), {
+      windowSize: SPECTROGRAM_WINDOW_SIZE,
+      sampleRate: INTERNAL_SAMPLE_RATE,
+    })
     frames.push({
       stageId: 'ns',
       kind: 'ns',
       capturedAtMs,
       waveform: downsampleForViz(nsFrame, vizPoints),
       levelDb: levelDb(nsFrame),
-      spectrum: computeSpectrum(nsFrame),
+      spectrogram: {
+        column: nsSpectrogram.column,
+        windowSize: nsSpectrogram.windowSize,
+        sampleRate: nsSpectrogram.sampleRate,
+      },
     })
 
     this._post({ type: 'frame', frames })


### PR DESCRIPTION
## Summary

Port the reference [Spectro](https://github.com/calebj0seph/spectro) visualizer's GPU rendering path into the AFE panels, replacing the old 2D-canvas per-pixel spectrogram (which had low frequency resolution and a jumpy look).

## Changes

### @wake-studio/dsp
- **spectrogram.ts (new)**: `spectrogramColumn()` - one magnitude column from the newest `windowSize` samples, 7-term **Blackman-Harris** window (spectro's choice for minimal sidelobes), `amplitude/sqrt(N)` normalization, default 4096-sample window -> **2048 bins**.
- **windows.ts**: `blackmanHarris7()` (coefficients verbatim from spectro).
- 8 new behavior tests lock the numerics (sine peak location, zero-padding, sqrt(N) normalization, non-power-of-2 rejection).

### @wake-studio/module-afe-graph
- **core/spectrogram-history.ts (new)**: `SpectrogramHistory` - contiguous ring that survives the 1920-sample processing-buffer wrap long before a 4096-sample FFT window is available (6 L1 tests).
- **web/pipeline-processor.worklet.ts**: emits one Spectro-style column per viz frame via new `StageFrameData.spectrogram` (raw stream for AEC/BSS, separate denoised history for NS).
- **core/types.ts**: new `SpectrogramData`; legacy `spectrum` deprecated but kept for downstream compat.

### @wake-studio/web
- **components/spectrogram/webgl-spectrogram.ts (new)**: faithful port of Spectro's GPU renderer - circular Float32 texture + partial `texSubImage2D` uploads, fragment shader with **mel frequency-axis** lookup texture, sensitivity/contrast/zoom uniforms, `mod()` circular wrap, **Lab-interpolated** color ramps (Heated Metal / Audacity).
- **components/spectrogram/WebGLSpectrogram.tsx (new)**: React wrapper (rAF loop, StrictMode-safe data dedup, lazy renderer creation).
- **AFEPanel.tsx**: three stage cards use the WebGL renderer (effect-first; 2D fallback intentionally dropped).

## Verification
- dsp 46 passed, afe-graph 14 passed, monorepo `pnpm -r test:unit` all green
- `pnpm -r typecheck` + web `vite build` pass; lint no new warnings
- Live-tested: mic -> columns stream into the circular texture; silence renders near-black (spectro behavior), speech lights up

## Notes
- `StageFrameData.spectrum` (64-bin Hann) is deprecated; kept so KWS/other consumers don't break.
- No new deps (uses existing @wake-studio/dsp fft.js core).
