### PR TITLE
feat(settings): data-driven Settings panel + layered KWS persistence (#52, #53 P1)

### DIFF
--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -133,27 +133,37 @@ test('mobile drawer positions correctly and expands Settings sub-menu', async ({
   await page.goto('/#/workspace')
 
   await page.getByRole('button', { name: 'Toggle navigation' }).click()
-  await expect(page.locator('[role="dialog"]')).toBeVisible()
+  const drawer = page.locator('[role="dialog"]')
+  await expect(drawer).toBeVisible()
 
-  // Drawer sits fully inside the viewport (regression: it used to overflow
-  // to negative coordinates when the Settings sub-menu expanded).
+  // Drawer sits at the left edge, full height (GitHub-style side panel, not a
+  // centered dialog). Wait for the slide-in animation to settle before
+  // measuring.
+  await page.waitForTimeout(400)
   const geo = await page.evaluate(() => {
     const d = document.querySelector('[role="dialog"]')
     if (!d) return null
     const r = d.getBoundingClientRect()
     return {
-      inside:
-        r.x >= 0 && r.y >= 0 && r.x + r.width <= window.innerWidth,
+      x: r.x,
+      y: r.y,
+      w: r.width,
+      h: r.height,
+      vh: window.innerHeight,
+      vw: window.innerWidth,
     }
   })
-  expect(geo?.inside).toBe(true)
+  expect(geo).toMatchObject({
+    x: 0,
+    y: 0,
+    w: expect.any(Number),
+    h: expect.any(Number),
+  })
+  expect(geo!.h).toBe(geo!.vh)
 
   // Settings expands inside the drawer and the sub-items render.
-  await page
-    .locator('[role="dialog"]')
-    .getByRole('button', { name: /Settings menu/ })
-    .click()
+  await drawer.getByRole('button', { name: /Settings menu/ }).click()
   await expect(
-    page.locator('[role="dialog"]').getByRole('button', { name: 'General' }),
+    drawer.getByRole('button', { name: 'General' }),
   ).toBeVisible()
 })

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Settings view e2e (issue #52).
+ *
+ * Covers: real Settings view renders (not a placeholder), theme switch flips
+ * documentElement.dataset.theme, secret fields render as password inputs,
+ * driver module settings persist to localStorage, export masks secrets,
+ * reset restores defaults.
+ */
+
+test('settings view renders platform + module groups', async ({ page }) => {
+  await page.goto('/#/settings')
+
+  // Real view heading + left rail.
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Settings' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'General' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Security' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Data' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Modules' })).toBeVisible()
+
+  // General group shows theme + locale controls.
+  await expect(page.getByText('Theme', { exact: true })).toBeVisible()
+  await expect(page.getByText('Language', { exact: true })).toBeVisible()
+})
+
+test('theme switch flips the document theme', async ({ page }) => {
+  await page.goto('/#/settings')
+
+  // The theme control is a Radix select trigger, rendered as a textbox whose
+  // accessible name is the current value ("light"). Click it, then pick Dark
+  // from the portal listbox.
+  // The theme control is the first Radix select trigger (role "combobox";
+  // three exist: theme/locale/execution-provider). The first is Theme.
+  const themeTrigger = page.getByRole('combobox').first()
+  await themeTrigger.click()
+  // Radix Select renders options in a portal listbox; pick Dark.
+  const darkOption = page.getByRole('option', { name: 'Dark' })
+  await darkOption.waitFor({ state: 'visible', timeout: 5000 })
+  await darkOption.click()
+
+  // documentElement.dataset.theme flips immediately (context side-effect).
+  const theme = await page.evaluate(() => document.documentElement.dataset.theme)
+  expect(theme).toBe('dark')
+
+  // Persisted to localStorage.
+  const stored = await page.evaluate(() =>
+    localStorage.getItem('wake-studio:settings:platform'),
+  )
+  expect(stored).toContain('"theme":"dark"')
+})
+
+test('secret fields render as password inputs', async ({ page }) => {
+  await page.goto('/#/settings')
+
+  // Security rail.
+  await page.getByRole('button', { name: 'Security' }).click()
+  const apiKeyInput = page.locator('input[type="password"]')
+  await expect(apiKeyInput.first()).toBeVisible()
+})
+
+test('module settings persist driver params to localStorage', async ({ page }) => {
+  await page.goto('/#/settings')
+
+  await page.getByRole('button', { name: 'Modules' }).click()
+
+  // Drivers with a spec appear (openwakeword/sherpa/plix). The sherpa
+  // keywords param is a string control (module-kit text input).
+  await expect(page.getByText('Wake words (comma-separated)')).toBeVisible()
+
+  // The sherpa keywords string control: a textbox whose placeholder is the
+  // default keyword list (Chinese chars). Target by placeholder.
+  const editable = page.getByPlaceholder(/你好/).first()
+  await editable.fill('test keyword @wake')
+  await page.waitForTimeout(150)
+
+  const stored = await page.evaluate(() =>
+    localStorage.getItem('wake-studio:settings:module'),
+  )
+  expect(stored).toContain('sherpa-onnx-kws')
+  expect(stored).toContain('test keyword @wake')
+})
+
+test('export masks secrets and reset restores defaults', async ({ page }) => {
+  await page.goto('/#/settings')
+
+  // Seed a secret so export has something to mask.
+  await page.getByRole('button', { name: 'Security' }).click()
+  const apiKeyInput = page.locator('input[type="password"]').first()
+  await apiKeyInput.fill('sk-super-secret')
+
+  // Export triggers a download; intercept it to inspect the payload.
+  const downloadPromise = page.waitForEvent('download')
+  await page.getByRole('button', { name: /Export settings/ }).click()
+  const download = await downloadPromise
+  const path = await download.path()
+  const fs = await import('node:fs')
+  const json = JSON.parse(fs.readFileSync(path!, 'utf8'))
+  // Secrets masked; theme untouched.
+  expect(json.platform['backend.apiKey']).toBe('••••••••')
+  expect(json.platform.theme).toBeDefined()
+
+  // Reset restores defaults (secret cleared).
+  await page.getByRole('button', { name: /Reset to defaults/ }).click()
+  await page.waitForTimeout(100)
+  const stored = await page.evaluate(() =>
+    localStorage.getItem('wake-studio:settings:platform'),
+  )
+  expect(stored).toBeNull()
+})

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -59,7 +59,7 @@ test('clicking a sub-item highlights only that item, not the Settings parent', a
   await expect(
     page
       .locator('aside')
-      .getByRole('button', { name: 'Settings', exact: true }),
+      .getByRole('button', { name: /Settings menu/ }),
   ).not.toHaveAttribute('aria-current', 'page')
 })
 

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,35 +1,47 @@
 import { test, expect } from '@playwright/test'
 
 /**
- * Settings view e2e (issue #52).
+ * Settings view e2e (issue #52, sub-route restructure).
  *
- * Covers: real Settings view renders (not a placeholder), theme switch flips
- * documentElement.dataset.theme, secret fields render as password inputs,
- * driver module settings persist to localStorage, export masks secrets,
- * reset restores defaults.
+ * The settings section menu lives in the shell sidebar (Settings sub-menu);
+ * the view renders section content full-width at #/settings/<section>.
+ * Covers: sub-route rendering, theme flip, secret password inputs, module
+ * settings persistence, export-mask/reset.
  */
 
