### PR TITLE
docs: GitHub Issues/Projects workflow — templates + contributor discipline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something isn't working as expected
+title: "bug: "
+labels: [bug]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken? Include the exact error message / stack trace.
+    validations:
+      required: true
+  - type: input
+    id: module
+    attributes:
+      label: Module
+      description: "One of: afe, kws, few-shot, sdk, export, training, platform, web, device, ci/deploy"
+    validations:
+      required: true
+  - type: input
+    id: phase
+    attributes:
+      label: Phase
+      description: "Which phase does this belong to? (e.g. P4, P3.6, v1.x)"
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can a teammate reproduce this?
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 blocks the delivery chain / release.
+      options:
+        - P0
+        - P1
+        - P2
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, device, OS, branch, local-service version as applicable.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,58 @@
+name: Task
+description: A concrete deliverable broken out of the plan (or an epic's sub-issue)
+title: "task: "
+labels: [task]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this task exist? Reference the plan section, epic, or ADR.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true for this task to be done? Be concrete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: input
+    id: module
+    attributes:
+      label: Module
+      description: "One of: afe, kws, few-shot, sdk, export, training, platform, web, device, ci/deploy"
+  - type: input
+    id: phase
+    attributes:
+      label: Phase
+      description: "Which phase does this belong to? (e.g. P4)"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 blocks the delivery chain / release.
+      options:
+        - P0
+        - P1
+        - P2
+    validations:
+      required: true
+  - type: dropdown
+    id: estimate
+    attributes:
+      label: Estimate
+      options:
+        - S
+        - M
+        - L
+  - type: input
+    id: adr
+    attributes:
+      label: Related ADR
+      description: "e.g. ADR-021, or N/A"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,24 @@ Treat every change as if a teammate will review it on Monday morning.
   `README.zh.md`, `getting-started.zh.md`. If a file is not clearly scoped to a
   non-English locale, write English.
 
+## Issue & project discipline
+
+Task and planning state lives in **GitHub Issues + the `WakeStudio Delivery`
+project** (org `awareride`), driven through the `gh` CLI. Docs keep the
+durable knowledge (ADRs, module specs, architecture); issues keep the work
+state. See `CONTRIBUTING.md` (Issues & Projects section) for the full model.
+
+- Before starting any non-trivial task, confirm the corresponding issue exists
+  (create it with `gh issue create` using the task/bug template if not) and
+  move it to `In progress` in the project.
+- PR bodies must reference the issue (`Closes #N` / `Fixes #N`) so merge
+  auto-closes it.
+- On merge/close, move the issue to `Done` in the project.
+- Use the repo's label set (type `epic`/`task`/`bug`/`question`/`docs`,
+  priority `p0`/`p1`, scope `sdk`/`kws`/`training`/`web`/`device`/`ci/deploy`/
+  `platform`/`export`/`few-shot`/`afe`).
+- Questions (`question` label) close with a decision that lands as an ADR.
+
 ## Git & deployment boundaries
 
 - You **may** stage and commit locally (`git add`, `git commit`) to group

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,37 @@ Treat every change as if a teammate will review it on Monday morning.
   `README.zh.md`, `getting-started.zh.md`. If a file is not clearly scoped to a
   non-English locale, write English.
 
-## Issue & project discipline
+## Planning docs & GitHub work tracking
+
+Three layers, each with its own reader and role. Do not blur them:
+
+| Layer | Where | Reader | Role | Nature |
+|---|---|---|---|---|
+| **Agent guidance** | `.agents/plan/*.plan` (gitignored) | agent | vision, constraints, ADR index, working agreements, issue index | static (low churn) |
+| **Work state** | GitHub Issues + `WakeStudio Delivery` project (org `awareride`) | human + cross-session | who/what/when/blocked | dynamic (live) |
+| **Durable knowledge** | `docs/`, `DECISIONS.md`, `docs/modules/*.md` | human + agent | ADRs, architecture, module specs | versioned with code |
+
+### Plan files (`.agents/plan/`) — read, don't maintain state
+
+Plan files are **agent-only context**: vision, phase history, ADR index, and
+pointers to issues. They are gitignored on purpose — they are not for GitHub
+readers and never enter PR diffs. Rules:
+
+- Read plan files for **static guidance** at session start (alongside the
+  board). They are the fastest way to load the project's shape.
+- Plan files do **not** hold live state. Do not edit P0/phase/question status
+  tables in them — state lives in GitHub.
+- The only plan-file edits allowed are **static-pointer fixes** (e.g. an issue
+  index line whose number went stale).
+
+### GitHub Issues + Projects — the live state source
 
 Task and planning state lives in **GitHub Issues + the `WakeStudio Delivery`
