### PR TITLE
fix(kws): sherpa-onnx-kws never triggers + Model sources shows wrong roles (#64)

### DIFF
--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -36,6 +36,7 @@ import {
   FEWSHOT_MODEL_ROLES,
   driverParamsFor,
   modelSourcesForRole,
+  type ModelSourceRole,
 } from '../workspace/kws-config'
 import { ParamRows, type ParamValue } from './UnifiedConfigPanel'
 import { drawScoreCurve } from './viz/ScoreCurve'
@@ -437,6 +438,17 @@ export const KWSPanel = memo(function KWSPanel({
   // (plixkws today, future drivers) get the enrollment flow automatically.
   const selectedBackend = getBackendRegistry().find((r) => r.id === config.backend)
   const isFewShot = selectedBackend?.category === 'few-shot'
+  // Model-source roles per category (ADR-024): traditional (openwakeword) and
+  // few-shot (plixkws) consume model URLs from the registry. asr-decoding
+  // (sherpa-onnx-kws) bundles its model into the wasm .data package and only
+  // takes a keyword list — it has NO registry model sources, so the section
+  // renders a note instead of the openwakeword pickers (issue #64).
+  const modelRoles: readonly ModelSourceRole[] =
+    selectedBackend?.category === 'few-shot'
+      ? FEWSHOT_MODEL_ROLES
+      : selectedBackend?.category === 'asr-decoding'
+        ? []
+        : TRADITIONAL_MODEL_ROLES
   // Backend switching is lightweight: it only updates the selection (and any
   // pending load state), it does NOT auto-load models. Loading a different
   // backend re-initializes the worker + model session, which is slow; the user
@@ -989,7 +1001,14 @@ export const KWSPanel = memo(function KWSPanel({
             models are stored in your browser (IndexedDB) and can be exported
             back to disk. Applied on the next Load/Reload.
           </p>
-          {(isFewShot ? FEWSHOT_MODEL_ROLES : TRADITIONAL_MODEL_ROLES).map(({ role, label, fallbackId }) => {
+          {modelRoles.length === 0 ? (
+            <p className="text-xs text-ink-3">
+              This backend's model is bundled in its wasm runtime — there are
+              no model sources to pick. See the Engine card's resources
+              (sherpa-onnx KWS wasm runtime + wake-word list).
+            </p>
+          ) : (
+            modelRoles.map(({ role, label, fallbackId }) => {
                 const options = registryModels
                   ? modelSourcesForRole(registryModels, role, customUrls[role])
                   : []
@@ -1112,7 +1131,9 @@ export const KWSPanel = memo(function KWSPanel({
                     </p>
                   </div>
                 )
-              })}
+              })
+            )
+          }
       </div>
 
       {/* plixkws enrollment + detection (Few-Shot, Phase 3) - inline in the KWS

--- a/docs/modules/kws.md
+++ b/docs/modules/kws.md
@@ -272,6 +272,13 @@ it runs on the **main thread** and drives its own smoothing/trigger loop there
 (see `packages/modules/kws/sherpa/core/backend.ts` + the engine's `KWSEngine`). Both paths expose the
 same `onScore`/`onTrigger` events to the UI.
 
+**sherpa stream lifecycle (issue #64):** the sherpa `KeywordSpotter` stream is
+resetted **only after a keyword hit**, never per-frame. `Reset()` wipes the
+decoder hypothesis *and* the encoder RNN states, so resetting after every
+decode destroyed the streaming context and multi-frame keywords (e.g. 你好军哥)
+never fired. sherpa itself auto-resets after ~1.5 s of trailing silence, so the
+backend just decodes every ready chunk (`while isReady -> decode`).
+
 ```
 AFE (AudioWorklet)                KWS Worker (ONNX backends)   Main thread (UI)
       │                               │                            │

--- a/packages/modules/kws/sherpa/core/backend.ts
+++ b/packages/modules/kws/sherpa/core/backend.ts
@@ -252,13 +252,31 @@ export class SherpaOnnxKwsBackend implements KWSBackend {
       return 1
     }
 
-    if (!this._spotter.isReady(this._stream)) return 0
+    // Decode as many ready chunks as the stream has buffered (mirrors the
+    // upstream wasm/kws/app.js loop). IMPORTANT: do NOT reset the stream here.
+    // sherpa-onnx's Reset() wipes the decoder hypothesis AND the encoder RNN
+    // states (keyword-spotter-transducer-impl.h), and the upstream demo
+    // resets only after a keyword hit — sherpa itself auto-resets after ~1.5 s
+    // of trailing silence. Resetting after every decode destroyed the
+    // streaming state, so keywords spanning multiple chunks (e.g. 你好军哥)
+    // never accumulated enough context to fire.
+    let keyword = ''
+    while (this._spotter.isReady(this._stream)) {
+      this._spotter.decode(this._stream)
+      const result = this._spotter.getResult(this._stream)
+      const k = (result.keyword ?? '').trim()
+      if (k.length > 0) {
+        keyword = k
+        // Reset right after a hit (upstream does the same) so the same
+        // keyword can be detected again on the next utterance.
+        try {
+          this._spotter.reset(this._stream)
+        } catch {
+          /* ignore */
+        }
+      }
+    }
 
-    this._spotter.decode(this._stream)
-    const result = this._spotter.getResult(this._stream)
-    this._spotter.reset(this._stream)
-
-    const keyword = (result.keyword ?? '').trim()
     if (keyword.length > 0) {
       this._lastKeyword = keyword
       // Hold high for ~400 ms (40 frames) to satisfy min-duration + cooldown.

--- a/packages/modules/kws/sherpa/tests/backend.test.ts
+++ b/packages/modules/kws/sherpa/tests/backend.test.ts
@@ -1,0 +1,139 @@
+/**
+ * kws-sherpa driver - backend decode-loop regression tests (issue #64).
+ *
+ * Guards the streaming decode contract: the stream must NOT be reset after
+ * every decode (that wiped the encoder RNN state and made multi-frame
+ * keywords like 你好军哥 never fire). Reset is only legal after a keyword hit,
+ * mirroring the upstream wasm/kws/app.js demo; sherpa auto-resets on trailing
+ * silence internally.
+ *
+ * These tests run without the wasm (L2 is gated, issue #49) - they inject a
+ * fake spotter/stream into the backend and drive processFrame directly.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { SherpaOnnxKwsBackend } from '../core/backend'
+
+interface FakeStream {
+  acceptWaveform: ReturnType<typeof vi.fn>
+  free: ReturnType<typeof vi.fn>
+}
+
+/** Minimal fake spotter mirroring the SherpaKws surface used by processFrame. */
+class FakeSpotter {
+  /** isReady() returns true this many times before turning false. */
+  readyTicks = 0
+  decodeCalls = 0
+  resetCalls = 0
+  results: Array<{ keyword?: string }> = []
+
+  createStream(): FakeStream {
+    return {
+      acceptWaveform: vi.fn(),
+      free: vi.fn(),
+    }
+  }
+
+  isReady(): boolean {
+    return this.readyTicks-- > 0
+  }
+
+  decode(): void {
+    this.decodeCalls += 1
+  }
+
+  getResult(): { keyword?: string } {
+    return this.results.shift() ?? { keyword: '' }
+  }
+
+  reset(): void {
+    this.resetCalls += 1
+  }
+
+  free(): void {}
+}
+
+function makeBackend(spotter: FakeSpotter): TestBackend {
+  const backend = new SherpaOnnxKwsBackend() as unknown as TestBackend
+  backend._ready = true
+  backend._spotter = spotter
+  backend._stream = spotter.createStream()
+  return backend
+}
+
+/** Structural view of the backend internals used by the tests (private
+ *  members are compile-time-only; cast via unknown avoids the never trap). */
+interface TestBackend {
+  _ready: boolean
+  _spotter: FakeSpotter
+  _stream: FakeStream
+  _holdFrames: number
+  lastPartialText: string
+  processFrame(samples: Float32Array): Promise<number | null>
+}
+
+const FRAME = new Float32Array(160) // 10 ms @ 16 kHz
+
+describe('SherpaOnnxKwsBackend.processFrame', () => {
+  it('does NOT reset the stream when no keyword is detected', async () => {
+    const spotter = new FakeSpotter()
+    spotter.readyTicks = 1
+    spotter.results = [{ keyword: '' }]
+    const backend = makeBackend(spotter)
+
+    const score = await backend.processFrame(FRAME)
+
+    expect(score).toBe(0)
+    expect(spotter.decodeCalls).toBe(1)
+    // The bug (issue #64): resetting here wiped the encoder RNN states, so
+    // keywords spanning multiple chunks never accumulated. Reset is only legal
+    // after a keyword hit.
+    expect(spotter.resetCalls).toBe(0)
+  })
+
+  it('decodes every ready chunk before giving up', async () => {
+    const spotter = new FakeSpotter()
+    spotter.readyTicks = 3
+    spotter.results = [{ keyword: '' }, { keyword: '' }, { keyword: '' }]
+    const backend = makeBackend(spotter)
+
+    const score = await backend.processFrame(FRAME)
+
+    expect(score).toBe(0)
+    expect(spotter.decodeCalls).toBe(3)
+    expect(spotter.resetCalls).toBe(0)
+  })
+
+  it('returns 1 and resets exactly once after a keyword hit', async () => {
+    const spotter = new FakeSpotter()
+    spotter.readyTicks = 2
+    spotter.results = [{ keyword: '' }, { keyword: '你好军哥' }]
+    const backend = makeBackend(spotter)
+
+    const score = await backend.processFrame(FRAME)
+
+    expect(score).toBe(1)
+    expect(backend.lastPartialText).toBe('你好军哥')
+    expect(spotter.resetCalls).toBe(1)
+    // The detected keyword's score is held for the trigger min-duration gate.
+    const next = await backend.processFrame(FRAME)
+    expect(next).toBe(1)
+  })
+
+  it('accepts waveform every frame even while holding a hit', async () => {
+    const spotter = new FakeSpotter()
+    spotter.readyTicks = 1
+    spotter.results = [{ keyword: '小爱同学' }]
+    const backend = makeBackend(spotter)
+
+    await backend.processFrame(FRAME)
+    const stream = backend._stream
+    expect(stream.acceptWaveform).toHaveBeenCalledTimes(1)
+
+    // Hold period: still accepts audio, does not decode.
+    const held = await backend.processFrame(FRAME)
+    expect(held).toBe(1)
+    expect(stream.acceptWaveform).toHaveBeenCalledTimes(2)
+    expect(spotter.decodeCalls).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #64 — two defects in the sherpa-onnx-kws backend and the KWS panel:

1. **sherpa-onnx-kws never triggered.** `SherpaOnnxKwsBackend.processFrame()` reset the `KeywordSpotter` stream after **every** decode. In sherpa-onnx, `Reset()` = `InitOnlineStream()`, which wipes the decoder hypothesis **and** the encoder RNN states (`keyword-spotter-transducer-impl.h`). The upstream demo (`wasm/kws/app.js`) resets **only after a keyword hit**; sherpa itself auto-resets after ~1.5 s of trailing silence. Our per-frame reset destroyed the streaming state, so a multi-frame keyword (e.g. 你好军哥) never accumulated enough context to fire. Verified the default keyword tokens exist in the bundled model's `tokens.txt` (extracted from the 40 MB `.data` package) — the config was valid; the decode loop was the bug.

2. **Model sources showed openwakeword roles for the sherpa backend.** `KWSPanel.tsx` rendered `TRADITIONAL_MODEL_ROLES` (mel / embedding / classifier) for every non-few-shot backend, including `sherpa-onnx-kws` (category `asr-decoding`), which loads its model from the wasm `.data` bundle and only takes a keyword list. Roles are now resolved from the backend's ADR-024 category: `traditional` → openwakeword roles, `few-shot` → plix roles, `asr-decoding` → no pickers (a note explains the model is bundled in the wasm runtime).

## Changes

- `packages/modules/kws/sherpa/core/backend.ts` — decode every ready chunk (`while isReady → decode`), reset only after a keyword hit, mirroring upstream.
- `apps/web/src/components/KWSPanel.tsx` — model-source roles driven by backend category; sherpa shows a note instead of the openwakeword pickers.
- `packages/modules/kws/sherpa/tests/backend.test.ts` — 4 regression tests pinning the stream-reset contract (no reset on miss, decode-all-ready-chunks, reset-once-on-hit + score hold, acceptWaveform during hold).
- `docs/modules/kws.md` — sherpa stream-lifecycle note (docs-sync rule).

## Validation

- `pnpm typecheck` — green (full repo)
- `pnpm test:unit` — 15/15 test files green; sherpa 10 passed (4 new) + 2 skipped (L2, tracked in #49)
- `pnpm --filter @wake-studio/web build` — green
- eslint on changed files — 0 errors

## Manual verification needed

The trigger fix changes wasm runtime behavior; please verify in-browser:
1. `pnpm dev` → Workspace → KWS → select `sherpa-onnx-kws`.
2. Load models, start AFE mic + detection, speak 你好军哥 → trigger should fire (score curve / flash / session-console event).
3. Model sources section should show the "bundled in wasm" note, not openwakeword pickers.

Closes #64