-test('settings view renders platform + module groups', async ({ page }) => {
-  await page.goto('/#/settings')
-
-  // Real view heading + left rail.
-  await expect(page.getByRole('main').getByRole('heading', { name: 'Settings' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'General' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Security' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Data' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Modules' })).toBeVisible()
-
-  // General group shows theme + locale controls.
+test('settings sub-routes render section content', async ({ page }) => {
+  // General is the default settings landing.
+  await page.goto('/#/settings/general')
+  await expect(
+    page.getByRole('main').getByRole('heading', { name: 'General', exact: true }),
+  ).toBeVisible()
   await expect(page.getByText('Theme', { exact: true })).toBeVisible()
   await expect(page.getByText('Language', { exact: true })).toBeVisible()
+
+  // Sidebar sub-menu shows all sections.
+  await expect(
+    page.locator('aside').getByRole('button', { name: 'General' }),
+  ).toBeVisible()
+  await expect(
+    page.locator('aside').getByRole('button', { name: 'Security' }),
+  ).toBeVisible()
+  await expect(
+    page.locator('aside').getByRole('button', { name: 'Modules' }),
+  ).toBeVisible()
+
+  // Modules section expands to drivers in the sidebar sub-menu.
+  await page.locator('aside').getByRole('button', { name: 'Modules' }).click()
+  await expect(page).toHaveURL(/#\/settings\/modules/)
+  await expect(page.getByRole('heading', { name: 'Module settings' })).toBeVisible()
+  // A driver with a spec appears in the sidebar sub-menu.
+  await expect(
+    page.locator('aside').getByRole('button', { name: /sherpa|PLiX|OpenWakeWord/ }).first(),
+  ).toBeVisible()
 })
 
 test('theme switch flips the document theme', async ({ page }) => {
-  await page.goto('/#/settings')
+  await page.goto('/#/settings/general')
 
-  // The theme control is a Radix select trigger, rendered as a textbox whose
-  // accessible name is the current value ("light"). Click it, then pick Dark
-  // from the portal listbox.
   // The theme control is the first Radix select trigger (role "combobox";
   // three exist: theme/locale/execution-provider). The first is Theme.
   const themeTrigger = page.getByRole('combobox').first()
@@ -51,25 +63,18 @@ test('theme switch flips the document theme', async ({ page }) => {
 })
 
 test('secret fields render as password inputs', async ({ page }) => {
-  await page.goto('/#/settings')
+  await page.goto('/#/settings/security')
 
-  // Security rail.
-  await page.getByRole('button', { name: 'Security' }).click()
   const apiKeyInput = page.locator('input[type="password"]')
   await expect(apiKeyInput.first()).toBeVisible()
 })
 
 test('module settings persist driver params to localStorage', async ({ page }) => {
-  await page.goto('/#/settings')
-
-  await page.getByRole('button', { name: 'Modules' }).click()
-
-  // Drivers with a spec appear (openwakeword/sherpa/plix). The sherpa
-  // keywords param is a string control (module-kit text input).
-  await expect(page.getByText('Wake words (comma-separated)')).toBeVisible()
+  await page.goto('/#/settings/modules')
 
   // The sherpa keywords string control: a textbox whose placeholder is the
   // default keyword list (Chinese chars). Target by placeholder.
+  await expect(page.getByText('Wake words (comma-separated)')).toBeVisible()
   const editable = page.getByPlaceholder(/你好/).first()
   await editable.fill('test keyword @wake')
   await page.waitForTimeout(150)
@@ -82,10 +87,9 @@ test('module settings persist driver params to localStorage', async ({ page }) =
 })
 
 test('export masks secrets and reset restores defaults', async ({ page }) => {
-  await page.goto('/#/settings')
+  await page.goto('/#/settings/security')
 
   // Seed a secret so export has something to mask.
-  await page.getByRole('button', { name: 'Security' }).click()
   const apiKeyInput = page.locator('input[type="password"]').first()
   await apiKeyInput.fill('sk-super-secret')
 

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from '@playwright/test'
 
 /**
- * Settings view e2e (issue #52, sub-route restructure).
+ * Settings view e2e (issue #52, save-to-apply).
  *
  * The settings section menu lives in the shell sidebar (Settings sub-menu);
  * the view renders section content full-width at #/settings/<section>.
- * Covers: sub-route rendering, theme flip, secret password inputs, module
- * settings persistence, export-mask/reset.
+ * Edits go into a local draft; Save persists them. Covers: sub-route
+ * rendering, focus on the clicked sub-item (parent not highlighted),
+ * save-to-apply theme, secret password inputs, module settings save.
  */
 
 test('settings sub-routes render section content', async ({ page }) => {
@@ -45,24 +46,47 @@ test('settings sub-routes render section content', async ({ page }) => {
   ).toBeVisible()
 })
 
-test('theme switch flips the document theme', async ({ page }) => {
+test('clicking a sub-item highlights only that item, not the Settings parent', async ({
+  page,
+}) => {
+  await page.goto('/#/settings/security')
+
+  // The Security sub-item is highlighted...
+  await expect(
+    page.locator('aside').getByRole('button', { name: 'Security' }),
+  ).toHaveAttribute('aria-current', 'page')
+  // ...but the Settings parent is not.
+  await expect(
+    page
+      .locator('aside')
+      .getByRole('button', { name: 'Settings', exact: true }),
+  ).not.toHaveAttribute('aria-current', 'page')
+})
+
+test('theme changes apply only after Save', async ({ page }) => {
   await page.goto('/#/settings/general')
 
   // The theme control is the first Radix select trigger (role "combobox";
   // three exist: theme/locale/execution-provider). The first is Theme.
   const themeTrigger = page.getByRole('combobox').first()
   await themeTrigger.click()
-  // Radix Select renders options in a portal listbox; pick Dark.
   const darkOption = page.getByRole('option', { name: 'Dark' })
   await darkOption.waitFor({ state: 'visible', timeout: 5000 })
   await darkOption.click()
 
-  // documentElement.dataset.theme flips immediately (context side-effect).
-  const theme = await page.evaluate(() => document.documentElement.dataset.theme)
-  expect(theme).toBe('dark')
+  // Not saved yet: theme unchanged, nothing persisted.
+  let theme = await page.evaluate(() => document.documentElement.dataset.theme)
+  expect(theme).toBe('light')
+  let stored = await page.evaluate(() =>
+    localStorage.getItem('wake-studio:settings:platform'),
+  )
+  expect(stored ?? '').not.toContain('"theme":"dark"')
 
-  // Persisted to localStorage.
-  const stored = await page.evaluate(() =>
+  // Save applies it.
+  await page.getByRole('button', { name: 'Save' }).click()
+  theme = await page.evaluate(() => document.documentElement.dataset.theme)
+  expect(theme).toBe('dark')
+  stored = await page.evaluate(() =>
     localStorage.getItem('wake-studio:settings:platform'),
   )
   expect(stored).toContain('"theme":"dark"')
@@ -75,7 +99,7 @@ test('secret fields render as password inputs', async ({ page }) => {
   await expect(apiKeyInput.first()).toBeVisible()
 })
 
-test('module settings persist driver params to localStorage', async ({ page }) => {
+test('module settings persist only after Save', async ({ page }) => {
   await page.goto('/#/settings/modules')
 
   // The sherpa keywords string control: a textbox whose placeholder is the
@@ -83,38 +107,21 @@ test('module settings persist driver params to localStorage', async ({ page }) =
   await expect(page.getByText('Wake words (comma-separated)')).toBeVisible()
   const editable = page.getByPlaceholder(/你好/).first()
   await editable.fill('test keyword @wake')
-  await page.waitForTimeout(150)
+  await page.waitForTimeout(100)
 
-  const stored = await page.evaluate(() =>
+  // Not saved yet.
+  let stored = await page.evaluate(() =>
+    localStorage.getItem('wake-studio:settings:module'),
+  )
+  expect(stored || '').not.toContain('test keyword @wake')
+
+  // Save persists all drivers (the modules section's own Save button - the
+  // header Save is for platform settings and stays disabled here).
+  await page.getByRole('button', { name: 'Save' }).last().click()
+  await page.waitForTimeout(150)
+  stored = await page.evaluate(() =>
     localStorage.getItem('wake-studio:settings:module'),
   )
   expect(stored).toContain('sherpa-onnx-kws')
   expect(stored).toContain('test keyword @wake')
-})
-
-test('export masks secrets and reset restores defaults', async ({ page }) => {
-  await page.goto('/#/settings/security')
-
-  // Seed a secret so export has something to mask.
-  const apiKeyInput = page.locator('input[type="password"]').first()
-  await apiKeyInput.fill('sk-super-secret')
-
-  // Export triggers a download; intercept it to inspect the payload.
-  const downloadPromise = page.waitForEvent('download')
-  await page.getByRole('button', { name: /Export settings/ }).click()
-  const download = await downloadPromise
-  const path = await download.path()
-  const fs = await import('node:fs')
-  const json = JSON.parse(fs.readFileSync(path!, 'utf8'))
-  // Secrets masked; theme untouched.
-  expect(json.platform['backend.apiKey']).toBe('••••••••')
-  expect(json.platform.theme).toBeDefined()
-
-  // Reset restores defaults (secret cleared).
-  await page.getByRole('button', { name: /Reset to defaults/ }).click()
-  await page.waitForTimeout(100)
-  const stored = await page.evaluate(() =>
-    localStorage.getItem('wake-studio:settings:platform'),
-  )
-  expect(stored).toBeNull()
 })

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -124,3 +124,36 @@ test('module settings persist only after Save', async ({ page }) => {
   expect(stored).toContain('sherpa-onnx-kws')
   expect(stored).toContain('test keyword @wake')
 })
+
+test('mobile drawer positions correctly and expands Settings sub-menu', async ({
+  page,
+}) => {
+  // Narrow viewport: the sidebar collapses into the mobile drawer.
+  await page.setViewportSize({ width: 500, height: 700 })
+  await page.goto('/#/workspace')
+
+  await page.getByRole('button', { name: 'Toggle navigation' }).click()
+  await expect(page.locator('[role="dialog"]')).toBeVisible()
+
+  // Drawer sits fully inside the viewport (regression: it used to overflow
+  // to negative coordinates when the Settings sub-menu expanded).
+  const geo = await page.evaluate(() => {
+    const d = document.querySelector('[role="dialog"]')
+    if (!d) return null
+    const r = d.getBoundingClientRect()
+    return {
+      inside:
+        r.x >= 0 && r.y >= 0 && r.x + r.width <= window.innerWidth,
+    }
+  })
+  expect(geo?.inside).toBe(true)
+
+  // Settings expands inside the drawer and the sub-items render.
+  await page
+    .locator('[role="dialog"]')
+    .getByRole('button', { name: /Settings menu/ })
+    .click()
+  await expect(
+    page.locator('[role="dialog"]').getByRole('button', { name: 'General' }),
+  ).toBeVisible()
+})

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -18,24 +18,30 @@ test('settings sub-routes render section content', async ({ page }) => {
   await expect(page.getByText('Theme', { exact: true })).toBeVisible()
   await expect(page.getByText('Language', { exact: true })).toBeVisible()
 
-  // Sidebar sub-menu shows all sections.
+  // Sidebar sub-menu shows sections + drivers directly under Settings.
   await expect(
     page.locator('aside').getByRole('button', { name: 'General' }),
   ).toBeVisible()
   await expect(
     page.locator('aside').getByRole('button', { name: 'Security' }),
   ).toBeVisible()
+  // Drivers appear as Settings children (no intermediate Modules layer).
   await expect(
-    page.locator('aside').getByRole('button', { name: 'Modules' }),
+    page
+      .locator('aside')
+      .getByRole('button', { name: /sherpa-onnx KWS/ })
+      .first(),
   ).toBeVisible()
 
-  // Modules section expands to drivers in the sidebar sub-menu.
-  await page.locator('aside').getByRole('button', { name: 'Modules' }).click()
-  await expect(page).toHaveURL(/#\/settings\/modules/)
-  await expect(page.getByRole('heading', { name: 'Module settings' })).toBeVisible()
-  // A driver with a spec appears in the sidebar sub-menu.
+  // Click a driver: lands on the modules section with the driver focused.
+  await page
+    .locator('aside')
+    .getByRole('button', { name: /sherpa-onnx KWS/ })
+    .first()
+    .click()
+  await expect(page).toHaveURL(/#\/settings\/modules\/sherpa-onnx-kws/)
   await expect(
-    page.locator('aside').getByRole('button', { name: /sherpa|PLiX|OpenWakeWord/ }).first(),
+    page.getByRole('heading', { name: 'Module settings' }),
   ).toBeVisible()
 })
 

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -115,8 +115,7 @@ test('module settings persist only after Save', async ({ page }) => {
   )
   expect(stored || '').not.toContain('test keyword @wake')
 
-  // Save persists all drivers (the modules section's own Save button - the
-  // header Save is for platform settings and stays disabled here).
+  // Save persists everything (the single bottom Save bar).
   await page.getByRole('button', { name: 'Save' }).last().click()
   await page.waitForTimeout(150)
   stored = await page.evaluate(() =>

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -38,10 +38,12 @@ test('hash routing navigates between views', async ({ page }) => {
   await expect(page).toHaveURL(/#\/projects/)
   await expect(page.getByRole('main').getByRole('heading', { name: 'Projects' })).toBeVisible()
 
-  // Settings placeholder.
+  // Settings view (issue #52): real data-driven panel, not a placeholder.
   await sidebarNav(page, 'Settings')
   await expect(page).toHaveURL(/#\/settings/)
-  await expect(page.getByText('Coming soon')).toBeVisible()
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Settings' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'General' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Security' })).toBeVisible()
 
   // Device SDK placeholder.
   await sidebarNav(page, 'Device SDK')

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -38,12 +38,13 @@ test('hash routing navigates between views', async ({ page }) => {
   await expect(page).toHaveURL(/#\/projects/)
   await expect(page.getByRole('main').getByRole('heading', { name: 'Projects' })).toBeVisible()
 
-  // Settings view (issue #52): real data-driven panel, not a placeholder.
+  // Settings view (issue #52): sub-menu + real section content, not a
+  // placeholder. Clicking Settings opens the default (General) sub-route.
   await sidebarNav(page, 'Settings')
-  await expect(page).toHaveURL(/#\/settings/)
-  await expect(page.getByRole('main').getByRole('heading', { name: 'Settings' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'General' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Security' })).toBeVisible()
+  await expect(page).toHaveURL(/#\/settings\/general/)
+  await expect(page.getByRole('main').getByRole('heading', { name: 'General' })).toBeVisible()
+  // The sub-menu shows the other sections.
+  await expect(page.locator('aside').getByRole('button', { name: 'Security' })).toBeVisible()
 
   // Device SDK placeholder.
   await sidebarNav(page, 'Device SDK')

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -40,7 +40,7 @@ test('hash routing navigates between views', async ({ page }) => {
 
   // Settings view (issue #52): sub-menu + real section content, not a
   // placeholder. Clicking Settings opens the default (General) sub-route.
-  await sidebarNav(page, 'Settings')
+  await sidebarNav(page, 'Settings', true)
   await expect(page).toHaveURL(/#\/settings\/general/)
   await expect(page.getByRole('main').getByRole('heading', { name: 'General' })).toBeVisible()
   // The sub-menu shows the other sections.
@@ -152,6 +152,10 @@ test('workspace: create a project and it persists across reload', async ({ page 
 async function sidebarNav(
   page: import('@playwright/test').Page,
   name: string,
+  exact = false,
 ): Promise<void> {
-  await page.locator('aside').getByRole('button', { name }).click()
+  await page
+    .locator('aside')
+    .getByRole('button', { name, exact })
+    .click()
 }

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -38,11 +38,20 @@ test('hash routing navigates between views', async ({ page }) => {
   await expect(page).toHaveURL(/#\/projects/)
   await expect(page.getByRole('main').getByRole('heading', { name: 'Projects' })).toBeVisible()
 
-  // Settings view (issue #52): sub-menu + real section content, not a
-  // placeholder. Clicking Settings opens the default (General) sub-route.
-  await sidebarNav(page, 'Settings', true)
+  // Settings parent toggles the sub-menu (no navigation itself); click a
+  // sub-item to reach a section.
+  await page
+    .locator('aside')
+    .getByRole('button', { name: /Settings menu/ })
+    .click()
+  await expect(
+    page.locator('aside').getByRole('button', { name: 'General' }),
+  ).toBeVisible()
+  await page.locator('aside').getByRole('button', { name: 'General' }).click()
   await expect(page).toHaveURL(/#\/settings\/general/)
-  await expect(page.getByRole('main').getByRole('heading', { name: 'General' })).toBeVisible()
+  await expect(
+    page.getByRole('main').getByRole('heading', { name: 'General' }),
+  ).toBeVisible()
   // The sub-menu shows the other sections.
   await expect(page.locator('aside').getByRole('button', { name: 'Security' })).toBeVisible()
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,7 +6,8 @@
  * — their internals are refactored in Phase 2.
  */
 
-import { useConsoleRoute, settingsSectionOf } from "./router";
+import * as React from "react";
+import { useConsoleRoute, settingsSectionOf, settingsBackendFromHash } from "./router";
 import type { SettingsSection } from "./router";
 import { ConsoleShell } from "./components/ConsoleShell";
 import { ConsoleStatusProvider } from "./status";
@@ -23,6 +24,21 @@ import { RnnoisePlayground } from "@wake-studio/module-rnnoise/web";
 
 export default function App() {
   const [route, navigate] = useConsoleRoute();
+  // Driver anchor for the Modules section (Settings -> driver focus).
+  const [settingsBackend, setSettingsBackend] = React.useState<
+    string | undefined
+  >(() =>
+    typeof window === "undefined"
+      ? undefined
+      : settingsBackendFromHash(window.location.hash),
+  );
+
+  React.useEffect(() => {
+    const onHash = () =>
+      setSettingsBackend(settingsBackendFromHash(window.location.hash));
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
 
   return (
     <ConsoleStatusProvider>
@@ -37,10 +53,11 @@ export default function App() {
                 {route === "console" && <SessionConsoleView />}
                 {route === "playground-rnnoise" && <RnnoisePlayground />}
                 {settingsSectionOf(route) && (
-                <SettingsView
-                  section={settingsSectionOf(route) as SettingsSection}
-                />
-              )}
+                  <SettingsView
+                    section={settingsSectionOf(route) as SettingsSection}
+                    backendId={settingsBackend}
+                  />
+                )}
                 {route === "device-sdk" && (
                   <ComingSoonView
                     title="Device SDK"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,7 +6,8 @@
  * — their internals are refactored in Phase 2.
  */
 
-import { useConsoleRoute } from "./router";
+import { useConsoleRoute, settingsSectionOf } from "./router";
+import type { SettingsSection } from "./router";
 import { ConsoleShell } from "./components/ConsoleShell";
 import { ConsoleStatusProvider } from "./status";
 import { AppToastProvider } from "./components/toast";
@@ -35,7 +36,11 @@ export default function App() {
                 {route === "projects" && <ProjectsView />}
                 {route === "console" && <SessionConsoleView />}
                 {route === "playground-rnnoise" && <RnnoisePlayground />}
-                {route === "settings" && <SettingsView />}
+                {settingsSectionOf(route) && (
+                <SettingsView
+                  section={settingsSectionOf(route) as SettingsSection}
+                />
+              )}
                 {route === "device-sdk" && (
                   <ComingSoonView
                     title="Device SDK"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,48 +6,47 @@
  * — their internals are refactored in Phase 2.
  */
 
-import { useConsoleRoute } from './router'
-import { ConsoleShell } from './components/ConsoleShell'
-import { ConsoleStatusProvider } from './status'
-import { AppToastProvider } from './components/toast'
-import { ProjectProvider } from './projects'
-import { LogProvider } from './log'
-import { WorkspaceView } from './views/WorkspaceView'
-import { ModelLibraryView } from './views/ModelLibraryView'
-import { SessionConsoleView } from './views/SessionConsoleView'
-import { ComingSoonView, ProjectsView } from './views/placeholders'
-import { RnnoisePlayground } from '@wake-studio/module-rnnoise/web'
+import { useConsoleRoute } from "./router";
+import { ConsoleShell } from "./components/ConsoleShell";
+import { ConsoleStatusProvider } from "./status";
+import { AppToastProvider } from "./components/toast";
+import { ProjectProvider } from "./projects";
+import { LogProvider } from "./log";
+import { SettingsProvider } from "./settings";
+import { WorkspaceView } from "./views/WorkspaceView";
+import { ModelLibraryView } from "./views/ModelLibraryView";
+import { SessionConsoleView } from "./views/SessionConsoleView";
+import { SettingsView } from "./views/SettingsView";
+import { ComingSoonView, ProjectsView } from "./views/placeholders";
+import { RnnoisePlayground } from "@wake-studio/module-rnnoise/web";
 
 export default function App() {
-  const [route, navigate] = useConsoleRoute()
+  const [route, navigate] = useConsoleRoute();
 
   return (
     <ConsoleStatusProvider>
       <AppToastProvider>
         <ProjectProvider>
-          <LogProvider>
-            <ConsoleShell route={route} onNavigate={navigate}>
-              {route === 'workspace' && <WorkspaceView />}
-              {route === 'library' && <ModelLibraryView />}
-              {route === 'projects' && <ProjectsView />}
-              {route === 'console' && <SessionConsoleView />}
-              {route === 'playground-rnnoise' && <RnnoisePlayground />}
-              {route === 'settings' && (
-                <ComingSoonView
-                  title="Settings"
-                  description="Console preferences, model source configuration and export defaults will live here."
-                />
-              )}
-              {route === 'device-sdk' && (
-                <ComingSoonView
-                  title="Device SDK"
-                  description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
-                />
-              )}
-            </ConsoleShell>
-          </LogProvider>
+          <SettingsProvider>
+            <LogProvider>
+              <ConsoleShell route={route} onNavigate={navigate}>
+                {route === "workspace" && <WorkspaceView />}
+                {route === "library" && <ModelLibraryView />}
+                {route === "projects" && <ProjectsView />}
+                {route === "console" && <SessionConsoleView />}
+                {route === "playground-rnnoise" && <RnnoisePlayground />}
+                {route === "settings" && <SettingsView />}
+                {route === "device-sdk" && (
+                  <ComingSoonView
+                    title="Device SDK"
+                    description="Export kits and device-side SDK tooling for your target chips arrive in Phase 4."
+                  />
+                )}
+              </ConsoleShell>
+            </LogProvider>
+          </SettingsProvider>
         </ProjectProvider>
       </AppToastProvider>
     </ConsoleStatusProvider>
-  )
+  );
 }

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -57,7 +57,10 @@ export function ConsoleShell({
 
           {/* Mobile drawer */}
           <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
-            <DialogContent className="left-4 top-4 -translate-x-0 -translate-y-0 w-[min(80vw,17rem)] p-0">
+            <DialogContent
+              centered={false}
+              className="left-4 top-4 w-[min(80vw,17rem)] max-w-[calc(100vw-2rem)] p-0"
+            >
               <DialogTitle className="sr-only">Navigation</DialogTitle>
               <DialogDescription className="sr-only">
                 Primary navigation

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -22,6 +22,10 @@ const VIEW_TITLES: Record<ConsoleRoute, string> = {
   console: 'Session Console',
   'playground-rnnoise': 'RNNoise Playground',
   settings: 'Settings',
+  'settings-general': 'Settings · General',
+  'settings-security': 'Settings · Security',
+  'settings-data': 'Settings · Data',
+  'settings-modules': 'Settings · Modules',
   'device-sdk': 'Device SDK',
 }
 

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -8,7 +8,6 @@ import type { ConsoleRoute } from '../router'
 import { Sidebar, TopBar } from './shell'
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -57,39 +56,22 @@ export function ConsoleShell({
           </aside>
 
           {/* Mobile drawer: left-edge slide-in panel (GitHub-style), not a
-              centered dialog. Full-height, no rounding, animates from off-
-              screen left. */}
+              centered dialog. Left edge flush (no rounding), right edge
+              rounded (rounded-r-xl). */}
           <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
             <DialogContent
               centered={false}
-              className="drawer-content left-0 top-0 h-screen w-[min(80vw,17rem)] max-w-[calc(100vw-2rem)] rounded-none border-l border-t-0 border-r-0 border-b-0 p-0 data-[state=open]:animate-[drawer-in_180ms_ease-out] data-[state=closed]:animate-[drawer-out_160ms_ease-in]"
+              className="drawer-content left-0 top-0 h-screen w-[min(80vw,17rem)] max-w-[calc(100vw-2rem)] rounded-r-xl border-l border-t-0 border-r-0 border-b-0 p-0 data-[state=open]:animate-[drawer-in_180ms_ease-out] data-[state=closed]:animate-[drawer-out_160ms_ease-in]"
             >
               <DialogTitle className="sr-only">Navigation</DialogTitle>
               <DialogDescription className="sr-only">
                 Primary navigation
               </DialogDescription>
-              <div className="flex h-full flex-col">
-                {/* Close button pinned top-right of the drawer. */}
-                <div className="flex justify-end border-b border-line px-3 py-2">
-                  <DialogClose
-                    className="rounded-md p-1.5 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
-                    aria-label="Close navigation"
-                  >
-                    <svg
-                      viewBox="0 0 16 16"
-                      className="h-4 w-4"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                    >
-                      <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
-                    </svg>
-                  </DialogClose>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  <Sidebar route={route} onNavigate={navigate} />
-                </div>
-              </div>
+              <Sidebar
+                route={route}
+                onNavigate={navigate}
+                onClose={() => setMobileNavOpen(false)}
+              />
             </DialogContent>
           </Dialog>
 

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -55,11 +55,13 @@ export function ConsoleShell({
             <Sidebar route={route} onNavigate={navigate} />
           </aside>
 
-          {/* Mobile drawer */}
+          {/* Mobile drawer: left-edge slide-in panel (GitHub-style), not a
+              centered dialog. Full-height, no rounding, animates from off-
+              screen left. */}
           <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
             <DialogContent
               centered={false}
-              className="left-4 top-4 w-[min(80vw,17rem)] max-w-[calc(100vw-2rem)] p-0"
+              className="drawer-content left-0 top-0 h-screen w-[min(80vw,17rem)] max-w-[calc(100vw-2rem)] rounded-none border-l border-t-0 border-r-0 border-b-0 p-0 data-[state=open]:animate-[drawer-in_180ms_ease-out] data-[state=closed]:animate-[drawer-out_160ms_ease-in]"
             >
               <DialogTitle className="sr-only">Navigation</DialogTitle>
               <DialogDescription className="sr-only">

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -8,6 +8,7 @@ import type { ConsoleRoute } from '../router'
 import { Sidebar, TopBar } from './shell'
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -67,7 +68,28 @@ export function ConsoleShell({
               <DialogDescription className="sr-only">
                 Primary navigation
               </DialogDescription>
-              <Sidebar route={route} onNavigate={navigate} />
+              <div className="flex h-full flex-col">
+                {/* Close button pinned top-right of the drawer. */}
+                <div className="flex justify-end border-b border-line px-3 py-2">
+                  <DialogClose
+                    className="rounded-md p-1.5 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+                    aria-label="Close navigation"
+                  >
+                    <svg
+                      viewBox="0 0 16 16"
+                      className="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    >
+                      <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+                    </svg>
+                  </DialogClose>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <Sidebar route={route} onNavigate={navigate} />
+                </div>
+              </div>
             </DialogContent>
           </Dialog>
 

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -12,7 +12,7 @@
  * registration spec (ADR-025) - adding a driver never edits this file.
  */
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { AFEPipeline } from '@wake-studio/module-afe-graph'
 import {
   KWSEngine,
@@ -33,6 +33,8 @@ import { loadRegistry, type ModelRegistry } from '@wake-studio/platform'
 import type { ModuleSpec, ModuleParam } from '@wake-studio/contracts'
 import { UnifiedConfigPanel, type ParamValue } from './UnifiedConfigPanel'
 import { useProjectStageConfig } from '../projects'
+import { useAppSettings } from '../settings/context'
+import { loadModuleSettings, saveModuleSettings } from '../settings/storage'
 import { logTrigger, logInfo, logError } from '../log'
 // Few-Shot enrollment (plixkws branch): the engine is the headless
 // enrollment/prototype layer (ADR-013 amendment - client-side only); the
@@ -255,6 +257,7 @@ export const KWSPanel = memo(function KWSPanel({
   const [warmup, setWarmup] = useState(false)
   // Seed config from the active project's KWS snapshot (falls back to defaults).
   const { projectConfig: projCfg, persist } = useProjectStageConfig('kws')
+  const { kwsSources, setKwsSources } = useAppSettings()
   const [config, setConfig] = useState<KWSConfig>({
     ...DEFAULT_CONFIG,
     ...(projCfg as Partial<KWSConfig> | undefined),
@@ -300,8 +303,25 @@ export const KWSPanel = memo(function KWSPanel({
   // User-selectable model sources per role (ModelSourceEditor). Keyed by
   // role; value is the selected registry id or 'custom' (URL follows).
   // Defaults to undefined -> the built-in registry URL is used.
-  const [modelSources, setModelSources] = useState<Record<string, string | undefined>>({})
-  const [customUrls, setCustomUrls] = useState<Record<string, string>>({})
+  // Persistence (#52/#53): seeded from the app-level kwsSources defaults
+  // (localStorage); the #53 WorkspaceConfig project snapshot will override
+  // per project when it lands. Writes persist to app defaults.
+  const [modelSources, setModelSources] = useState<Record<string, string | undefined>>(
+    () => ({ ...(kwsSources.modelSources ?? {}) }),
+  )
+  const [customUrls, setCustomUrls] = useState<Record<string, string>>(
+    () => ({ ...(kwsSources.customUrls ?? {}) }),
+  )
+  // Persist edits to app-level defaults on change (#52/#53). Skipped on
+  // first mount (initial values already come from kwsSources).
+  const firstRenderRef = useRef(true)
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false
+      return
+    }
+    setKwsSources({ modelSources, customUrls })
+  }, [modelSources, customUrls, setKwsSources])
   // The loaded registry (for the selector options); loaded lazily on demand.
   const [registryModels, setRegistryModels] = useState<ModelRegistry | null>(null)
   // User model library (IndexedDB): local-file imports and future training
@@ -379,13 +399,26 @@ export const KWSPanel = memo(function KWSPanel({
   // The selected backend's own params, from its registration spec (ADR-025).
   // Empty when the backend carries no spec (no driver config panel).
   const driverParams = driverParamsFor(config.backend)
-  // Editable driver param values, seeded from the spec defaults; edited via
-  // the config panel, then passed to engine.load on the next Load.
+  // Editable driver param values, seeded from the app-level module defaults
+  // (#52) + the active project's snapshot override (#53 P1 layered
+  // persistence), falling back to the spec defaults. Edited via the config
+  // panel, then passed to engine.load on the next Load.
+  const appDriverDefaults = useMemo(() => {
+    const all = loadModuleSettings()
+    return (all[config.backend] as Record<string, unknown>) ?? {}
+  }, [config.backend])
   const [driverValues, setDriverValues] = useState<Record<string, ParamValue>>(
-    () =>
-      Object.fromEntries(
+    () => {
+      const specDefaults = Object.fromEntries(
         driverParamsFor(config.backend).map((p) => [p.id, p.default]),
-      ),
+      )
+      // Layer order: spec defaults < app module defaults (#52). The #53
+      // WorkspaceConfig project-snapshot override lands with that epic.
+      return {
+        ...specDefaults,
+        ...appDriverDefaults,
+      } as Record<string, ParamValue>
+    },
   )
 
   // Reset driver param values when the backend changes (each driver's spec
@@ -395,12 +428,30 @@ export const KWSPanel = memo(function KWSPanel({
     const prev = driverBackendRef.current
     driverBackendRef.current = config.backend
     if (prev === config.backend) return
-    setDriverValues(
-      Object.fromEntries(
-        driverParamsFor(config.backend).map((p) => [p.id, p.default]),
-      ),
+    const specDefaults = Object.fromEntries(
+      driverParamsFor(config.backend).map((p) => [p.id, p.default]),
     )
+    const appDefaults = (loadModuleSettings()[config.backend] as
+      | Record<string, unknown>
+      | undefined) ?? {}
+    setDriverValues({
+      ...specDefaults,
+      ...appDefaults,
+    } as Record<string, ParamValue>)
   }, [config.backend])
+
+  // Persist driver param edits to app-level module defaults on change (#52).
+  // Skipped on first render + backend-switch resets (those set spec defaults).
+  const driverFirstRef = useRef(true)
+  useEffect(() => {
+    if (driverFirstRef.current) {
+      driverFirstRef.current = false
+      return
+    }
+    if (Object.keys(driverValues).length > 0) {
+      saveModuleSettings(config.backend, { ...driverValues })
+    }
+  }, [driverValues, config.backend])
 
   const params = describeParameters()
 

--- a/apps/web/src/components/shell-nav.ts
+++ b/apps/web/src/components/shell-nav.ts
@@ -5,7 +5,8 @@
  * about non-component exports in a component file.
  */
 
-import type { ConsoleRoute } from '../router'
+import type { ConsoleRoute, SettingsSection } from '../router'
+import { settingsRoute } from '../router'
 import {
   IconWorkspace,
   IconLibrary,
@@ -20,6 +21,22 @@ export interface NavItem {
   label: string
   icon: React.ComponentType<{ size?: number; className?: string }>
   badge?: string
+  /** Child sub-menu items (expanded in the sidebar, e.g. Settings sections). */
+  children?: SettingsNavItem[]
+}
+
+export interface SettingsNavItem {
+  /** Settings sub-route (settings-general etc). */
+  route: ConsoleRoute
+  label: string
+  /** Optional nested driver items (Modules section expands to drivers). */
+  children?: DriverNavItem[]
+}
+
+export interface DriverNavItem {
+  /** Backend id (module settings key). */
+  backendId: string
+  label: string
 }
 
 export const PRIMARY_NAV: NavItem[] = [
@@ -29,7 +46,27 @@ export const PRIMARY_NAV: NavItem[] = [
   { route: 'console', label: 'Console', icon: IconConsole },
 ]
 
+/** Settings sections shown as the Settings sub-menu. */
+export const SETTINGS_NAV: SettingsNavItem[] = [
+  { route: settingsRoute('general'), label: 'General' },
+  { route: settingsRoute('security'), label: 'Security' },
+  { route: settingsRoute('data'), label: 'Data' },
+  { route: settingsRoute('modules'), label: 'Modules' },
+]
+
 export const SECONDARY_NAV: NavItem[] = [
   { route: 'device-sdk', label: 'Device SDK', icon: IconChip, badge: 'soon' },
-  { route: 'settings', label: 'Settings', icon: IconSettings },
+  {
+    route: 'settings',
+    label: 'Settings',
+    icon: IconSettings,
+    children: SETTINGS_NAV,
+  },
 ]
+
+/** True when a route is one of the settings sub-routes. */
+export function isSettingsRoute(route: ConsoleRoute): boolean {
+  return route.startsWith('settings')
+}
+
+export type { SettingsSection }

--- a/apps/web/src/components/shell-nav.ts
+++ b/apps/web/src/components/shell-nav.ts
@@ -29,14 +29,6 @@ export interface SettingsNavItem {
   /** Settings sub-route (settings-general etc). */
   route: ConsoleRoute
   label: string
-  /** Optional nested driver items (Modules section expands to drivers). */
-  children?: DriverNavItem[]
-}
-
-export interface DriverNavItem {
-  /** Backend id (module settings key). */
-  backendId: string
-  label: string
 }
 
 export const PRIMARY_NAV: NavItem[] = [
@@ -51,7 +43,6 @@ export const SETTINGS_NAV: SettingsNavItem[] = [
   { route: settingsRoute('general'), label: 'General' },
   { route: settingsRoute('security'), label: 'Security' },
   { route: settingsRoute('data'), label: 'Data' },
-  { route: settingsRoute('modules'), label: 'Modules' },
 ]
 
 export const SECONDARY_NAV: NavItem[] = [

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -117,7 +117,9 @@ function SettingsNav({
       <div className="flex w-full items-center gap-2.5">
         <NavButton
           item={item}
-          active={isOpen}
+          // Keep the focus on the clicked sub-item: the Settings parent is
+          // not highlighted when a sub-menu item is active.
+          active={false}
           onClick={() => onNavigate(settingsRouteOf(route))}
         />
         <button

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -11,7 +11,11 @@
 
 import * as React from 'react'
 import type { ConsoleRoute } from '../router'
-import { settingsSectionOf } from '../router'
+import {
+  settingsSectionOf,
+  settingsHash,
+  settingsBackendFromHash,
+} from '../router'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui'
 import { PRIMARY_NAV, SECONDARY_NAV, isSettingsRoute, type NavItem } from './shell-nav'
 import type { ConsoleStatus } from '../status'
@@ -80,60 +84,100 @@ function SettingsNav({
   route,
   onNavigate,
   drivers,
+  settingsBackend,
 }: {
   item: NavItem
   route: ConsoleRoute
   onNavigate: (r: ConsoleRoute) => void
   drivers: ReadonlyArray<{ backendId: string; label: string }>
+  settingsBackend?: string
 }) {
-  const open = isSettingsRoute(route)
+  const isOpen = isSettingsRoute(route)
   const activeSection = settingsSectionOf(route)
+  const [open, setOpen] = React.useState(isOpen)
+  // Keep the sub-menu open when navigating within settings.
+  React.useEffect(() => {
+    if (isOpen) setOpen(true)
+  }, [isOpen])
+
+  const toggle = () => {
+    setOpen((o) => !o)
+    if (!open) onNavigate('settings-general')
+  }
+
+  const driversActive = activeSection === 'modules'
+
+  // Settings -> xxx: sections first, then drivers directly (no Modules layer).
+  const sections = (item.children ?? []).filter(
+    (c) => c.route !== 'settings-modules',
+  )
+
   return (
     <div>
-      <NavButton
-        item={item}
-        active={open}
-        onClick={() => onNavigate(settingsRouteOf(route))}
-      />
+      <div className="flex w-full items-center gap-2.5">
+        <NavButton
+          item={item}
+          active={isOpen}
+          onClick={() => onNavigate(settingsRouteOf(route))}
+        />
+        <button
+          onClick={toggle}
+          aria-label={open ? 'Collapse Settings menu' : 'Expand Settings menu'}
+          aria-expanded={open}
+          className="rounded p-0.5 text-ink-3 hover:bg-surface-3 hover:text-ink-1"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-90')}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
+
       {open && (
         <div className="ml-3 mt-0.5 space-y-0.5 border-l border-line pl-2">
-          {item.children?.map((child) => {
+          {sections.map((child) => {
             const childActive = activeSection === settingsSectionOf(child.route)
-            const isModules = child.route === 'settings-modules'
             return (
-              <div key={child.route}>
-                <button
-                  onClick={() => onNavigate(child.route)}
-                  aria-current={childActive ? 'page' : undefined}
-                  className={cn(
-                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors',
-                    childActive
-                      ? 'bg-brand-500/10 text-brand-700'
-                      : 'text-ink-3 hover:bg-surface-3 hover:text-ink-1',
-                  )}
-                >
-                  <span className="flex-1 truncate text-left">{child.label}</span>
-                  {isModules && drivers.length > 0 && (
-                    <span className="rounded bg-surface-4 px-1.5 py-0.5 text-[10px] text-ink-3">
-                      {drivers.length}
-                    </span>
-                  )}
-                </button>
-                {/* Modules expands to per-driver items. */}
-                {isModules && childActive && drivers.length > 0 && (
-                  <div className="ml-2 mt-0.5 space-y-0.5 border-l border-line pl-2">
-                    {drivers.map((d) => (
-                      <button
-                        key={d.backendId}
-                        onClick={() => onNavigate('settings-modules')}
-                        className="flex w-full items-center gap-2 truncate rounded-md px-2 py-1 text-xs text-ink-3 hover:bg-surface-3 hover:text-ink-1"
-                      >
-                        {d.label}
-                      </button>
-                    ))}
-                  </div>
+              <button
+                key={child.route}
+                onClick={() => onNavigate(child.route)}
+                aria-current={childActive ? 'page' : undefined}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors',
+                  childActive
+                    ? 'bg-brand-500/10 text-brand-700'
+                    : 'text-ink-3 hover:bg-surface-3 hover:text-ink-1',
                 )}
-              </div>
+              >
+                <span className="flex-1 truncate text-left">{child.label}</span>
+              </button>
+            )
+          })}
+
+          {/* Drivers: Settings -> driver (keeps focus on the clicked one). */}
+          {drivers.map((d) => {
+            const active = driversActive && d.backendId === settingsBackend
+            return (
+              <button
+                key={d.backendId}
+                onClick={() => {
+                  window.location.hash = settingsHash('modules', d.backendId)
+                }}
+                aria-current={active ? 'page' : undefined}
+                className={cn(
+                  'flex w-full items-center gap-2 truncate rounded-md px-2 py-1.5 text-[13px] transition-colors',
+                  active
+                    ? 'bg-brand-500/10 text-brand-700'
+                    : 'text-ink-3 hover:bg-surface-3 hover:text-ink-1',
+                )}
+              >
+                <span className="flex-1 truncate text-left">{d.label}</span>
+              </button>
             )
           })}
         </div>
@@ -178,6 +222,16 @@ export function Sidebar({
   onNavigate: (r: ConsoleRoute) => void
 }) {
   const drivers = useSettingsDrivers()
+  // Current driver anchor (Settings -> driver focus).
+  const [settingsBackend, setSettingsBackend] = React.useState<string | undefined>(
+    () => settingsBackendFromHash(window.location.hash),
+  )
+  React.useEffect(() => {
+    const onHash = () =>
+      setSettingsBackend(settingsBackendFromHash(window.location.hash))
+    window.addEventListener('hashchange', onHash)
+    return () => window.removeEventListener('hashchange', onHash)
+  }, [])
   return (
     <div className="flex h-full w-full flex-col gap-1 overflow-y-auto p-3">
       <div className="mb-2 flex items-center gap-2 px-1.5">
@@ -203,6 +257,7 @@ export function Sidebar({
               route={route}
               onNavigate={onNavigate}
               drivers={drivers}
+              settingsBackend={settingsBackend}
             />
           ) : (
             <NavButton

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -75,9 +75,9 @@ function NavButton({
 }
 
 /**
- * Render the Settings parent + its expanded sub-menu (sections, Modules
- * expands to drivers). The sub-menu is always visible when the Settings
- * parent is active or the current route is a settings sub-route.
+ * Render the Settings parent + its expanded sub-menu. The parent is a single
+ * full-width button (icon + label + chevron) that only toggles open/closed -
+ * no navigation. Clicking a sub-item navigates. Hover covers the whole row.
  */
 function SettingsNav({
   item,
@@ -100,11 +100,7 @@ function SettingsNav({
     if (isOpen) setOpen(true)
   }, [isOpen])
 
-  const toggle = () => {
-    setOpen((o) => !o)
-    if (!open) onNavigate('settings-general')
-  }
-
+  const Icon = item.icon
   const driversActive = activeSection === 'modules'
 
   // Settings -> xxx: sections first, then drivers directly (no Modules layer).
@@ -114,35 +110,34 @@ function SettingsNav({
 
   return (
     <div>
-      <div className="flex w-full items-center gap-2.5">
-        <NavButton
-          item={item}
-          // Keep the focus on the clicked sub-item: the Settings parent is
-          // not highlighted when a sub-menu item is active.
-          active={false}
-          onClick={() => onNavigate(settingsRouteOf(route))}
-        />
-        <button
-          onClick={toggle}
-          aria-label={open ? 'Collapse Settings menu' : 'Expand Settings menu'}
-          aria-expanded={open}
-          className="rounded p-0.5 text-ink-3 hover:bg-surface-3 hover:text-ink-1"
+      {/* Parent: toggles open/closed only, no navigation. */}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-label={`Settings menu ${open ? 'collapsed' : 'expanded'}`}
+        className={cn(
+          'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors',
+          'text-ink-2 hover:bg-surface-3 hover:text-ink-1',
+        )}
+      >
+        <Icon className="h-[18px] w-[18px] shrink-0" />
+        <span className="flex-1 truncate text-left">{item.label}</span>
+        <svg
+          viewBox="0 0 16 16"
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-ink-3 transition-transform group-hover:text-ink-1',
+            open && 'rotate-90',
+          )}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
         >
-          <svg
-            viewBox="0 0 16 16"
-            className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-90')}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </button>
-      </div>
+          <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
 
       {open && (
-        <div className="ml-3 mt-0.5 space-y-0.5 border-l border-line pl-2">
-          {sections.map((child) => {
+        <div className="ml-3 mt-0.5 space-y-0.5 border-l border-line pl-2">          {sections.map((child) => {
             const childActive = activeSection === settingsSectionOf(child.route)
             return (
               <button
@@ -186,11 +181,6 @@ function SettingsNav({
       )}
     </div>
   )
-}
-
-/** The canonical settings route for the sidebar parent click. */
-function settingsRouteOf(route: ConsoleRoute): ConsoleRoute {
-  return isSettingsRoute(route) ? route : 'settings-general'
 }
 
 function NavSection({ title, items, route, onNavigate }: {

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -209,9 +209,12 @@ function NavSection({ title, items, route, onNavigate }: {
 export function Sidebar({
   route,
   onNavigate,
+  onClose,
 }: {
   route: ConsoleRoute
   onNavigate: (r: ConsoleRoute) => void
+  /** When set (mobile drawer), renders a Close button beside the logo. */
+  onClose?: () => void
 }) {
   const drivers = useSettingsDrivers()
   // Current driver anchor (Settings -> driver focus).
@@ -228,12 +231,29 @@ export function Sidebar({
     <div className="flex h-full w-full flex-col gap-1 overflow-y-auto p-3">
       <div className="mb-2 flex items-center gap-2 px-1.5">
         <Logo />
-        <div className="flex flex-col leading-tight">
+        <div className="flex min-w-0 flex-1 flex-col leading-tight">
           <span className="text-sm font-semibold tracking-tight text-ink-1">
             WakeStudio
           </span>
           <span className="text-[11px] text-ink-3">on-device KWS studio</span>
         </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            aria-label="Close navigation"
+            className="rounded-md p-1.5 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+            </svg>
+          </button>
+        )}
       </div>
 
       <NavSection title="Studio" items={PRIMARY_NAV} route={route} onNavigate={onNavigate} />

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -9,11 +9,14 @@
  * hand-rolled nav state.
  */
 
+import * as React from 'react'
 import type { ConsoleRoute } from '../router'
+import { settingsSectionOf } from '../router'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui'
-import { PRIMARY_NAV, SECONDARY_NAV, type NavItem } from './shell-nav'
+import { PRIMARY_NAV, SECONDARY_NAV, isSettingsRoute, type NavItem } from './shell-nav'
 import type { ConsoleStatus } from '../status'
 import { cn } from './cn'
+import { getBackendRegistry } from '@wake-studio/module-kws-engine'
 
 function Logo() {
   return (
@@ -67,6 +70,83 @@ function NavButton({
   )
 }
 
+/**
+ * Render the Settings parent + its expanded sub-menu (sections, Modules
+ * expands to drivers). The sub-menu is always visible when the Settings
+ * parent is active or the current route is a settings sub-route.
+ */
+function SettingsNav({
+  item,
+  route,
+  onNavigate,
+  drivers,
+}: {
+  item: NavItem
+  route: ConsoleRoute
+  onNavigate: (r: ConsoleRoute) => void
+  drivers: ReadonlyArray<{ backendId: string; label: string }>
+}) {
+  const open = isSettingsRoute(route)
+  const activeSection = settingsSectionOf(route)
+  return (
+    <div>
+      <NavButton
+        item={item}
+        active={open}
+        onClick={() => onNavigate(settingsRouteOf(route))}
+      />
+      {open && (
+        <div className="ml-3 mt-0.5 space-y-0.5 border-l border-line pl-2">
+          {item.children?.map((child) => {
+            const childActive = activeSection === settingsSectionOf(child.route)
+            const isModules = child.route === 'settings-modules'
+            return (
+              <div key={child.route}>
+                <button
+                  onClick={() => onNavigate(child.route)}
+                  aria-current={childActive ? 'page' : undefined}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors',
+                    childActive
+                      ? 'bg-brand-500/10 text-brand-700'
+                      : 'text-ink-3 hover:bg-surface-3 hover:text-ink-1',
+                  )}
+                >
+                  <span className="flex-1 truncate text-left">{child.label}</span>
+                  {isModules && drivers.length > 0 && (
+                    <span className="rounded bg-surface-4 px-1.5 py-0.5 text-[10px] text-ink-3">
+                      {drivers.length}
+                    </span>
+                  )}
+                </button>
+                {/* Modules expands to per-driver items. */}
+                {isModules && childActive && drivers.length > 0 && (
+                  <div className="ml-2 mt-0.5 space-y-0.5 border-l border-line pl-2">
+                    {drivers.map((d) => (
+                      <button
+                        key={d.backendId}
+                        onClick={() => onNavigate('settings-modules')}
+                        className="flex w-full items-center gap-2 truncate rounded-md px-2 py-1 text-xs text-ink-3 hover:bg-surface-3 hover:text-ink-1"
+                      >
+                        {d.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** The canonical settings route for the sidebar parent click. */
+function settingsRouteOf(route: ConsoleRoute): ConsoleRoute {
+  return isSettingsRoute(route) ? route : 'settings-general'
+}
+
 function NavSection({ title, items, route, onNavigate }: {
   title: string
   items: NavItem[]
@@ -97,6 +177,7 @@ export function Sidebar({
   route: ConsoleRoute
   onNavigate: (r: ConsoleRoute) => void
 }) {
+  const drivers = useSettingsDrivers()
   return (
     <div className="flex h-full w-full flex-col gap-1 overflow-y-auto p-3">
       <div className="mb-2 flex items-center gap-2 px-1.5">
@@ -110,7 +191,29 @@ export function Sidebar({
       </div>
 
       <NavSection title="Studio" items={PRIMARY_NAV} route={route} onNavigate={onNavigate} />
-      <NavSection title="Platform" items={SECONDARY_NAV} route={route} onNavigate={onNavigate} />
+      <div className="space-y-0.5">
+        <div className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-widest text-ink-3">
+          Platform
+        </div>
+        {SECONDARY_NAV.map((item) =>
+          item.route === 'settings' ? (
+            <SettingsNav
+              key={item.route}
+              item={item}
+              route={route}
+              onNavigate={onNavigate}
+              drivers={drivers}
+            />
+          ) : (
+            <NavButton
+              key={item.route}
+              item={item}
+              active={route === item.route}
+              onClick={() => onNavigate(item.route)}
+            />
+          ),
+        )}
+      </div>
 
       <div className="mt-auto px-2.5 pt-2 text-[11px] leading-relaxed text-ink-3">
         <div className="rounded-lg border border-line bg-surface-2 px-2.5 py-2">
@@ -119,6 +222,19 @@ export function Sidebar({
         </div>
       </div>
     </div>
+  )
+}
+
+/** Drivers with a spec, for the Modules sub-menu (registry-driven, ADR-024). */
+function useSettingsDrivers(): ReadonlyArray<{ backendId: string; label: string }> {
+  // The KWS backend registry is populated at import time by driver modules;
+  // a new driver with a spec automatically appears in the sub-menu.
+  return React.useMemo(
+    () =>
+      getBackendRegistry()
+        .filter((r) => r.spec?.params?.length)
+        .map((r) => ({ backendId: r.id, label: r.label })),
+    [],
   )
 }
 

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -40,16 +40,22 @@ export const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = 'DialogOverlay'
 export const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    /** Center on screen (default). When false, no positioning classes are
+     *  applied so the caller can position it (e.g. a side drawer). */
+    centered?: boolean
+  }
+>(({ className, children, centered = true, ...props }, ref) => (
   <DialogPrimitive.Portal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 w-[min(92vw,26rem)] -translate-x-1/2 -translate-y-1/2',
-        'rounded-xl border border-line bg-surface-2 p-6 shadow-2xl',
+        'z-50 rounded-xl border border-line bg-surface-2 shadow-2xl',
         'outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+        centered
+          ? 'fixed left-1/2 top-1/2 w-[min(92vw,26rem)] -translate-x-1/2 -translate-y-1/2 p-6'
+          : 'fixed',
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -30,7 +30,9 @@ export const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-[2px]',
+      // Light dim, no blur - a subtle scrim so the drawer/dialog stands out
+      // without darkening or blurring the page behind it.
+      'fixed inset-0 z-50 bg-slate-900/20',
       'data-[state=open]:animate-in data-[state=closed]:animate-out',
       className,
     )}
@@ -51,10 +53,10 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'z-50 rounded-xl border border-line bg-surface-2 shadow-2xl',
+        'z-50 border border-line bg-surface-2 shadow-2xl',
         'outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
         centered
-          ? 'fixed left-1/2 top-1/2 w-[min(92vw,26rem)] -translate-x-1/2 -translate-y-1/2 p-6'
+          ? 'fixed left-1/2 top-1/2 w-[min(92vw,26rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl p-6'
           : 'fixed',
         className,
       )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,6 +3,19 @@
 @tailwind utilities;
 
 /*
+ * Mobile drawer slide-in (GitHub-style left-edge panel, paired with
+ * data-state data-[state=open]/closed in ConsoleShell).
+ */
+@keyframes drawer-in {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
+}
+@keyframes drawer-out {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-100%); }
+}
+
+/*
  * WakeStudio semantic design tokens (light theme, v1).
  *
  * Components use semantic utilities (bg-surface, text-ink-2, border-line...)

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -42,6 +42,28 @@ const ROUTE_BY_HASH: Record<string, ConsoleRoute> = {
   '/': 'workspace',
 }
 
+/**
+ * Parse the settings backend anchor from the hash, e.g.
+ * `#/settings/modules/plixkws` -> 'plixkws'. Used to keep focus on the
+ * driver the user clicked in the sidebar (Settings -> driver).
+ */
+export function settingsBackendFromHash(hash: string): string | undefined {
+  const raw = hash.replace(/^#/, '')
+  const prefix = '/settings/modules/'
+  if (!raw.startsWith(prefix)) return undefined
+  const id = raw.slice(prefix.length).split('/')[0]
+  return id || undefined
+}
+
+/**
+ * Build the settings hash for a section, optionally anchored to a driver
+ * (e.g. `/settings/modules/plixkws`).
+ */
+export function settingsHash(section: SettingsSection, backendId?: string): string {
+  const base = routeToHash(settingsRoute(section))
+  return backendId ? `${base}/${backendId}` : base
+}
+
 /** Map a route to its canonical hash (without the leading '#'). */
 export function routeToHash(route: ConsoleRoute): string {
   switch (route) {
@@ -102,6 +124,8 @@ export function settingsSectionOf(route: ConsoleRoute): SettingsSection | undefi
 
 function parseHash(): ConsoleRoute {
   const raw = window.location.hash.replace(/^#/, '')
+  // /settings/modules/<backendId> also maps to settings-modules.
+  if (raw.startsWith('/settings/modules/')) return 'settings-modules'
   return ROUTE_BY_HASH[raw] ?? DEFAULT_ROUTE
 }
 

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -15,7 +15,14 @@ export type ConsoleRoute =
   | 'console'
   | 'playground-rnnoise'
   | 'settings'
+  | 'settings-general'
+  | 'settings-security'
+  | 'settings-data'
+  | 'settings-modules'
   | 'device-sdk'
+
+/** Settings sub-views (driven from the sidebar sub-menu). */
+export type SettingsSection = 'general' | 'security' | 'data' | 'modules'
 
 export const DEFAULT_ROUTE: ConsoleRoute = 'workspace'
 
@@ -26,6 +33,10 @@ const ROUTE_BY_HASH: Record<string, ConsoleRoute> = {
   '/console': 'console',
   '/playground/rnnoise': 'playground-rnnoise',
   '/settings': 'settings',
+  '/settings/general': 'settings-general',
+  '/settings/security': 'settings-security',
+  '/settings/data': 'settings-data',
+  '/settings/modules': 'settings-modules',
   '/device-sdk': 'device-sdk',
   '': 'workspace',
   '/': 'workspace',
@@ -45,9 +56,47 @@ export function routeToHash(route: ConsoleRoute): string {
     case 'playground-rnnoise':
       return '/playground/rnnoise'
     case 'settings':
-      return '/settings'
+      return '/settings/general'
+    case 'settings-general':
+      return '/settings/general'
+    case 'settings-security':
+      return '/settings/security'
+    case 'settings-data':
+      return '/settings/data'
+    case 'settings-modules':
+      return '/settings/modules'
     case 'device-sdk':
       return '/device-sdk'
+  }
+}
+
+/** Map a SettingsSection to its ConsoleRoute. */
+export function settingsRoute(section: SettingsSection): ConsoleRoute {
+  switch (section) {
+    case 'general':
+      return 'settings-general'
+    case 'security':
+      return 'settings-security'
+    case 'data':
+      return 'settings-data'
+    case 'modules':
+      return 'settings-modules'
+  }
+}
+
+/** Map a ConsoleRoute back to its SettingsSection (or undefined). */
+export function settingsSectionOf(route: ConsoleRoute): SettingsSection | undefined {
+  switch (route) {
+    case 'settings-general':
+      return 'general'
+    case 'settings-security':
+      return 'security'
+    case 'settings-data':
+      return 'data'
+    case 'settings-modules':
+      return 'modules'
+    default:
+      return undefined
   }
 }
 

--- a/apps/web/src/settings/ModuleSettings.tsx
+++ b/apps/web/src/settings/ModuleSettings.tsx
@@ -1,0 +1,76 @@
+/**
+ * Module settings - registry-driven module groups (issue #52).
+ *
+ * Iterates the KWS backend registry and renders one group per driver that
+ * carries a `spec` (ADR-025). Only drivers WITH a spec are listed
+ * (human-confirmed): openwakeword has no spec.params today, so sherpa and
+ * plix appear.
+ *
+ * Values persist to `wake-studio:settings:module` (per backendId). These are
+ * the app-level defaults; the KWS panel (issue #53 P1) reads them as seeds
+ * and lets the active project's snapshot override per project.
+ */
+
+import * as React from 'react'
+import { renderParamRow } from '@wake-studio/module-kit'
+import { getBackendRegistry } from '@wake-studio/module-kws-engine'
+import { useAppSettings } from './context'
+import { mergeModuleDefaults } from './storage'
+
+export function ModuleSettingsSection() {
+  const { module, setModuleBackend } = useAppSettings()
+  const drivers = React.useMemo(
+    () => getBackendRegistry().filter((r) => r.spec?.params?.length),
+    [],
+  )
+
+  if (drivers.length === 0) {
+    return (
+      <p className="text-sm text-ink-3">
+        No module settings yet — drivers that carry a spec appear here
+        automatically.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {drivers.map((driver) => {
+        const defaults = Object.fromEntries(
+          driver.spec!.params.map((p) => [p.id, p.default]),
+        )
+        const values = mergeModuleDefaults(module[driver.id], defaults)
+        return (
+          <div
+            key={driver.id}
+            className="rounded-xl border border-line bg-surface-2 p-5"
+          >
+            <h3 className="mb-1 text-sm font-semibold text-ink-1">
+              {driver.label}
+            </h3>
+            <p className="mb-3 text-xs text-ink-3">
+              Params from the driver module spec (ADR-025). Persisted locally
+              as app defaults; per-project overrides live in the project
+              snapshot.
+            </p>
+            <div className="divide-y divide-line">
+              {driver.spec!.params.map((param) => (
+                <div key={param.id} className="py-1">
+                  {renderParamRow(
+                    param,
+                    values[param.id] ?? param.default,
+                    (v: unknown) =>
+                      setModuleBackend(driver.id, {
+                        ...values,
+                        [param.id]: v,
+                      }),
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/settings/ModuleSettings.tsx
+++ b/apps/web/src/settings/ModuleSettings.tsx
@@ -16,13 +16,27 @@ import { renderParamRow } from '@wake-studio/module-kit'
 import { getBackendRegistry } from '@wake-studio/module-kws-engine'
 import { useAppSettings } from './context'
 import { mergeModuleDefaults } from './storage'
+import { cn } from '../components/cn'
 
-export function ModuleSettingsSection() {
+export function ModuleSettingsSection({
+  focusBackendId,
+}: {
+  /** Driver to keep focused (from the sidebar Settings -> driver). */
+  focusBackendId?: string
+}) {
   const { module, setModuleBackend } = useAppSettings()
   const drivers = React.useMemo(
     () => getBackendRegistry().filter((r) => r.spec?.params?.length),
     [],
   )
+
+  // Scroll the focused driver card into view once.
+  const focusedRef = React.useRef<HTMLDivElement | null>(null)
+  React.useEffect(() => {
+    if (focusBackendId && focusedRef.current) {
+      focusedRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' })
+    }
+  }, [focusBackendId])
 
   if (drivers.length === 0) {
     return (
@@ -40,13 +54,25 @@ export function ModuleSettingsSection() {
           driver.spec!.params.map((p) => [p.id, p.default]),
         )
         const values = mergeModuleDefaults(module[driver.id], defaults)
+        const focused = driver.id === focusBackendId
         return (
           <div
             key={driver.id}
-            className="rounded-xl border border-line bg-surface-2 p-5"
+            ref={focused ? focusedRef : undefined}
+            className={cn(
+              'rounded-xl border bg-surface-2 p-5 transition-opacity',
+              focused
+                ? 'border-brand-400 ring-1 ring-brand-400/30'
+                : 'border-line',
+            )}
           >
             <h3 className="mb-1 text-sm font-semibold text-ink-1">
               {driver.label}
+              {focused && (
+                <span className="ml-2 rounded bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-700">
+                  active
+                </span>
+              )}
             </h3>
             <p className="mb-3 text-xs text-ink-3">
               Params from the driver module spec (ADR-025). Persisted locally

--- a/apps/web/src/settings/ModuleSettings.tsx
+++ b/apps/web/src/settings/ModuleSettings.tsx
@@ -4,62 +4,59 @@
  * Iterates the KWS backend registry and renders one group per driver that
  * carries a `spec` (ADR-025). Only drivers WITH a spec are listed.
  *
- * Edits accumulate in a local draft; the section's Save button persists all
- * driver values to `wake-studio:settings:module` (per backendId) at once
- * (save-to-apply). These are the app-level defaults; the KWS panel (#53 P1)
- * reads them as seeds and lets the active project's snapshot override per
- * project.
+ * Controlled: the host (SettingsView) owns the draft values + Save; this
+ * component renders the driver cards and reports edits via onChange.
  */
 
 import * as React from 'react'
 import { renderParamRow } from '@wake-studio/module-kit'
 import { getBackendRegistry } from '@wake-studio/module-kws-engine'
-import { useAppSettings } from './context'
-import { useToast } from '../components/toast'
+import type { ModuleParam } from '@wake-studio/contracts'
 import { mergeModuleDefaults } from './storage'
 import { cn } from '../components/cn'
 
-type DraftMap = Record<string, Record<string, unknown>>
+export type ModuleDraftMap = Record<string, Record<string, unknown>>
+
+/** A spec-bearing driver (ADR-025) - the ones shown in module settings. */
+export interface SpecDriver {
+  id: string
+  label: string
+  params: ReadonlyArray<ModuleParam>
+}
+
+/** Drivers that carry a spec - the ones shown in module settings. */
+export function getSpecDrivers(): ReadonlyArray<SpecDriver> {
+  return getBackendRegistry()
+    .filter((r) => r.spec?.params?.length)
+    .map((r) => ({ id: r.id, label: r.label, params: r.spec!.params }))
+}
+
+/** Seed a module draft from persisted settings + spec defaults. */
+export function seedModuleDraft(
+  module: Record<string, Record<string, unknown>>,
+): ModuleDraftMap {
+  const out: ModuleDraftMap = {}
+  for (const d of getSpecDrivers()) {
+    const defaults = Object.fromEntries(
+      d.params.map((p) => [p.id, p.default]),
+    )
+    out[d.id] = mergeModuleDefaults(module[d.id], defaults)
+  }
+  return out
+}
 
 export function ModuleSettingsSection({
+  values,
+  onChange,
   focusBackendId,
 }: {
+  /** Draft values per backend id (controlled by the host). */
+  values: ModuleDraftMap
+  onChange: (backendId: string, paramId: string, value: unknown) => void
   /** Driver to keep focused (from the sidebar Settings -> driver). */
   focusBackendId?: string
 }) {
-  const { module, setModuleBackend } = useAppSettings()
-  const { toast } = useToast()
-  const drivers = React.useMemo(
-    () => getBackendRegistry().filter((r) => r.spec?.params?.length),
-    [],
-  )
-
-  // Local draft: seeded from persisted module settings + spec defaults.
-  const [draft, setDraft] = React.useState<DraftMap>(() => {
-    const out: DraftMap = {}
-    for (const d of drivers) {
-      const defaults = Object.fromEntries(
-        d.spec!.params.map((p) => [p.id, p.default]),
-      )
-      out[d.id] = mergeModuleDefaults(module[d.id], defaults)
-    }
-    return out
-  })
-  const [dirty, setDirty] = React.useState(false)
-
-  // Re-seed when the section mounts / module settings change from elsewhere.
-  React.useEffect(() => {
-    const out: DraftMap = {}
-    for (const d of drivers) {
-      const defaults = Object.fromEntries(
-        d.spec!.params.map((p) => [p.id, p.default]),
-      )
-      out[d.id] = mergeModuleDefaults(module[d.id], defaults)
-    }
-    setDraft(out)
-    setDirty(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [drivers])
+  const drivers = React.useMemo(() => getSpecDrivers(), [])
 
   // Scroll the focused driver card into view once.
   const focusedRef = React.useRef<HTMLDivElement | null>(null)
@@ -68,22 +65,6 @@ export function ModuleSettingsSection({
       focusedRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' })
     }
   }, [focusBackendId])
-
-  const handleDraftChange = (backendId: string, paramId: string, value: unknown) => {
-    setDraft((prev) => ({
-      ...prev,
-      [backendId]: { ...prev[backendId], [paramId]: value },
-    }))
-    setDirty(true)
-  }
-
-  const handleSave = () => {
-    for (const [backendId, values] of Object.entries(draft)) {
-      setModuleBackend(backendId, { ...values })
-    }
-    setDirty(false)
-    toast({ title: 'Module settings saved', variant: 'success' })
-  }
 
   if (drivers.length === 0) {
     return (
@@ -95,59 +76,47 @@ export function ModuleSettingsSection({
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex justify-end">
-        <button
-          onClick={handleSave}
-          disabled={!dirty}
-          className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-40"
-        >
-          Save
-        </button>
-      </div>
-
-      <div className="space-y-6">
-        {drivers.map((driver) => {
-          const values = draft[driver.id] ?? {}
-          const focused = driver.id === focusBackendId
-          return (
-            <div
-              key={driver.id}
-              ref={focused ? focusedRef : undefined}
-              className={cn(
-                'rounded-xl border bg-surface-2 p-5 transition-opacity',
-                focused
-                  ? 'border-brand-400 ring-1 ring-brand-400/30'
-                  : 'border-line',
+    <div className="space-y-6">
+      {drivers.map((driver) => {
+        const valuesForDriver = values[driver.id] ?? {}
+        const focused = driver.id === focusBackendId
+        return (
+          <div
+            key={driver.id}
+            ref={focused ? focusedRef : undefined}
+            className={cn(
+              'rounded-xl border bg-surface-2 p-5 transition-opacity',
+              focused
+                ? 'border-brand-400 ring-1 ring-brand-400/30'
+                : 'border-line',
+            )}
+          >
+            <h3 className="mb-1 text-sm font-semibold text-ink-1">
+              {driver.label}
+              {focused && (
+                <span className="ml-2 rounded bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-700">
+                  active
+                </span>
               )}
-            >
-              <h3 className="mb-1 text-sm font-semibold text-ink-1">
-                {driver.label}
-                {focused && (
-                  <span className="ml-2 rounded bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-700">
-                    active
-                  </span>
-                )}
-              </h3>
-              <p className="mb-3 text-xs text-ink-3">
-                Params from the driver module spec (ADR-025). Changes apply on
-                Save; per-project overrides live in the project snapshot.
-              </p>
-              <div className="divide-y divide-line">
-                {driver.spec!.params.map((param) => (
-                  <div key={param.id} className="py-1">
-                    {renderParamRow(
-                      param,
-                      values[param.id] ?? param.default,
-                      (v: unknown) => handleDraftChange(driver.id, param.id, v),
-                    )}
-                  </div>
-                ))}
-              </div>
+            </h3>
+            <p className="mb-3 text-xs text-ink-3">
+              Params from the driver module spec (ADR-025). Changes apply on
+              Save; per-project overrides live in the project snapshot.
+            </p>
+            <div className="divide-y divide-line">
+              {driver.params.map((param) => (
+                <div key={param.id} className="py-1">
+                  {renderParamRow(
+                    param,
+                    valuesForDriver[param.id] ?? param.default,
+                    (v: unknown) => onChange(driver.id, param.id, v),
+                  )}
+                </div>
+              ))}
             </div>
-          )
-        })}
-      </div>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/apps/web/src/settings/ModuleSettings.tsx
+++ b/apps/web/src/settings/ModuleSettings.tsx
@@ -2,21 +2,24 @@
  * Module settings - registry-driven module groups (issue #52).
  *
  * Iterates the KWS backend registry and renders one group per driver that
- * carries a `spec` (ADR-025). Only drivers WITH a spec are listed
- * (human-confirmed): openwakeword has no spec.params today, so sherpa and
- * plix appear.
+ * carries a `spec` (ADR-025). Only drivers WITH a spec are listed.
  *
- * Values persist to `wake-studio:settings:module` (per backendId). These are
- * the app-level defaults; the KWS panel (issue #53 P1) reads them as seeds
- * and lets the active project's snapshot override per project.
+ * Edits accumulate in a local draft; the section's Save button persists all
+ * driver values to `wake-studio:settings:module` (per backendId) at once
+ * (save-to-apply). These are the app-level defaults; the KWS panel (#53 P1)
+ * reads them as seeds and lets the active project's snapshot override per
+ * project.
  */
 
 import * as React from 'react'
 import { renderParamRow } from '@wake-studio/module-kit'
 import { getBackendRegistry } from '@wake-studio/module-kws-engine'
 import { useAppSettings } from './context'
+import { useToast } from '../components/toast'
 import { mergeModuleDefaults } from './storage'
 import { cn } from '../components/cn'
+
+type DraftMap = Record<string, Record<string, unknown>>
 
 export function ModuleSettingsSection({
   focusBackendId,
@@ -25,10 +28,38 @@ export function ModuleSettingsSection({
   focusBackendId?: string
 }) {
   const { module, setModuleBackend } = useAppSettings()
+  const { toast } = useToast()
   const drivers = React.useMemo(
     () => getBackendRegistry().filter((r) => r.spec?.params?.length),
     [],
   )
+
+  // Local draft: seeded from persisted module settings + spec defaults.
+  const [draft, setDraft] = React.useState<DraftMap>(() => {
+    const out: DraftMap = {}
+    for (const d of drivers) {
+      const defaults = Object.fromEntries(
+        d.spec!.params.map((p) => [p.id, p.default]),
+      )
+      out[d.id] = mergeModuleDefaults(module[d.id], defaults)
+    }
+    return out
+  })
+  const [dirty, setDirty] = React.useState(false)
+
+  // Re-seed when the section mounts / module settings change from elsewhere.
+  React.useEffect(() => {
+    const out: DraftMap = {}
+    for (const d of drivers) {
+      const defaults = Object.fromEntries(
+        d.spec!.params.map((p) => [p.id, p.default]),
+      )
+      out[d.id] = mergeModuleDefaults(module[d.id], defaults)
+    }
+    setDraft(out)
+    setDirty(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drivers])
 
   // Scroll the focused driver card into view once.
   const focusedRef = React.useRef<HTMLDivElement | null>(null)
@@ -37,6 +68,22 @@ export function ModuleSettingsSection({
       focusedRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' })
     }
   }, [focusBackendId])
+
+  const handleDraftChange = (backendId: string, paramId: string, value: unknown) => {
+    setDraft((prev) => ({
+      ...prev,
+      [backendId]: { ...prev[backendId], [paramId]: value },
+    }))
+    setDirty(true)
+  }
+
+  const handleSave = () => {
+    for (const [backendId, values] of Object.entries(draft)) {
+      setModuleBackend(backendId, { ...values })
+    }
+    setDirty(false)
+    toast({ title: 'Module settings saved', variant: 'success' })
+  }
 
   if (drivers.length === 0) {
     return (
@@ -48,55 +95,59 @@ export function ModuleSettingsSection({
   }
 
   return (
-    <div className="space-y-6">
-      {drivers.map((driver) => {
-        const defaults = Object.fromEntries(
-          driver.spec!.params.map((p) => [p.id, p.default]),
-        )
-        const values = mergeModuleDefaults(module[driver.id], defaults)
-        const focused = driver.id === focusBackendId
-        return (
-          <div
-            key={driver.id}
-            ref={focused ? focusedRef : undefined}
-            className={cn(
-              'rounded-xl border bg-surface-2 p-5 transition-opacity',
-              focused
-                ? 'border-brand-400 ring-1 ring-brand-400/30'
-                : 'border-line',
-            )}
-          >
-            <h3 className="mb-1 text-sm font-semibold text-ink-1">
-              {driver.label}
-              {focused && (
-                <span className="ml-2 rounded bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-700">
-                  active
-                </span>
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={!dirty}
+          className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-40"
+        >
+          Save
+        </button>
+      </div>
+
+      <div className="space-y-6">
+        {drivers.map((driver) => {
+          const values = draft[driver.id] ?? {}
+          const focused = driver.id === focusBackendId
+          return (
+            <div
+              key={driver.id}
+              ref={focused ? focusedRef : undefined}
+              className={cn(
+                'rounded-xl border bg-surface-2 p-5 transition-opacity',
+                focused
+                  ? 'border-brand-400 ring-1 ring-brand-400/30'
+                  : 'border-line',
               )}
-            </h3>
-            <p className="mb-3 text-xs text-ink-3">
-              Params from the driver module spec (ADR-025). Persisted locally
-              as app defaults; per-project overrides live in the project
-              snapshot.
-            </p>
-            <div className="divide-y divide-line">
-              {driver.spec!.params.map((param) => (
-                <div key={param.id} className="py-1">
-                  {renderParamRow(
-                    param,
-                    values[param.id] ?? param.default,
-                    (v: unknown) =>
-                      setModuleBackend(driver.id, {
-                        ...values,
-                        [param.id]: v,
-                      }),
-                  )}
-                </div>
-              ))}
+            >
+              <h3 className="mb-1 text-sm font-semibold text-ink-1">
+                {driver.label}
+                {focused && (
+                  <span className="ml-2 rounded bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-700">
+                    active
+                  </span>
+                )}
+              </h3>
+              <p className="mb-3 text-xs text-ink-3">
+                Params from the driver module spec (ADR-025). Changes apply on
+                Save; per-project overrides live in the project snapshot.
+              </p>
+              <div className="divide-y divide-line">
+                {driver.spec!.params.map((param) => (
+                  <div key={param.id} className="py-1">
+                    {renderParamRow(
+                      param,
+                      values[param.id] ?? param.default,
+                      (v: unknown) => handleDraftChange(driver.id, param.id, v),
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        )
-      })}
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/settings/__tests__/storage.test.ts
+++ b/apps/web/src/settings/__tests__/storage.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Settings storage tests (issue #52).
+ *
+ * Vitest runs in Node (no localStorage), so a minimal in-memory localStorage
+ * shim is stubbed globally - same pattern as projects/__tests__/store.test.ts.
+ * Covers: defaults merge, versioned round-trip, module settings map, KWS
+ * sources layer, export masking, import parsing, reset.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  PLATFORM_DEFAULTS,
+  PLATFORM_SETTING_IDS,
+  isSecretSetting,
+} from '../schema'
+import {
+  buildExportPayload,
+  loadKwsSources,
+  loadModuleSettings,
+  loadPlatformSettings,
+  mergeModuleDefaults,
+  mergePlatformDefaults,
+  parseImportPayload,
+  resetSettings,
+  saveKwsSources,
+  saveModuleSettings,
+  savePlatformSettings,
+  SETTINGS_STORAGE_KEYS,
+  KWS_SOURCES_KEY,
+} from '../storage'
+import type { ThemeMode } from '../types'
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory localStorage shim.
+// ---------------------------------------------------------------------------
+
+function makeLocalStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, String(v))
+    },
+  } as Storage
+}
+
+let shim: Storage
+
+beforeEach(() => {
+  shim = makeLocalStorage()
+  vi.stubGlobal('localStorage', shim)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ---------------------------------------------------------------------------
+// Platform settings
+// ---------------------------------------------------------------------------
+
+describe('platform settings', () => {
+  it('loads defaults when nothing is stored', () => {
+    expect(loadPlatformSettings()).toEqual(PLATFORM_DEFAULTS)
+  })
+
+  it('round-trips a full settings object', () => {
+    const custom = {
+      ...PLATFORM_DEFAULTS,
+      theme: 'dark' as ThemeMode,
+      'backend.endpoint': 'http://x',
+    }
+    savePlatformSettings(custom)
+    expect(loadPlatformSettings()).toEqual(custom)
+  })
+
+  it('merges partial/older payloads over defaults without crashing', () => {
+    // Simulate an older payload missing newer keys + containing unknown keys.
+    localStorage.setItem(
+      SETTINGS_STORAGE_KEYS.platform,
+      JSON.stringify({ theme: 'dark', bogusKey: 1 }),
+    )
+    const loaded = loadPlatformSettings()
+    expect(loaded.theme).toBe('dark')
+    expect(loaded.locale).toBe(PLATFORM_DEFAULTS.locale)
+    expect('bogusKey' in loaded).toBe(false)
+  })
+
+  it('falls back to defaults on corrupt JSON', () => {
+    localStorage.setItem(SETTINGS_STORAGE_KEYS.platform, '{not json')
+    expect(loadPlatformSettings()).toEqual(PLATFORM_DEFAULTS)
+  })
+
+  it('mergePlatformDefaults drops unknown keys and fills missing', () => {
+    const merged = mergePlatformDefaults({
+      theme: 'system',
+      junk: 'x',
+    } as unknown as Parameters<typeof mergePlatformDefaults>[0])
+    expect(merged.theme).toBe('system')
+    expect((merged as unknown as Record<string, unknown>).junk).toBeUndefined()
+    expect(merged['kws.executionProvider']).toBe(PLATFORM_DEFAULTS['kws.executionProvider'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Module settings
+// ---------------------------------------------------------------------------
+
+describe('module settings', () => {
+  it('round-trips per-backend values', () => {
+    saveModuleSettings('sherpa-onnx-kws', { keywords: 'a b @c' })
+    expect(loadModuleSettings()['sherpa-onnx-kws']).toEqual({
+      keywords: 'a b @c',
+    })
+  })
+
+  it('keeps multiple backends independent', () => {
+    saveModuleSettings('sherpa-onnx-kws', { keywords: 'x' })
+    saveModuleSettings('plixkws', { encoder: 'base' })
+    const all = loadModuleSettings()
+    expect(all['sherpa-onnx-kws']).toEqual({ keywords: 'x' })
+    expect(all['plixkws']).toEqual({ encoder: 'base' })
+  })
+
+  it('mergeModuleDefaults layers stored values over spec defaults', () => {
+    const merged = mergeModuleDefaults({ encoder: 'base' }, {
+      encoder: 'small',
+      runtime: 'onnx',
+    })
+    expect(merged).toEqual({ encoder: 'base', runtime: 'onnx' })
+  })
+
+  it('returns {} on missing/corrupt storage', () => {
+    expect(loadModuleSettings()).toEqual({})
+    localStorage.setItem(SETTINGS_STORAGE_KEYS.module, 'nope')
+    expect(loadModuleSettings()).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// KWS sources layer (#52/#53)
+// ---------------------------------------------------------------------------
+
+describe('kws sources', () => {
+  it('round-trips modelSources + customUrls', () => {
+    saveKwsSources({
+      modelSources: { melspectrogram: 'hey-buddy' },
+      customUrls: { 'plix-encoder': '/x.onnx' },
+    })
+    const loaded = loadKwsSources()
+    expect(loaded.modelSources.melspectrogram).toBe('hey-buddy')
+    expect(loaded.customUrls['plix-encoder']).toBe('/x.onnx')
+  })
+
+  it('defaults to empty maps when nothing stored', () => {
+    expect(loadKwsSources()).toEqual({ modelSources: {}, customUrls: {} })
+  })
+
+  it('lives under the reserved KWS_SOURCES_KEY in the module map', () => {
+    saveKwsSources({ modelSources: { classifier: 'hey-buddy' }, customUrls: {} })
+    expect(loadModuleSettings()[KWS_SOURCES_KEY]).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Export / import / reset
+// ---------------------------------------------------------------------------
+
+describe('export/import/reset', () => {
+  it('masks secret values in exports', () => {
+    const platform = {
+      ...PLATFORM_DEFAULTS,
+      'backend.apiKey': 'sk-123',
+      'backend.secret': 'sec-456',
+    }
+    const payload = buildExportPayload(platform, {}, true)
+    expect(payload.platform['backend.apiKey']).toBe('••••••••')
+    expect(payload.platform['backend.secret']).toBe('••••••••')
+    // Non-secrets pass through.
+    expect(payload.platform.theme).toBe(platform.theme)
+  })
+
+  it('keeps real values when maskSecrets=false', () => {
+    const platform = { ...PLATFORM_DEFAULTS, 'backend.apiKey': 'sk-123' }
+    const payload = buildExportPayload(platform, {}, false)
+    expect(payload.platform['backend.apiKey']).toBe('sk-123')
+  })
+
+  it('empty secrets are not masked (stay empty)', () => {
+    const payload = buildExportPayload(PLATFORM_DEFAULTS, {}, true)
+    expect(payload.platform['backend.apiKey']).toBe('')
+  })
+
+  it('parseImportPayload merges over defaults and keeps module map', () => {
+    const raw = JSON.stringify({
+      platform: { theme: 'dark' },
+      module: { plixkws: { encoder: 'base' } },
+    })
+    const parsed = parseImportPayload(raw)
+    expect(parsed.platform.theme).toBe('dark')
+    expect(parsed.platform.locale).toBe(PLATFORM_DEFAULTS.locale)
+    expect(parsed.module.plixkws).toEqual({ encoder: 'base' })
+  })
+
+  it('reset clears both storage keys', () => {
+    savePlatformSettings({ ...PLATFORM_DEFAULTS, theme: 'dark' as ThemeMode })
+    saveModuleSettings('sherpa-onnx-kws', { keywords: 'x' })
+    resetSettings()
+    expect(loadPlatformSettings()).toEqual(PLATFORM_DEFAULTS)
+    expect(loadModuleSettings()).toEqual({})
+  })
+
+  it('descriptor schema covers every id with a secret flag', () => {
+    // Every id has exactly one descriptor; secrets are the backend credentials.
+    for (const id of PLATFORM_SETTING_IDS) {
+      expect(typeof isSecretSetting(id)).toBe('boolean')
+    }
+    expect(isSecretSetting('backend.apiKey')).toBe(true)
+    expect(isSecretSetting('backend.secret')).toBe(true)
+    expect(isSecretSetting('theme')).toBe(false)
+  })
+})

--- a/apps/web/src/settings/context.tsx
+++ b/apps/web/src/settings/context.tsx
@@ -1,0 +1,162 @@
+/**
+ * Settings context - app-level settings provider (issue #52).
+ *
+ * `SettingsProvider` loads platform + module settings from localStorage on
+ * mount and exposes `useAppSettings()` for reading and updating. Theme
+ * side-effects (documentElement.dataset.theme + meta theme-color) live here
+ * so any consumer that changes `theme` gets an immediate effect.
+ *
+ * `system` mode follows `prefers-color-scheme` via matchMedia (with a live
+ * listener), resolving to the actual light/dark token value at render time.
+ */
+
+import * as React from 'react'
+import { PLATFORM_DEFAULTS, PLATFORM_SETTING_IDS } from './schema'
+import {
+  loadModuleSettings,
+  loadPlatformSettings,
+  saveModuleSettings,
+  savePlatformSettings,
+  loadKwsSources,
+  saveKwsSources,
+  resetSettings,
+} from './storage'
+import type { KwsSourcesSettings } from './storage'
+import type { ModuleSettings, PlatformSettings, PlatformSettingId, ThemeMode } from './types'
+
+interface SettingsContextValue {
+  /** Resolved platform settings (theme already applied to the document). */
+  platform: PlatformSettings
+  /** Module settings per backend id (driver spec params). */
+  module: ModuleSettings
+  setPlatform: (patch: Partial<PlatformSettings>) => void
+  setModuleBackend: (backendId: string, values: Record<string, unknown>) => void
+  /** Persist a single platform setting. */
+  /** Persist a single platform setting. */
+  set: (id: PlatformSettingId, value: unknown) => void
+  /** App-level KWS model-source defaults (#52/#53 layered persistence). */
+  kwsSources: KwsSourcesSettings
+  setKwsSources: (s: KwsSourcesSettings) => void
+  /** Reset everything to defaults (clears localStorage). */
+  reset: () => void
+  /** The theme that is actually applied (system resolved). */
+  resolvedTheme: Exclude<ThemeMode, 'system'>
+}
+
+const SettingsContext = React.createContext<SettingsContextValue | null>(null)
+
+/** Resolve `system` to light/dark using matchMedia (defaults to light). */
+export function resolveSystemTheme(): Exclude<ThemeMode, 'system'> {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+/** Apply the theme to the document (data-theme + meta theme-color). */
+export function applyTheme(mode: ThemeMode): void {
+  const resolved = mode === 'system' ? resolveSystemTheme() : mode
+  if (typeof document === 'undefined') return
+  document.documentElement.dataset.theme = resolved
+  document.documentElement.style.colorScheme = resolved
+  // Update the PWA theme-color meta (light/dark accent).
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) meta.setAttribute('content', resolved === 'dark' ? '#0b1020' : '#0ea5e9')
+}
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [platform, setPlatformState] = React.useState<PlatformSettings>(() =>
+    loadPlatformSettings(),
+  )
+  const [module, setModuleState] = React.useState<ModuleSettings>(() =>
+    loadModuleSettings(),
+  )
+  const [kwsSources, setKwsSourcesState] = React.useState<KwsSourcesSettings>(() =>
+    loadKwsSources(),
+  )
+  // Follow OS theme changes when in `system` mode.
+  const [osTheme, setOsTheme] = React.useState<'light' | 'dark'>('light')
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = (e: MediaQueryListEvent) => setOsTheme(e.matches ? 'dark' : 'light')
+    // iOS Safari: addEventListener may not exist on MediaQueryList.
+    if (typeof mq.addEventListener === 'function') mq.addEventListener('change', onChange)
+    return () => {
+      if (typeof mq.removeEventListener === 'function') mq.removeEventListener('change', onChange)
+    }
+  }, [])
+
+  // Apply the theme whenever the setting or OS preference changes.
+  const theme: ThemeMode = platform.theme ?? PLATFORM_DEFAULTS.theme
+  React.useEffect(() => {
+    applyTheme(theme)
+  }, [theme, osTheme])
+
+  const resolvedTheme: Exclude<ThemeMode, 'system'> =
+    theme === 'system' ? osTheme : theme
+
+  const setPlatform = React.useCallback(
+    (patch: Partial<PlatformSettings>) => {
+      setPlatformState((prev) => {
+        const next = { ...prev, ...patch }
+        savePlatformSettings(next)
+        return next
+      })
+    },
+    [],
+  )
+
+  const set = React.useCallback(
+    (id: PlatformSettingId, value: unknown) => {
+      setPlatformState((prev) => {
+        const next: PlatformSettings = { ...prev, [id]: value as never }
+        savePlatformSettings(next)
+        return next
+      })
+    },
+    [],
+  )
+
+  const setModuleBackend = React.useCallback(
+    (backendId: string, values: Record<string, unknown>) => {
+      saveModuleSettings(backendId, values)
+      setModuleState((prev) => ({ ...prev, [backendId]: { ...values } }))
+    },
+    [],
+  )
+
+  const setKwsSources = React.useCallback((s: KwsSourcesSettings) => {
+    saveKwsSources(s)
+    setKwsSourcesState(s)
+  }, [])
+
+  const reset = React.useCallback(() => {
+    resetSettings()
+    setPlatformState({ ...PLATFORM_DEFAULTS })
+    setModuleState({})
+  }, [])
+
+  const value: SettingsContextValue = {
+    platform,
+    module,
+    setPlatform,
+    setModuleBackend,
+    set,
+    reset,
+    resolvedTheme,
+    kwsSources,
+    setKwsSources,
+  }
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+export function useAppSettings(): SettingsContextValue {
+  const ctx = React.useContext(SettingsContext)
+  if (!ctx) throw new Error('useAppSettings must be used within SettingsProvider')
+  return ctx
+}
+
+// Re-export for convenience (id type used by callers).
+export type { PlatformSettingId }
+export { PLATFORM_SETTING_IDS }

--- a/apps/web/src/settings/index.ts
+++ b/apps/web/src/settings/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Settings - public exports (issue #52).
+ */
+
+export {
+  PLATFORM_DEFAULTS,
+  PLATFORM_SETTING_DESCRIPTORS,
+  PLATFORM_SETTING_IDS,
+  SETTINGS_SCHEMA_VERSION,
+  descriptorToModuleParam,
+  isSecretSetting,
+  settingGroupOf,
+} from './schema'
+export type { SettingDescriptor } from './types'
+export {
+  buildExportPayload,
+  getModuleSettings,
+  KWS_SOURCES_KEY,
+  loadKwsSources,
+  loadModuleSettings,
+  loadPlatformSettings,
+  mergeModuleDefaults,
+  mergePlatformDefaults,
+  parseImportPayload,
+  resetSettings,
+  saveKwsSources,
+  saveModuleSettings,
+  savePlatformSettings,
+  SETTINGS_STORAGE_KEYS,
+} from './storage'
+export type { KwsSourcesSettings } from './storage'
+export type {
+  AppLocale,
+  AppSettings,
+  DataRetention,
+  ExecutionProvider,
+  ModuleSettings,
+  PlatformSettingId,
+  PlatformSettings,
+  ThemeMode,
+} from './types'
+export {
+  SettingsProvider,
+  applyTheme,
+  resolveSystemTheme,
+  useAppSettings,
+} from './context'
+export { ModuleSettingsSection } from './ModuleSettings'

--- a/apps/web/src/settings/schema.ts
+++ b/apps/web/src/settings/schema.ts
@@ -1,0 +1,175 @@
+/**
+ * Settings schema - static descriptors for the platform settings (issue #52).
+ *
+ * The schema is a *descriptor array + value map*: adding a future cloud
+ * provider / backend endpoint is just adding more descriptor rows, no new UI
+ * code (the "many cloud endpoints" concern from the human review). All values
+ * are localStorage-only; `secret` fields are masked on export and never
+ * logged or transmitted.
+ */
+
+import type { PlatformSettings, PlatformSettingId, SettingDescriptor } from './types'
+
+/** Current schema version. Bump when a field is added/removed. */
+export const SETTINGS_SCHEMA_VERSION = 1
+
+/** Default platform settings (schemaVersion is explicit so merge works). */
+export const PLATFORM_DEFAULTS: PlatformSettings = {
+  schemaVersion: SETTINGS_SCHEMA_VERSION,
+  theme: 'light',
+  locale: 'en',
+  'kws.executionProvider': 'wasm',
+  'backend.endpoint': 'http://127.0.0.1:4824',
+  'backend.apiKey': '',
+  'backend.secret': '',
+  'data.upload': false,
+  'settings.dataRetention': 'keep',
+  'mic.rememberPermission': true,
+}
+
+/** Static descriptors - the data-driven source of truth for the platform UI. */
+export const PLATFORM_SETTING_DESCRIPTORS: ReadonlyArray<SettingDescriptor> = [
+  // ---- General ----
+  {
+    id: 'theme',
+    label: 'Theme',
+    description:
+      'Console appearance. "System" follows your OS light/dark preference.',
+    type: 'select',
+    default: 'light',
+    options: [
+      { value: 'light', label: 'Light' },
+      { value: 'dark', label: 'Dark' },
+      { value: 'system', label: 'System' },
+    ],
+    group: 'general',
+  },
+  {
+    id: 'locale',
+    label: 'Language',
+    description: 'UI language. Stored now; i18n lands in Phase 6.',
+    type: 'select',
+    default: 'en',
+    options: [
+      { value: 'en', label: 'English' },
+      { value: 'zh-CN', label: '中文 (简体)' },
+    ],
+    group: 'general',
+  },
+  {
+    id: 'kws.executionProvider',
+    label: 'KWS execution provider',
+    description:
+      'onnxruntime-web execution provider. WebGPU-first with WASM fallback (ADR-018).',
+    type: 'select',
+    default: 'wasm',
+    options: [
+      { value: 'webgpu', label: 'WebGPU (faster)' },
+      { value: 'wasm', label: 'WASM (universal)' },
+    ],
+    group: 'general',
+  },
+
+  // ---- Security ----
+  {
+    id: 'backend.endpoint',
+    label: 'Backend endpoint',
+    description:
+      'Self-hosted service base URL (ADR-005). Used by future training/data jobs.',
+    type: 'string',
+    default: 'http://127.0.0.1:4824',
+    group: 'security',
+  },
+  {
+    id: 'backend.apiKey',
+    label: 'API key',
+    description:
+      'Credential for the backend. Stored locally only, never sent to a WakeStudio server, never logged or exported.',
+    type: 'secret',
+    default: '',
+    group: 'security',
+  },
+  {
+    id: 'backend.secret',
+    label: 'Secret',
+    description:
+      'Shared secret for the backend. Same storage guarantees as the API key.',
+    type: 'secret',
+    default: '',
+    group: 'security',
+  },
+
+  // ---- Data ----
+  {
+    id: 'data.upload',
+    label: 'Allow data upload',
+    description:
+      'Gate for the pluggable data-source layer (ADR-022). Off by default; audio generation runs in backends, not WASM.',
+    type: 'boolean',
+    default: false,
+    group: 'data',
+  },
+  {
+    id: 'settings.dataRetention',
+    label: 'Data retention',
+    description: 'Future export/cleanup policy for local artifacts.',
+    type: 'select',
+    default: 'keep',
+    options: [
+      { value: 'keep', label: 'Keep local data' },
+      { value: 'session', label: 'Session only' },
+      { value: 'export-only', label: 'Export then delete' },
+    ],
+    group: 'data',
+  },
+  {
+    id: 'mic.rememberPermission',
+    label: 'Remember mic permission',
+    description:
+      'Anchor for the mic permission prompt flow (the browser owns the real permission).',
+    type: 'boolean',
+    default: true,
+    group: 'data',
+  },
+]
+
+/** All ids with a default (schemaVersion excluded). */
+export const PLATFORM_SETTING_IDS: ReadonlyArray<PlatformSettingId> =
+  PLATFORM_SETTING_DESCRIPTORS.map((d) => d.id)
+
+/** Map a descriptor id to its group (for the left rail). */
+export function settingGroupOf(id: PlatformSettingId): SettingDescriptor['group'] {
+  const d = PLATFORM_SETTING_DESCRIPTORS.find((x) => x.id === id)
+  return d?.group ?? 'general'
+}
+
+/** True when a setting is a secret (password input + masked export). */
+export function isSecretSetting(id: PlatformSettingId): boolean {
+  return PLATFORM_SETTING_DESCRIPTORS.find((x) => x.id === id)?.type === 'secret'
+}
+
+/**
+ * Bridge a SettingDescriptor to the module-kit ModuleParam shape so
+ * `renderParamRow` renders it unchanged (group is always primary - the
+ * settings rail handles grouping).
+ */
+export function descriptorToModuleParam(d: SettingDescriptor): import('@wake-studio/contracts').ModuleParam {
+  return {
+    id: d.id as string,
+    label: d.label,
+    group: 'primary',
+    // Keep select as select (module-kit renders UiSelect); boolean -> UiToggle;
+    // secret -> password input; else string -> text input.
+    type:
+      d.type === 'boolean'
+        ? 'boolean'
+        : d.type === 'secret'
+          ? 'secret'
+          : d.type === 'select'
+            ? 'select'
+            : 'string',
+    default: d.default,
+    description: d.description,
+    options: d.options,
+  }
+}

--- a/apps/web/src/settings/storage.ts
+++ b/apps/web/src/settings/storage.ts
@@ -1,0 +1,194 @@
+/**
+ * Settings storage - localStorage persistence (issue #52).
+ *
+ * Two keys:
+ *   - `wake-studio:settings:platform` -> whole PlatformSettings object,
+ *     versioned (schemaVersion), merged with defaults on read so new fields
+ *     get defaults and old payloads never crash.
+ *   - `wake-studio:settings:module`   -> { backendId: { paramId: value } }.
+ *
+ * localStorage is chosen over IndexedDB because settings are small,
+ * synchronous, boot-critical data (matches the existing
+ * `wake-studio:last-project` pattern).
+ *
+ * Security: `secret` values are stored locally only and masked in the export.
+ */
+
+import { PLATFORM_DEFAULTS, PLATFORM_SETTING_IDS, isSecretSetting } from './schema'
+import type { AppSettings, ModuleSettings, PlatformSettings } from './types'
+
+const PLATFORM_KEY = 'wake-studio:settings:platform'
+const MODULE_KEY = 'wake-studio:settings:module'
+
+/** Mask used for secret values in exports (never leaks the real value). */
+const SECRET_MASK = '••••••••'
+
+// ---------------------------------------------------------------------------
+// Platform settings
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a stored platform payload over the defaults. Unknown/extra keys are
+ * dropped (we only keep descriptor ids); missing keys get the default.
+ */
+export function mergePlatformDefaults(
+  stored: Partial<PlatformSettings> | null | undefined,
+): PlatformSettings {
+  const out = { ...PLATFORM_DEFAULTS }
+  if (!stored || typeof stored !== 'object') return out
+  for (const id of PLATFORM_SETTING_IDS) {
+    const v = (stored as Record<string, unknown>)[id]
+    if (v !== undefined) (out as Record<string, unknown>)[id] = v
+  }
+  return out
+}
+
+/** Read the platform settings, merged over defaults (never throws). */
+export function loadPlatformSettings(): PlatformSettings {
+  try {
+    const raw = localStorage.getItem(PLATFORM_KEY)
+    if (!raw) return { ...PLATFORM_DEFAULTS }
+    const parsed = JSON.parse(raw) as Partial<PlatformSettings>
+    return mergePlatformDefaults(parsed)
+  } catch {
+    // Corrupt/private-mode storage - fall back to defaults.
+    return { ...PLATFORM_DEFAULTS }
+  }
+}
+
+/** Persist the platform settings (writes the whole object, versioned). */
+export function savePlatformSettings(settings: PlatformSettings): void {
+  try {
+    localStorage.setItem(PLATFORM_KEY, JSON.stringify({ ...settings, schemaVersion: PLATFORM_DEFAULTS.schemaVersion }))
+  } catch {
+    // Storage full/blocked - ignore; settings stay in-memory for the session.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module settings
+// ---------------------------------------------------------------------------
+
+/** Reserved key in the module map for KWS model-source app defaults (#52/#53).
+ *  Not a backend id - excluded from the module settings UI (registry-driven). */
+export const KWS_SOURCES_KEY = 'kws-sources'
+
+/** App-level defaults for the KWS model-source editor. */
+export interface KwsSourcesSettings {
+  modelSources: Record<string, string | undefined>
+  customUrls: Record<string, string>
+}
+
+/** Read the module settings map (per backendId). Never throws. */
+export function loadModuleSettings(): ModuleSettings {
+  try {
+    const raw = localStorage.getItem(MODULE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as ModuleSettings
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Read the app-level KWS model-source defaults (never throws). */
+export function loadKwsSources(): KwsSourcesSettings {
+  const m = loadModuleSettings()
+  const s = m[KWS_SOURCES_KEY] as Partial<KwsSourcesSettings> | undefined
+  return {
+    modelSources: s?.modelSources && typeof s.modelSources === 'object' ? s.modelSources : {},
+    customUrls: s?.customUrls && typeof s.customUrls === 'object' ? s.customUrls : {},
+  }
+}
+
+/** Persist the app-level KWS model-source defaults. */
+export function saveKwsSources(settings: KwsSourcesSettings): void {
+  try {
+    const all = loadModuleSettings()
+    all[KWS_SOURCES_KEY] = { ...settings } as unknown as Record<string, unknown>
+    localStorage.setItem(MODULE_KEY, JSON.stringify(all))
+  } catch {
+    // ignore
+  }
+}
+
+/** Merge one backend's stored values over its spec defaults. */
+export function mergeModuleDefaults(
+  stored: Record<string, unknown> | undefined,
+  defaults: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...defaults, ...(stored ?? {}) }
+}
+
+/** Persist one backend's values (reads-modifies-writes the whole map). */
+export function saveModuleSettings(backendId: string, values: Record<string, unknown>): void {
+  try {
+    const all = loadModuleSettings()
+    all[backendId] = { ...values }
+    localStorage.setItem(MODULE_KEY, JSON.stringify(all))
+  } catch {
+    // ignore
+  }
+}
+
+/** Read a single backend's stored values (or undefined). */
+export function getModuleSettings(backendId: string): Record<string, unknown> | undefined {
+  return loadModuleSettings()[backendId]
+}
+
+// ---------------------------------------------------------------------------
+// Export / import / reset
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the export payload with secrets masked. `maskSecrets=false` yields
+ * the real values (used only for round-tripping via import, never for a
+ * user-facing download without a warning - see SettingsView).
+ */
+export function buildExportPayload(
+  platform: PlatformSettings,
+  module: ModuleSettings,
+  maskSecrets: boolean,
+): AppSettings {
+  const platformOut = { ...platform }
+  if (maskSecrets) {
+    for (const id of PLATFORM_SETTING_IDS) {
+      if (isSecretSetting(id)) {
+        const v = (platformOut as Record<string, unknown>)[id]
+        if (typeof v === 'string' && v.length > 0) {
+          ;(platformOut as Record<string, unknown>)[id] = SECRET_MASK
+        }
+      }
+    }
+  }
+  return { platform: platformOut, module: JSON.parse(JSON.stringify(module)) }
+}
+
+/** Parse an imported payload, applying defaults for missing/unknown fields. */
+export function parseImportPayload(raw: string): AppSettings {
+  const parsed = JSON.parse(raw) as Partial<AppSettings>
+  const platform = mergePlatformDefaults(
+    parsed.platform as Partial<PlatformSettings> | undefined,
+  )
+  const module: ModuleSettings =
+    parsed.module && typeof parsed.module === 'object'
+      ? (parsed.module as ModuleSettings)
+      : {}
+  return { platform, module }
+}
+
+/** Reset platform + module settings to defaults. */
+export function resetSettings(): void {
+  try {
+    localStorage.removeItem(PLATFORM_KEY)
+    localStorage.removeItem(MODULE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Keys (exported for tests / debugging)
+// ---------------------------------------------------------------------------
+
+export const SETTINGS_STORAGE_KEYS = { platform: PLATFORM_KEY, module: MODULE_KEY } as const

--- a/apps/web/src/settings/types.ts
+++ b/apps/web/src/settings/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Settings types - app-level settings (issue #52).
+ *
+ * Two kinds of settings, one renderer:
+ *   - platform settings: fixed, console-wide keys (theme, locale, backend
+ *     endpoint + secrets, execution provider, data/mic prefs). Described by a
+ *     static `SettingDescriptor[]` in schema.ts so module-kit controls render
+ *     them unchanged.
+ *   - module settings: dynamic, driven by each KWS driver's `spec.params`
+ *     (ADR-025). Only drivers that carry a spec are listed.
+ *
+ * Storage is localStorage only (`wake-studio:settings:*`), versioned so old
+ * payloads merge with defaults instead of crashing. `secret` values are
+ * stored locally, never sent, and masked in the JSON export.
+ *
+ * Note (issue #52 scope): settings are the app-level layer; project-level
+ * config (per-project snapshot) remains separate and overrides app defaults
+ * where they intersect (e.g. KWS driver/model-source persistence in #53 P1
+ * reads the module settings as defaults and lets the project snapshot
+ * override per project).
+ */
+
+/** Platform theme modes. `system` follows `prefers-color-scheme`. */
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+/** Locale anchor (store-only for now; i18n lands in Phase 6). */
+export type AppLocale = 'en' | 'zh-CN'
+
+/** onnxruntime-web execution provider (ADR-018). */
+export type ExecutionProvider = 'webgpu' | 'wasm'
+
+/** Data-retention policy (future export/cleanup anchor). */
+export type DataRetention = 'keep' | 'session' | 'export-only'
+
+/** The fixed, console-wide platform settings object. */
+export interface PlatformSettings {
+  /** Version gate for mergeWithDefaults on read. */
+  schemaVersion: number
+  theme: ThemeMode
+  locale: AppLocale
+  'kws.executionProvider': ExecutionProvider
+  'backend.endpoint': string
+  /** Secret - stored locally only; masked on export. */
+  'backend.apiKey': string
+  /** Secret - stored locally only; masked on export. */
+  'backend.secret': string
+  'data.upload': boolean
+  'settings.dataRetention': DataRetention
+  'mic.rememberPermission': boolean
+}
+
+/** Defaults for the platform settings (schemaVersion set by schema.ts). */
+export type PlatformSettingId = keyof Omit<PlatformSettings, 'schemaVersion'>
+
+/** Module settings: one value map per backend id (driver spec params). */
+export type ModuleSettings = Record<string, Record<string, unknown>>
+
+/** The full app-settings bundle (platform + module). */
+export interface AppSettings {
+  platform: PlatformSettings
+  module: ModuleSettings
+}
+
+/** A single platform setting descriptor (aligned to ParameterDescriptor). */
+export interface SettingDescriptor {
+  id: PlatformSettingId
+  label: string
+  description: string
+  type: 'select' | 'boolean' | 'string' | 'secret'
+  default: string | boolean | number
+  options?: ReadonlyArray<{ value: string; label: string }>
+  /** Group drives the left rail section. */
+  group: 'general' | 'security' | 'data'
+}

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -1,14 +1,12 @@
 /**
- * Settings view (issue #52) - section content only.
+ * Settings view (issue #52) - section content only, save-to-apply.
  *
  * The section menu lives in the shell sidebar (Settings sub-menu); this view
  * renders the selected section's content full-width, driven by the route
  * (settings-general / settings-security / settings-data / settings-modules).
  *
- * Data-driven: platform settings render from `PLATFORM_SETTING_DESCRIPTORS`
- * via module-kit controls; module settings render from each driver's spec
- * (ADR-025). Export/import JSON (secrets masked on export) + reset live in
- * a footer bar shared across sections.
+ * Edits go into a local draft; a single Save button persists them
+ * (localStorage + immediate theme effect). No export/import, no reset.
  */
 
 import * as React from 'react'
@@ -17,13 +15,12 @@ import { useToast } from '../components/toast'
 import { ModuleSettingsSection } from '../settings/ModuleSettings'
 import {
   PLATFORM_SETTING_DESCRIPTORS,
-  buildExportPayload,
   descriptorToModuleParam,
-  parseImportPayload,
   settingGroupOf,
 } from '../settings'
 import { useAppSettings } from '../settings/context'
 import type { SettingsSection } from '../router'
+import type { PlatformSettingId } from '../settings'
 
 const GROUP_TITLES: Record<SettingsSection, string> = {
   general: 'General',
@@ -33,21 +30,13 @@ const GROUP_TITLES: Record<SettingsSection, string> = {
 }
 
 const GROUP_DESCRIPTIONS: Record<SettingsSection, string> = {
-  general: 'Console-wide appearance and runtime defaults.',
+  general: 'Console-wide appearance and runtime defaults. Changes apply on Save.',
   security:
-    'Backend connection + credentials. Stored locally only; secrets are masked on export and never sent.',
-  data: 'Local data preferences and future data-source gates.',
+    'Backend connection + credentials. Stored locally only; never sent. Changes apply on Save.',
+  data: 'Local data preferences and future data-source gates. Changes apply on Save.',
   modules:
-    'Per-driver defaults from the module specs (ADR-025). The active project can override these per project.',
+    'Per-driver defaults from the module specs (ADR-025). The active project can override these per project. Changes apply on Save.',
 }
-
-/** The settings sections this view can render (order = sidebar order). */
-export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
-  'general',
-  'security',
-  'data',
-  'modules',
-]
 
 export function SettingsView({
   section,
@@ -57,59 +46,44 @@ export function SettingsView({
   /** Driver anchor for the Modules section (Settings -> driver focus). */
   backendId?: string
 }) {
-  const { platform, set, module, setModuleBackend, reset } = useAppSettings()
+  const { platform, set } = useAppSettings()
   const { toast } = useToast()
-  const fileInputRef = React.useRef<HTMLInputElement | null>(null)
 
-  const handleExport = () => {
-    const payload = buildExportPayload(platform, module, true)
-    const blob = new Blob([JSON.stringify(payload, null, 2)], {
-      type: 'application/json',
-    })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'wake-studio-settings.json'
-    document.body.appendChild(a)
-    a.click()
-    a.remove()
-    setTimeout(() => URL.revokeObjectURL(url), 1000)
-    toast({
-      title: 'Settings exported',
-      description: 'Secrets are masked (••••••••).',
-    })
-  }
-
-  const handleImport = (file: File | undefined) => {
-    if (!file) return
-    const reader = new FileReader()
-    reader.onload = () => {
-      try {
-        const parsed = parseImportPayload(String(reader.result))
-        for (const [id, value] of Object.entries(parsed.platform)) {
-          if (id !== 'schemaVersion') set(id as never, value)
-        }
-        for (const [backendId, values] of Object.entries(parsed.module)) {
-          setModuleBackend(backendId, values as Record<string, unknown>)
-        }
-        toast({ title: 'Settings imported', variant: 'success' })
-      } catch (err) {
-        toast({
-          title: 'Import failed',
-          description: err instanceof Error ? err.message : String(err),
-          variant: 'error',
-        })
-      }
+  // Local draft: edits accumulate here; Save persists them.
+  const [draft, setDraft] = React.useState<
+    Record<PlatformSettingId, unknown>
+  >(() => {
+    const out = {} as Record<PlatformSettingId, unknown>
+    for (const d of PLATFORM_SETTING_DESCRIPTORS) {
+      out[d.id] = platform[d.id] ?? d.default
     }
-    reader.readAsText(file)
+    return out
+  })
+  const [dirty, setDirty] = React.useState(false)
+
+  // Re-seed the draft when the section changes (avoid stale values).
+  React.useEffect(() => {
+    const out = {} as Record<PlatformSettingId, unknown>
+    for (const d of PLATFORM_SETTING_DESCRIPTORS) {
+      out[d.id] = platform[d.id] ?? d.default
+    }
+    setDraft(out)
+    setDirty(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [section])
+
+  const handleDraftChange = (id: PlatformSettingId, value: unknown) => {
+    setDraft((prev) => ({ ...prev, [id]: value }))
+    setDirty(true)
   }
 
-  const handleReset = () => {
-    reset()
-    toast({
-      title: 'Settings reset',
-      description: 'All app settings restored to defaults.',
-    })
+  const handleSave = () => {
+    // Persist all draft fields (platform).
+    for (const [id, value] of Object.entries(draft)) {
+      set(id as PlatformSettingId, value)
+    }
+    setDirty(false)
+    toast({ title: 'Settings saved', variant: 'success' })
   }
 
   const platformIds = PLATFORM_SETTING_DESCRIPTORS.filter(
@@ -118,11 +92,20 @@ export function SettingsView({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold text-ink-1">
-          {GROUP_TITLES[section]}
-        </h2>
-        <p className="mt-1 text-sm text-ink-2">{GROUP_DESCRIPTIONS[section]}</p>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-ink-1">
+            {GROUP_TITLES[section]}
+          </h2>
+          <p className="mt-1 text-sm text-ink-2">{GROUP_DESCRIPTIONS[section]}</p>
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={!dirty}
+          className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-40"
+        >
+          Save
+        </button>
       </div>
 
       <div className="space-y-4">
@@ -135,8 +118,8 @@ export function SettingsView({
                 <div key={d.id} className="py-1">
                   {renderParamRow(
                     descriptorToModuleParam(d),
-                    platform[d.id] ?? d.default,
-                    (v: unknown) => set(d.id, v),
+                    draft[d.id],
+                    (v: unknown) => handleDraftChange(d.id, v),
                   )}
                 </div>
               ))}
@@ -146,42 +129,9 @@ export function SettingsView({
 
         {section === 'security' && (
           <p className="rounded-lg border border-line bg-surface-3 px-3 py-2 text-xs text-ink-3">
-            Credentials never leave this browser. Export masks secrets with
-            ••••••••; imports overwrite them.
+            Credentials never leave this browser. Changes apply on Save.
           </p>
         )}
-
-        {/* Shared actions bar (all sections). */}
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            onClick={handleExport}
-            className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
-          >
-            Export settings (JSON)
-          </button>
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
-          >
-            Import settings…
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="application/json,.json"
-            className="hidden"
-            onChange={(e) => {
-              handleImport(e.target.files?.[0])
-              e.target.value = ''
-            }}
-          />
-          <button
-            onClick={handleReset}
-            className="rounded-lg border border-danger/40 px-3 py-1.5 text-sm text-danger hover:bg-danger/10"
-          >
-            Reset to defaults
-          </button>
-        </div>
       </div>
     </div>
   )

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -1,16 +1,18 @@
 /**
- * Settings view (issue #52) - replaces the ComingSoon placeholder.
+ * Settings view (issue #52) - section content only.
+ *
+ * The section menu lives in the shell sidebar (Settings sub-menu); this view
+ * renders the selected section's content full-width, driven by the route
+ * (settings-general / settings-security / settings-data / settings-modules).
  *
  * Data-driven: platform settings render from `PLATFORM_SETTING_DESCRIPTORS`
  * via module-kit controls; module settings render from each driver's spec
- * (ADR-025). Left rail groups: General / Security / Data / Modules.
- *
- * Export/import JSON (secrets masked on export) + reset-to-defaults.
+ * (ADR-025). Export/import JSON (secrets masked on export) + reset live in
+ * a footer bar shared across sections.
  */
 
 import * as React from 'react'
 import { renderParamRow } from '@wake-studio/module-kit'
-import { cn } from '../components/cn'
 import { useToast } from '../components/toast'
 import { ModuleSettingsSection } from '../settings/ModuleSettings'
 import {
@@ -21,34 +23,35 @@ import {
   settingGroupOf,
 } from '../settings'
 import { useAppSettings } from '../settings/context'
+import type { SettingsSection } from '../router'
 
-type RailGroup = 'general' | 'security' | 'data' | 'modules'
-
-const RAIL: ReadonlyArray<{ id: RailGroup; label: string }> = [
-  { id: 'general', label: 'General' },
-  { id: 'security', label: 'Security' },
-  { id: 'data', label: 'Data' },
-  { id: 'modules', label: 'Modules' },
-]
-
-const GROUP_TITLES: Record<RailGroup, string> = {
+const GROUP_TITLES: Record<SettingsSection, string> = {
   general: 'General',
   security: 'Security',
   data: 'Data',
   modules: 'Module settings',
 }
 
-const GROUP_DESCRIPTIONS: Record<RailGroup, string> = {
+const GROUP_DESCRIPTIONS: Record<SettingsSection, string> = {
   general: 'Console-wide appearance and runtime defaults.',
-  security: 'Backend connection + credentials. Stored locally only; secrets are masked on export and never sent.',
+  security:
+    'Backend connection + credentials. Stored locally only; secrets are masked on export and never sent.',
   data: 'Local data preferences and future data-source gates.',
-  modules: 'Per-driver defaults from the module specs (ADR-025). The active project can override these per project.',
+  modules:
+    'Per-driver defaults from the module specs (ADR-025). The active project can override these per project.',
 }
 
-export function SettingsView() {
+/** The settings sections this view can render (order = sidebar order). */
+export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
+  'general',
+  'security',
+  'data',
+  'modules',
+]
+
+export function SettingsView({ section }: { section: SettingsSection }) {
   const { platform, set, module, setModuleBackend, reset } = useAppSettings()
   const { toast } = useToast()
-  const [rail, setRail] = React.useState<RailGroup>('general')
   const fileInputRef = React.useRef<HTMLInputElement | null>(null)
 
   const handleExport = () => {
@@ -64,7 +67,10 @@ export function SettingsView() {
     a.click()
     a.remove()
     setTimeout(() => URL.revokeObjectURL(url), 1000)
-    toast({ title: 'Settings exported', description: 'Secrets are masked (••••••••).' })
+    toast({
+      title: 'Settings exported',
+      description: 'Secrets are masked (••••••••).',
+    })
   }
 
   const handleImport = (file: File | undefined) => {
@@ -73,7 +79,6 @@ export function SettingsView() {
     reader.onload = () => {
       try {
         const parsed = parseImportPayload(String(reader.result))
-        // Apply parsed platform values via set() (persists), then module map.
         for (const [id, value] of Object.entries(parsed.platform)) {
           if (id !== 'schemaVersion') set(id as never, value)
         }
@@ -94,109 +99,81 @@ export function SettingsView() {
 
   const handleReset = () => {
     reset()
-    toast({ title: 'Settings reset', description: 'All app settings restored to defaults.' })
+    toast({
+      title: 'Settings reset',
+      description: 'All app settings restored to defaults.',
+    })
   }
 
   const platformIds = PLATFORM_SETTING_DESCRIPTORS.filter(
-    (d) => settingGroupOf(d.id) === rail,
+    (d) => settingGroupOf(d.id) === section,
   )
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold text-ink-1">Settings</h2>
-        <p className="mt-1 max-w-2xl text-sm text-ink-2">
-          App-level settings, stored locally in your browser. Module settings
-          are generated from the module specs (ADR-025) — a new driver with a
-          spec appears here automatically.
-        </p>
+      <div className="max-w-3xl">
+        <h2 className="text-lg font-semibold text-ink-1">
+          {GROUP_TITLES[section]}
+        </h2>
+        <p className="mt-1 text-sm text-ink-2">{GROUP_DESCRIPTIONS[section]}</p>
       </div>
 
-      <div className="flex gap-6">
-        {/* Left rail */}
-        <nav className="w-44 shrink-0 space-y-0.5">
-          {RAIL.map((r) => (
-            <button
-              key={r.id}
-              onClick={() => setRail(r.id)}
-              aria-current={rail === r.id ? 'page' : undefined}
-              className={cn(
-                'w-full rounded-lg px-2.5 py-1.5 text-left text-sm font-medium transition-colors',
-                rail === r.id
-                  ? 'bg-brand-500/10 text-brand-700'
-                  : 'text-ink-2 hover:bg-surface-3 hover:text-ink-1',
-              )}
-            >
-              {r.label}
-            </button>
-          ))}
-        </nav>
-
-        {/* Content */}
-        <div className="min-w-0 flex-1 space-y-4">
+      <div className="max-w-3xl space-y-4">
+        {section === 'modules' ? (
+          <ModuleSettingsSection />
+        ) : (
           <div className="rounded-xl border border-line bg-surface-2 p-5">
-            <h3 className="text-sm font-semibold text-ink-1">
-              {GROUP_TITLES[rail]}
-            </h3>
-            <p className="mt-1 mb-3 text-xs text-ink-3">
-              {GROUP_DESCRIPTIONS[rail]}
-            </p>
-
-            {rail === 'modules' ? (
-              <ModuleSettingsSection />
-            ) : (
-              <div className="divide-y divide-line">
-                {platformIds.map((d) => (
-                  <div key={d.id} className="py-1">
-                    {renderParamRow(
-                      descriptorToModuleParam(d),
-                      platform[d.id] ?? d.default,
-                      (v: unknown) => set(d.id, v),
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {rail === 'security' && (
-              <p className="mt-4 rounded-lg border border-line bg-surface-3 px-3 py-2 text-xs text-ink-3">
-                Credentials never leave this browser. Export masks secrets
-                with ••••••••; imports overwrite them.
-              </p>
-            )}
+            <div className="divide-y divide-line">
+              {platformIds.map((d) => (
+                <div key={d.id} className="py-1">
+                  {renderParamRow(
+                    descriptorToModuleParam(d),
+                    platform[d.id] ?? d.default,
+                    (v: unknown) => set(d.id, v),
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
+        )}
 
-          {/* Global actions */}
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              onClick={handleExport}
-              className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
-            >
-              Export settings (JSON)
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
-            >
-              Import settings…
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="application/json,.json"
-              className="hidden"
-              onChange={(e) => {
-                handleImport(e.target.files?.[0])
-                e.target.value = ''
-              }}
-            />
-            <button
-              onClick={handleReset}
-              className="rounded-lg border border-danger/40 px-3 py-1.5 text-sm text-danger hover:bg-danger/10"
-            >
-              Reset to defaults
-            </button>
-          </div>
+        {section === 'security' && (
+          <p className="rounded-lg border border-line bg-surface-3 px-3 py-2 text-xs text-ink-3">
+            Credentials never leave this browser. Export masks secrets with
+            ••••••••; imports overwrite them.
+          </p>
+        )}
+
+        {/* Shared actions bar (all sections). */}
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={handleExport}
+            className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
+          >
+            Export settings (JSON)
+          </button>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
+          >
+            Import settings…
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={(e) => {
+              handleImport(e.target.files?.[0])
+              e.target.value = ''
+            }}
+          />
+          <button
+            onClick={handleReset}
+            className="rounded-lg border border-danger/40 px-3 py-1.5 text-sm text-danger hover:bg-danger/10"
+          >
+            Reset to defaults
+          </button>
         </div>
       </div>
     </div>

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -49,7 +49,14 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
   'modules',
 ]
 
-export function SettingsView({ section }: { section: SettingsSection }) {
+export function SettingsView({
+  section,
+  backendId,
+}: {
+  section: SettingsSection
+  /** Driver anchor for the Modules section (Settings -> driver focus). */
+  backendId?: string
+}) {
   const { platform, set, module, setModuleBackend, reset } = useAppSettings()
   const { toast } = useToast()
   const fileInputRef = React.useRef<HTMLInputElement | null>(null)
@@ -111,16 +118,16 @@ export function SettingsView({ section }: { section: SettingsSection }) {
 
   return (
     <div className="space-y-6">
-      <div className="max-w-3xl">
+      <div>
         <h2 className="text-lg font-semibold text-ink-1">
           {GROUP_TITLES[section]}
         </h2>
         <p className="mt-1 text-sm text-ink-2">{GROUP_DESCRIPTIONS[section]}</p>
       </div>
 
-      <div className="max-w-3xl space-y-4">
+      <div className="space-y-4">
         {section === 'modules' ? (
-          <ModuleSettingsSection />
+          <ModuleSettingsSection focusBackendId={backendId} />
         ) : (
           <div className="rounded-xl border border-line bg-surface-2 p-5">
             <div className="divide-y divide-line">

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -1,0 +1,204 @@
+/**
+ * Settings view (issue #52) - replaces the ComingSoon placeholder.
+ *
+ * Data-driven: platform settings render from `PLATFORM_SETTING_DESCRIPTORS`
+ * via module-kit controls; module settings render from each driver's spec
+ * (ADR-025). Left rail groups: General / Security / Data / Modules.
+ *
+ * Export/import JSON (secrets masked on export) + reset-to-defaults.
+ */
+
+import * as React from 'react'
+import { renderParamRow } from '@wake-studio/module-kit'
+import { cn } from '../components/cn'
+import { useToast } from '../components/toast'
+import { ModuleSettingsSection } from '../settings/ModuleSettings'
+import {
+  PLATFORM_SETTING_DESCRIPTORS,
+  buildExportPayload,
+  descriptorToModuleParam,
+  parseImportPayload,
+  settingGroupOf,
+} from '../settings'
+import { useAppSettings } from '../settings/context'
+
+type RailGroup = 'general' | 'security' | 'data' | 'modules'
+
+const RAIL: ReadonlyArray<{ id: RailGroup; label: string }> = [
+  { id: 'general', label: 'General' },
+  { id: 'security', label: 'Security' },
+  { id: 'data', label: 'Data' },
+  { id: 'modules', label: 'Modules' },
+]
+
+const GROUP_TITLES: Record<RailGroup, string> = {
+  general: 'General',
+  security: 'Security',
+  data: 'Data',
+  modules: 'Module settings',
+}
+
+const GROUP_DESCRIPTIONS: Record<RailGroup, string> = {
+  general: 'Console-wide appearance and runtime defaults.',
+  security: 'Backend connection + credentials. Stored locally only; secrets are masked on export and never sent.',
+  data: 'Local data preferences and future data-source gates.',
+  modules: 'Per-driver defaults from the module specs (ADR-025). The active project can override these per project.',
+}
+
+export function SettingsView() {
+  const { platform, set, module, setModuleBackend, reset } = useAppSettings()
+  const { toast } = useToast()
+  const [rail, setRail] = React.useState<RailGroup>('general')
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null)
+
+  const handleExport = () => {
+    const payload = buildExportPayload(platform, module, true)
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'wake-studio-settings.json'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+    toast({ title: 'Settings exported', description: 'Secrets are masked (••••••••).' })
+  }
+
+  const handleImport = (file: File | undefined) => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const parsed = parseImportPayload(String(reader.result))
+        // Apply parsed platform values via set() (persists), then module map.
+        for (const [id, value] of Object.entries(parsed.platform)) {
+          if (id !== 'schemaVersion') set(id as never, value)
+        }
+        for (const [backendId, values] of Object.entries(parsed.module)) {
+          setModuleBackend(backendId, values as Record<string, unknown>)
+        }
+        toast({ title: 'Settings imported', variant: 'success' })
+      } catch (err) {
+        toast({
+          title: 'Import failed',
+          description: err instanceof Error ? err.message : String(err),
+          variant: 'error',
+        })
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  const handleReset = () => {
+    reset()
+    toast({ title: 'Settings reset', description: 'All app settings restored to defaults.' })
+  }
+
+  const platformIds = PLATFORM_SETTING_DESCRIPTORS.filter(
+    (d) => settingGroupOf(d.id) === rail,
+  )
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-ink-1">Settings</h2>
+        <p className="mt-1 max-w-2xl text-sm text-ink-2">
+          App-level settings, stored locally in your browser. Module settings
+          are generated from the module specs (ADR-025) — a new driver with a
+          spec appears here automatically.
+        </p>
+      </div>
+
+      <div className="flex gap-6">
+        {/* Left rail */}
+        <nav className="w-44 shrink-0 space-y-0.5">
+          {RAIL.map((r) => (
+            <button
+              key={r.id}
+              onClick={() => setRail(r.id)}
+              aria-current={rail === r.id ? 'page' : undefined}
+              className={cn(
+                'w-full rounded-lg px-2.5 py-1.5 text-left text-sm font-medium transition-colors',
+                rail === r.id
+                  ? 'bg-brand-500/10 text-brand-700'
+                  : 'text-ink-2 hover:bg-surface-3 hover:text-ink-1',
+              )}
+            >
+              {r.label}
+            </button>
+          ))}
+        </nav>
+
+        {/* Content */}
+        <div className="min-w-0 flex-1 space-y-4">
+          <div className="rounded-xl border border-line bg-surface-2 p-5">
+            <h3 className="text-sm font-semibold text-ink-1">
+              {GROUP_TITLES[rail]}
+            </h3>
+            <p className="mt-1 mb-3 text-xs text-ink-3">
+              {GROUP_DESCRIPTIONS[rail]}
+            </p>
+
+            {rail === 'modules' ? (
+              <ModuleSettingsSection />
+            ) : (
+              <div className="divide-y divide-line">
+                {platformIds.map((d) => (
+                  <div key={d.id} className="py-1">
+                    {renderParamRow(
+                      descriptorToModuleParam(d),
+                      platform[d.id] ?? d.default,
+                      (v: unknown) => set(d.id, v),
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {rail === 'security' && (
+              <p className="mt-4 rounded-lg border border-line bg-surface-3 px-3 py-2 text-xs text-ink-3">
+                Credentials never leave this browser. Export masks secrets
+                with ••••••••; imports overwrite them.
+              </p>
+            )}
+          </div>
+
+          {/* Global actions */}
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              onClick={handleExport}
+              className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
+            >
+              Export settings (JSON)
+            </button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
+            >
+              Import settings…
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json,.json"
+              className="hidden"
+              onChange={(e) => {
+                handleImport(e.target.files?.[0])
+                e.target.value = ''
+              }}
+            />
+            <button
+              onClick={handleReset}
+              className="rounded-lg border border-danger/40 px-3 py-1.5 text-sm text-danger hover:bg-danger/10"
+            >
+              Reset to defaults
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -5,14 +5,19 @@
  * renders the selected section's content full-width, driven by the route
  * (settings-general / settings-security / settings-data / settings-modules).
  *
- * Edits go into a local draft; a single Save button persists them
- * (localStorage + immediate theme effect). No export/import, no reset.
+ * One shared draft (platform + module) lives here; a single Save button at
+ * the bottom persists everything at once (localStorage + immediate theme
+ * effect). No export/import, no reset.
  */
 
 import * as React from 'react'
 import { renderParamRow } from '@wake-studio/module-kit'
 import { useToast } from '../components/toast'
-import { ModuleSettingsSection } from '../settings/ModuleSettings'
+import {
+  ModuleSettingsSection,
+  seedModuleDraft,
+  type ModuleDraftMap,
+} from '../settings/ModuleSettings'
 import {
   PLATFORM_SETTING_DESCRIPTORS,
   descriptorToModuleParam,
@@ -46,11 +51,11 @@ export function SettingsView({
   /** Driver anchor for the Modules section (Settings -> driver focus). */
   backendId?: string
 }) {
-  const { platform, set } = useAppSettings()
+  const { platform, set, module, setModuleBackend } = useAppSettings()
   const { toast } = useToast()
 
-  // Local draft: edits accumulate here; Save persists them.
-  const [draft, setDraft] = React.useState<
+  // Shared draft: platform fields + per-driver module values.
+  const [platformDraft, setPlatformDraft] = React.useState<
     Record<PlatformSettingId, unknown>
   >(() => {
     const out = {} as Record<PlatformSettingId, unknown>
@@ -59,6 +64,9 @@ export function SettingsView({
     }
     return out
   })
+  const [moduleDraft, setModuleDraft] = React.useState<ModuleDraftMap>(() =>
+    seedModuleDraft(module),
+  )
   const [dirty, setDirty] = React.useState(false)
 
   // Re-seed the draft when the section changes (avoid stale values).
@@ -67,20 +75,37 @@ export function SettingsView({
     for (const d of PLATFORM_SETTING_DESCRIPTORS) {
       out[d.id] = platform[d.id] ?? d.default
     }
-    setDraft(out)
+    setPlatformDraft(out)
+    setModuleDraft(seedModuleDraft(module))
     setDirty(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [section])
 
-  const handleDraftChange = (id: PlatformSettingId, value: unknown) => {
-    setDraft((prev) => ({ ...prev, [id]: value }))
+  const handlePlatformChange = (id: PlatformSettingId, value: unknown) => {
+    setPlatformDraft((prev) => ({ ...prev, [id]: value }))
+    setDirty(true)
+  }
+
+  const handleModuleChange = (
+    backendId_: string,
+    paramId: string,
+    value: unknown,
+  ) => {
+    setModuleDraft((prev) => ({
+      ...prev,
+      [backendId_]: { ...prev[backendId_], [paramId]: value },
+    }))
     setDirty(true)
   }
 
   const handleSave = () => {
-    // Persist all draft fields (platform).
-    for (const [id, value] of Object.entries(draft)) {
+    // Persist all platform draft fields.
+    for (const [id, value] of Object.entries(platformDraft)) {
       set(id as PlatformSettingId, value)
+    }
+    // Persist all module draft values.
+    for (const [backendId_, values] of Object.entries(moduleDraft)) {
+      setModuleBackend(backendId_, { ...values })
     }
     setDirty(false)
     toast({ title: 'Settings saved', variant: 'success' })
@@ -92,25 +117,20 @@ export function SettingsView({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold text-ink-1">
-            {GROUP_TITLES[section]}
-          </h2>
-          <p className="mt-1 text-sm text-ink-2">{GROUP_DESCRIPTIONS[section]}</p>
-        </div>
-        <button
-          onClick={handleSave}
-          disabled={!dirty}
-          className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-40"
-        >
-          Save
-        </button>
+      <div>
+        <h2 className="text-lg font-semibold text-ink-1">
+          {GROUP_TITLES[section]}
+        </h2>
+        <p className="mt-1 text-sm text-ink-2">{GROUP_DESCRIPTIONS[section]}</p>
       </div>
 
       <div className="space-y-4">
         {section === 'modules' ? (
-          <ModuleSettingsSection focusBackendId={backendId} />
+          <ModuleSettingsSection
+            values={moduleDraft}
+            onChange={handleModuleChange}
+            focusBackendId={backendId}
+          />
         ) : (
           <div className="rounded-xl border border-line bg-surface-2 p-5">
             <div className="divide-y divide-line">
@@ -118,8 +138,8 @@ export function SettingsView({
                 <div key={d.id} className="py-1">
                   {renderParamRow(
                     descriptorToModuleParam(d),
-                    draft[d.id],
-                    (v: unknown) => handleDraftChange(d.id, v),
+                    platformDraft[d.id],
+                    (v: unknown) => handlePlatformChange(d.id, v),
                   )}
                 </div>
               ))}
@@ -132,6 +152,20 @@ export function SettingsView({
             Credentials never leave this browser. Changes apply on Save.
           </p>
         )}
+      </div>
+
+      {/* Bottom action bar: single Save for the whole settings section. */}
+      <div className="flex items-center justify-between gap-3 border-t border-line pt-4">
+        <span className="text-xs text-ink-3">
+          {dirty ? 'Unsaved changes' : 'All changes saved'}
+        </span>
+        <button
+          onClick={handleSave}
+          disabled={!dirty}
+          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-40"
+        >
+          Save
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Data-driven Settings panel (issue #52) + the first slice of #53 P1
(driver/model-source persistence layer). The `#/settings` placeholder is
replaced with a real, spec-driven settings experience.

## What's in this PR

**Settings panel (#52)**
- Platform settings: theme (light/dark/system, immediate effect + meta
  theme-color), locale anchor, KWS execution provider, backend endpoint +
  secrets (password inputs, localStorage-only, never sent), data/mic prefs.
- Module settings: registry-driven — only KWS drivers that carry a spec
  appear (OpenWakeWord / sherpa-onnx / PLiX), values persisted per backendId.
  A new driver with a spec shows up automatically.
- localStorage-backed (`wake-studio:settings:*`), versioned merge on read;
  save-to-apply (single bottom Save bar; edits are drafts until saved).
- Reuses module-kit controls (`renderParamRow`) via `descriptorToModuleParam`
  — zero new controls.

**Sidebar integration**
- Settings becomes an expandable sub-menu (parent toggles open/closed only,
  no navigation; full-row hover, single focus on the clicked sub-item).
- Hierarchy is flat: `Settings → General / Security / Data / <driver>` —
  drivers are direct Settings children (no intermediate "Modules" layer).
- Driver click anchors `#/settings/modules/<backendId>`; the modules section
  scrolls to and highlights that driver.

**Layered persistence (#53 P1 slice)**
- KWS driver values seed from app-level module settings (spec defaults < app
  defaults); the #53 `WorkspaceConfig` project snapshot will override per
  project when it lands.
- Model-source selections persist to app-level `kwsSources` defaults and
  rehydrate across reloads.

**Mobile drawer (GitHub-style)**
- Narrow viewports: the sidebar collapses into a left-edge slide-in panel —
  full height, right-edge rounded (top-right/bottom-right), left flush,
  light scrim (no blur), close button beside the logo. Not a centered dialog.

## Files

- `apps/web/src/settings/*` — new: types, schema, storage, context,
  ModuleSettings, unit tests (18 tests)
- `apps/web/src/views/SettingsView.tsx` — replaces the ComingSoon placeholder
- `apps/web/src/router.ts` — settings sub-routes + driver anchors
- `apps/web/src/components/{shell,shell-nav,ConsoleShell,ui}.tsx` — sub-menu,
  drawer, DialogContent `centered` prop, lighter overlay
- `apps/web/src/components/KWSPanel.tsx` — layered persistence reads/writes
- `apps/web/e2e/{settings,smoke}.spec.ts` — new settings e2e + updated smoke

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` — 0 errors ✅
- `pnpm test:unit` — 33/33 ✅ (18 new settings storage tests)
- `pnpm build` ✅
- `pnpm test:e2e` — 23/23 ✅ (6 settings specs incl. mobile drawer regression)

## Notes

- Storage layer keeps `buildExportPayload`/`parseImportPayload`/`resetSettings`
  for unit tests; the UI intentionally has no export/import/reset.
- Pre-existing gap (not in scope, documented): few-shot `fsConfig` edits never
  reach the engine — tracked for #53 P1's few-shot wiring fixes.
- `docs/workspace-optimization.plan.md` is untracked (#53's plan) and NOT part
  of this PR.

Closes #52
Refs #53