-project** (org `awareride`), driven through the `gh` CLI. Docs keep the
-durable knowledge (ADRs, module specs, architecture); issues keep the work
-state. See `CONTRIBUTING.md` (Issues & Projects section) for the full model.
+project** (org `awareride`), driven through the `gh` CLI. See
+`CONTRIBUTING.md` (Issues & Projects section) for the full model.
 
+- **Session start:** load live state with `gh project item-list 2 --owner
+  awareride` (or `gh issue list`). Prefer this over reading plan state.
 - Before starting any non-trivial task, confirm the corresponding issue exists
   (create it with `gh issue create` using the task/bug template if not) and
   move it to `In progress` in the project.
@@ -43,6 +67,8 @@ state. See `CONTRIBUTING.md` (Issues & Projects section) for the full model.
   priority `p0`/`p1`, scope `sdk`/`kws`/`training`/`web`/`device`/`ci/deploy`/
   `platform`/`export`/`few-shot`/`afe`).
 - Questions (`question` label) close with a decision that lands as an ADR.
+- **State changes go to GitHub only** — never write status back into plan
+  files.
 
 ## Git & deployment boundaries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,33 @@ Run `pnpm test:unit` before pushing; the CI runs L1+L2 on every PR.
 - Commit logical units locally. Group related work. Do not commit generated
   artifacts (`dist/`, lockfiles are the exception - `pnpm-lock.yaml` IS tracked).
 
+## Issues & Projects (work tracking)
+
+Task state lives in GitHub Issues + the **WakeStudio Delivery** project
+(org-level, `awareride`), not in plan documents. Docs keep the durable
+knowledge (ADRs, module specs); issues keep the work state.
+
+- **Every change starts from an issue.** Before starting a task, confirm the
+  issue exists (create it if not, using the task/bug templates) and move it to
+  `In progress` in the project.
+- **Every PR must reference an issue.** Put `Closes #N` / `Fixes #N` in the PR
+  description so merge auto-closes the issue. A PR without an issue link is
+  incomplete.
+- **Labels** carry type + priority + scope: `epic`, `task`, `bug`, `question`,
+  `docs`, `p0`, `p1`, and the scope labels (`sdk`, `kws`, `training`, `web`,
+  `device`, `ci/deploy`, `platform`, `export`, `few-shot`, `afe`).
+- **Epics** group phase-sized work; their tasks are GitHub sub-issues.
+- **Questions** (`question` label) close with a decision that lands as an ADR
+  in `DECISIONS.md`.
+- On merge/close, move the issue to `Done` in the project (or let project
+  automation do it).
+- Project fields: `Phase` (P0–P7, v1.x), `Priority` (P0/P1/P2), `Module`,
+  `Estimate` (S/M/L), `Status` (Todo / In progress / Done).
+
+Agent (pi) workflows should drive this via `gh`: `gh issue create`,
+`gh project item-add 2 --owner awareride --url <issue>`, `gh project item-edit`,
+and `gh issue close` on merge.
+
 ## Documentation-first (docs-first)
 
 WakeStudio follows a **documentation-first** workflow (see plan §11):


### PR DESCRIPTION
## Summary

Introduce GitHub Issues/Projects as the live work-tracking layer and define
how it relates to the agent-only plan files. Docs-first change only — no
code, no CI, no behavior change.

## Changes

- **`.github/ISSUE_TEMPLATE/`** — structured forms for `bug` and `task`
  (Module / Phase / Priority / Acceptance criteria / Estimate / Related ADR)
- **`CONTRIBUTING.md`** — new *Issues & Projects* section: PR must reference
  an issue (`Closes #N`), label taxonomy, project fields, agent `gh` workflow
- **`AGENTS.md`** — new *Planning docs & GitHub work tracking* section:
  three-layer model (plan files = static agent guidance; GitHub Issues +
  `WakeStudio Delivery` project = live state; `docs/` = durable knowledge).
  State changes go to GitHub only; plan files never hold live state.

## Context

Previously all task/planning state lived in `.agents/plan/goal.plan`
(gitignored) — invisible to GitHub, no open/close semantics, no PR linkage.
Now the **WakeStudio Delivery** project (org `awareride`, private) tracks the
17 seeded items (P0 blockers #27–#30, questions #32–#36, Phase 4 epic #31
with sub-issues #37–#42, bug #23).

## Follow-ups

- Project board grouping (Kanban by Status, Timeline by Phase) is set by hand
  in the UI (GraphQL cannot write `groupBy`)
- Optional Phase 3 automation (label→add, close→Done) — explicitly deferred

Closes #26-related tracking setup (no single issue; this is infrastructure).
