### PR TITLE
fix(kws): plix few-shot detection end-to-end (#66 #67 #68 #69 #70)

### DIFF
--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -177,6 +177,7 @@ export const KWSPanel = memo(function KWSPanel({
     windowMs: number
     hopMs: number
     useNegativePrototype: boolean
+    silenceFloorDbfs: number
   }>({
     ...FS_DEFAULTS,
     ...(fsProjCfg as Partial<typeof FS_DEFAULTS> | undefined),
@@ -688,8 +689,13 @@ export const KWSPanel = memo(function KWSPanel({
         proto.vector,
         // Few-Shot detection params from the config panel (epic #53 P1):
         // windowMs + useNegativePrototype reach the plix backend via the
-        // worker load message -> initWithPrototype opts.
-        { windowMs: fsConfig.windowMs, useNegative: fsConfig.useNegativePrototype },
+        // worker load message -> initWithPrototype opts. silenceFloorDbfs
+        // gates silent windows to score 0 (no false triggers on silence).
+        {
+          windowMs: fsConfig.windowMs,
+          useNegative: fsConfig.useNegativePrototype,
+          silenceFloorDbfs: fsConfig.silenceFloorDbfs,
+        },
       )
       const afe2 = afeRef?.current ?? afePipeline
       fresh.start({
@@ -704,7 +710,7 @@ export const KWSPanel = memo(function KWSPanel({
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
     }
-  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype])
+  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype, fsConfig.silenceFloorDbfs])
 
   const handleStopPlix = useCallback(() => {
     engineRef.current?.stop()

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -659,7 +659,23 @@ export const KWSPanel = memo(function KWSPanel({
       fresh.onTrigger(() => {
       })
       engineRef.current = fresh
-      fresh.setConfig({ ...DEFAULT_CONFIG, backend: 'plixkws' })
+      // Keep the top-bar wake indicator + preview curve on the same threshold
+      // the engine trigger now uses (the Few-Shot panel's, not KWS defaults).
+      setThreshold(fsConfig.threshold)
+      // Seed the engine trigger config from the Few-Shot panel (fsConfig),
+      // not the KWS DEFAULT_CONFIG: threshold/min-duration/cooldown/VAD live in
+      // the Few-Shot config surface, and the engine's TriggerDetector must use
+      // the same threshold the score curve renders (issue #66 secondary).
+      fresh.setConfig({
+        ...DEFAULT_CONFIG,
+        backend: 'plixkws',
+        threshold: fsConfig.threshold,
+        minDurationMs: fsConfig.minDurationMs,
+        cooldownMs: fsConfig.cooldownMs,
+        smoothingWindowFrames: fsConfig.smoothingWindowFrames,
+        vadGateEnabled: fsConfig.vadGateEnabled,
+        vadThreshold: fsConfig.vadThreshold,
+      })
       const { url, runtime } = resolvePlixLocator()
       await fresh.load(
         { plixkws: url, runtime },
@@ -682,7 +698,7 @@ export const KWSPanel = memo(function KWSPanel({
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
     }
-  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, fsConfig.windowMs, fsConfig.useNegativePrototype])
+  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, setThreshold, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype])
 
   const handleStopPlix = useCallback(() => {
     engineRef.current?.stop()

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -653,8 +653,14 @@ export const KWSPanel = memo(function KWSPanel({
       const fresh = new KWSEngine()
       fresh.onScore((s) => {
         setLastScore(s.smoothedScore)
+        // Few-shot scores must reach BOTH the panel's own curve (fsHistoryRef)
+        // and the shared workspace history (historyRef) that ScoreCurvePanel /
+        // the top-bar mini bar render (issue #67: previously only fsHistoryRef
+        // was written, so the workspace score curve stayed empty).
         fsHistoryRef.current.push(s)
         if (fsHistoryRef.current.length > HISTORY_MAX) fsHistoryRef.current.shift()
+        historyRef.current.push(s)
+        if (historyRef.current.length > HISTORY_MAX) historyRef.current.shift()
       })
       fresh.onTrigger(() => {
       })
@@ -698,13 +704,14 @@ export const KWSPanel = memo(function KWSPanel({
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
     }
-  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, setThreshold, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype])
+  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype])
 
   const handleStopPlix = useCallback(() => {
     engineRef.current?.stop()
     setDetecting(false)
     fsHistoryRef.current = []
-  }, [])
+    historyRef.current = []
+  }, [historyRef])
 
 
   const handleStart = useCallback(() => {
@@ -729,16 +736,23 @@ export const KWSPanel = memo(function KWSPanel({
   // Expose load/start/stop to the workspace pipeline runner via commandRef
   // (epic #53 P4). The runner drives the unified Start/Stop; the panel keeps
   // its own Load/Reload buttons.
+  //
+  // Dispatch on the backend's few-shot category (issue #67): the few-shot
+  // flow needs its own load/start/stop (handleLoadEncoder/handleStartPlix/
+  // handleStopPlix) because the plixkws backend must be booted WITH the
+  // enrolled prototype. Using the traditional handlers here made the unified
+  // Start either fail (handleLoad with no prototype -> worker error) or start
+  // the encoder-only engine with no detection backend (empty score curve).
   useEffect(() => {
     if (commandRef) {
       commandRef.current = {
-        load: handleLoad,
-        start: handleStart,
-        stop: handleStop,
-        getState: () => ({ status, running, isFewShot }),
+        load: isFewShot ? handleLoadEncoder : handleLoad,
+        start: isFewShot ? handleStartPlix : handleStart,
+        stop: isFewShot ? handleStopPlix : handleStop,
+        getState: () => ({ status, running: running || detecting, isFewShot }),
       }
     }
-  }, [commandRef, handleLoad, handleStart, handleStop, status, running, isFewShot])
+  }, [commandRef, handleLoad, handleLoadEncoder, handleStart, handleStartPlix, handleStop, handleStopPlix, status, running, detecting, isFewShot])
 
   const updateConfig = useCallback((patch: Partial<KWSConfig>) => {
     setConfig((prev) => {

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -162,8 +162,13 @@ export const KWSPanel = memo(function KWSPanel({
   // --- plixkws enrollment state (Few-Shot, Phase 3) ---
   const fsEngineRef = useRef<FewShotEngine | null>(null)
   const [samples, setSamples] = useState<EnrolledSample[]>([])
+  // Negative-class enrollment (open-set rejection, issue #69): the user
+  // records other words / background speech so non-target audio scores low.
+  const [negSamples, setNegSamples] = useState<EnrolledSample[]>([])
   const [recording, setRecording] = useState(false)
+  const [recordingNeg, setRecordingNeg] = useState(false)
   const [building, setBuilding] = useState(false)
+  const [buildingNeg, setBuildingNeg] = useState(false)
   const [prototype, setPrototype] = useState<WakeWordPrototype | null>(null)
   const [detecting, setDetecting] = useState(false)
   const { projectConfig: fsProjCfg, persist: persistFs } = useProjectStageConfig('fewShot')
@@ -566,57 +571,65 @@ export const KWSPanel = memo(function KWSPanel({
     }
   }, [ensureFsEngines, resolvePlixLocator])
 
-  /** Record a 1.5 s sample from the mic at 16 kHz. */
-  const handleRecord = useCallback(async () => {
-    setError(null)
-    setRecording(true)
-    let ctx: AudioContext | null = null
-    let stream: MediaStream | null = null
-    let node: AudioWorkletNode | null = null
-    let source: MediaStreamAudioSourceNode | null = null
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
-      })
-      ctx = new AudioContext({ sampleRate: 16000 })
-      if (ctx.state === 'suspended') await ctx.resume()
-      await ctx.audioWorklet.addModule(recorderUrl)
+  /** Record a 1.5 s sample from the mic at 16 kHz into the given bucket
+   *  ('pos' = wake word samples, 'neg' = other-speech/background samples for
+   *  the negative class, issue #69). */
+  const handleRecord = useCallback(
+    async (bucket: 'pos' | 'neg' = 'pos') => {
+      setError(null)
+      if (bucket === 'neg') setRecordingNeg(true)
+      else setRecording(true)
+      let ctx: AudioContext | null = null
+      let stream: MediaStream | null = null
+      let node: AudioWorkletNode | null = null
+      let source: MediaStreamAudioSourceNode | null = null
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+        })
+        ctx = new AudioContext({ sampleRate: 16000 })
+        if (ctx.state === 'suspended') await ctx.resume()
+        await ctx.audioWorklet.addModule(recorderUrl)
 
-      source = ctx.createMediaStreamSource(stream)
-      node = new AudioWorkletNode(ctx, 'few-shot-recorder')
-      const chunks: Float32Array[] = []
-      node.port.onmessage = (e: MessageEvent<{ type: 'chunk'; samples: Float32Array }>) => {
-        if (e.data.type === 'chunk') chunks.push(e.data.samples)
+        source = ctx.createMediaStreamSource(stream)
+        node = new AudioWorkletNode(ctx, 'few-shot-recorder')
+        const chunks: Float32Array[] = []
+        node.port.onmessage = (e: MessageEvent<{ type: 'chunk'; samples: Float32Array }>) => {
+          if (e.data.type === 'chunk') chunks.push(e.data.samples)
+        }
+        source.connect(node)
+        node.connect(ctx.destination)
+
+        await new Promise((r) => setTimeout(r, RECORD_MS))
+        node.disconnect()
+        source.disconnect()
+        stream.getTracks().forEach((t) => t.stop())
+
+        const total = chunks.reduce((a, c) => a + c.length, 0)
+        const audio = new Float32Array(total)
+        let off = 0
+        for (const c of chunks) {
+          audio.set(c, off)
+          off += c.length
+        }
+
+        ensureFsEngines()
+        const sample = await fsEngineRef.current!.embedSample(audio, 16000)
+        if (bucket === 'neg') setNegSamples((prev) => [...prev, sample])
+        else setSamples((prev) => [...prev, sample])
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (bucket === 'neg') setRecordingNeg(false)
+        else setRecording(false)
+        try { node?.disconnect() } catch { /* ignore */ }
+        try { source?.disconnect() } catch { /* ignore */ }
+        stream?.getTracks().forEach((t) => t.stop())
+        if (ctx) await ctx.close().catch(() => {})
       }
-      source.connect(node)
-      node.connect(ctx.destination)
-
-      await new Promise((r) => setTimeout(r, RECORD_MS))
-      node.disconnect()
-      source.disconnect()
-      stream.getTracks().forEach((t) => t.stop())
-
-      const total = chunks.reduce((a, c) => a + c.length, 0)
-      const audio = new Float32Array(total)
-      let off = 0
-      for (const c of chunks) {
-        audio.set(c, off)
-        off += c.length
-      }
-
-      ensureFsEngines()
-      const sample = await fsEngineRef.current!.embedSample(audio, 16000)
-      setSamples((prev) => [...prev, sample])
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setRecording(false)
-      try { node?.disconnect() } catch { /* ignore */ }
-      try { source?.disconnect() } catch { /* ignore */ }
-      stream?.getTracks().forEach((t) => t.stop())
-      if (ctx) await ctx.close().catch(() => {})
-    }
-  }, [ensureFsEngines])
+    },
+    [ensureFsEngines],
+  )
 
   const handleBuildPrototype = useCallback(async () => {
     setError(null)
@@ -632,6 +645,30 @@ export const KWSPanel = memo(function KWSPanel({
       setBuilding(false)
     }
   }, [samples])
+
+  /** Build + persist the negative-class prototype from non-target samples. */
+  const handleBuildNegative = useCallback(async () => {
+    setError(null)
+    setBuildingNeg(true)
+    try {
+      const fs = fsEngineRef.current!
+      if (!prototype) {
+        setError('Build the wake-word prototype first, then enroll negative samples.')
+        return
+      }
+      const negVector = fs.buildNegativeVector(negSamples)
+      const updated = await fs.attachNegativePrototype(prototype, negVector)
+      setPrototype(updated)
+      // Open-set rejection is only meaningful when a negative class exists:
+      // auto-enable it so detection uses the relative score.
+      setFsConfig((prev) => ({ ...prev, useNegativePrototype: true }))
+      logInfo('kws', `Negative prototype built (${negSamples.length} samples, ${negVector.length}-dim)`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBuildingNeg(false)
+    }
+  }, [prototype, negSamples])
 
   /** Load the plixkws detection backend with the prototype and start. */
   const handleStartPlix = useCallback(async () => {
@@ -696,6 +733,9 @@ export const KWSPanel = memo(function KWSPanel({
           useNegative: fsConfig.useNegativePrototype,
           silenceFloorDbfs: fsConfig.silenceFloorDbfs,
         },
+        // Negative-class prototype (open-set rejection, issue #69): reaches
+        // the worker as prototypeNegative -> initWithPrototype proto.
+        proto.negativeVector,
       )
       const afe2 = afeRef?.current ?? afePipeline
       fresh.start({
@@ -1219,7 +1259,7 @@ export const KWSPanel = memo(function KWSPanel({
             <div className="space-y-4">
               <div className="flex flex-wrap items-center gap-3">
                 <button
-                  onClick={handleRecord}
+                  onClick={() => void handleRecord('pos')}
                   disabled={recording}
                   className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500 disabled:opacity-50"
                 >
@@ -1270,6 +1310,76 @@ export const KWSPanel = memo(function KWSPanel({
                   )}
                 </div>
               )}
+
+              {/* Negative-class enrollment (open-set rejection, issue #69):
+                  record other words / background speech so non-target audio
+                  scores low instead of triggering. Optional, but strongly
+                  recommended - the model's single-prototype score can clear
+                  the threshold on other speech without a negative class. */}
+              <div className="space-y-2 border-t border-line pt-3">
+                <div className="flex items-center gap-2">
+                  <h4 className="text-xs font-semibold text-ink-2">
+                    Negative samples{' '}
+                    <span className="font-normal text-ink-3">
+                      (optional — other words / background, for open-set rejection)
+                    </span>
+                  </h4>
+                  {prototype?.negativeVector && (
+                    <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300">
+                      enrolled
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    onClick={() => void handleRecord('neg')}
+                    disabled={recordingNeg}
+                    className="rounded-lg bg-surface-3 px-4 py-2 text-sm font-medium text-ink-2 hover:bg-surface-4 disabled:opacity-50"
+                  >
+                    {recordingNeg ? `Recording… (${RECORD_MS}ms)` : 'Record non-target sample'}
+                  </button>
+                  {negSamples.length >= MIN_SAMPLES && prototype && (
+                    <button
+                      onClick={handleBuildNegative}
+                      disabled={buildingNeg}
+                      className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+                    >
+                      {buildingNeg
+                        ? 'Building…'
+                        : prototype.negativeVector
+                          ? 'Re-enroll negative prototype'
+                          : `Build negative prototype (${negSamples.length} samples)`}
+                    </button>
+                  )}
+                  {negSamples.length > 0 && (
+                    <span className="text-xs text-ink-3">
+                      {negSamples.length}/{MIN_SAMPLES}+ samples
+                    </span>
+                  )}
+                </div>
+                {prototype && !prototype.negativeVector && negSamples.length === 0 && (
+                  <p className="text-[10px] text-ink-3">
+                    Say other words you don't want to trigger on (e.g. "hello", "hi",
+                    background conversation) — the detector then scores them against this
+                    negative class instead of the wake word alone.
+                  </p>
+                )}
+                {negSamples.length > 0 && (
+                  <div className="space-y-1 text-xs text-ink-2">
+                    {negSamples.map((s, i) => (
+                      <div key={s.id} className="flex gap-3">
+                        <span className="w-8 font-mono">#{i + 1}</span>
+                        <span>{s.quality.durationMs.toFixed(0)} ms</span>
+                        <span>{s.quality.peakDbfs.toFixed(1)} dBFS</span>
+                        <span>SNR {s.quality.snrDb.toFixed(1)} dB</span>
+                        <span className={s.quality.acceptable ? 'text-success' : 'text-warning'}>
+                          {s.quality.clipped ? 'clipped' : s.quality.acceptable ? 'OK' : 'low quality'}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           )}
 

--- a/apps/web/src/projects/__tests__/store.test.ts
+++ b/apps/web/src/projects/__tests__/store.test.ts
@@ -104,7 +104,7 @@ function makeProject(partial: Partial<WakeWordProject> = {}): WakeWordProject {
     config: {
       afe: { topology: 'single-worklet', channels: 1, frameMs: { aec: 10, bss: 10, ns: 10 }, latencyBudgetMs: 150, vizFps: 30 },
       kws: { backend: 'openwakeword', threshold: 0.5, minDurationMs: 300, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, cooldownMs: 2000, executionProvider: 'wasm' },
-      fewShot: { threshold: 0.7, minDurationMs: 300, cooldownMs: 2000, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, windowMs: 1500, hopMs: 80, useNegativePrototype: false },
+      fewShot: { threshold: 0.7, minDurationMs: 300, cooldownMs: 2000, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, windowMs: 1500, hopMs: 80, useNegativePrototype: false, silenceFloorDbfs: -45 },
     },
     sampleIds: [],
     prototypeIds: [],

--- a/apps/web/src/projects/__tests__/store.test.ts
+++ b/apps/web/src/projects/__tests__/store.test.ts
@@ -104,7 +104,7 @@ function makeProject(partial: Partial<WakeWordProject> = {}): WakeWordProject {
     config: {
       afe: { topology: 'single-worklet', channels: 1, frameMs: { aec: 10, bss: 10, ns: 10 }, latencyBudgetMs: 150, vizFps: 30 },
       kws: { backend: 'openwakeword', threshold: 0.5, minDurationMs: 300, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, cooldownMs: 2000, executionProvider: 'wasm' },
-      fewShot: { threshold: 0.7, minDurationMs: 300, cooldownMs: 2000, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, windowMs: 1500, hopMs: 80, useNegativePrototype: false, silenceFloorDbfs: -45 },
+      fewShot: { threshold: 0.9, minDurationMs: 300, cooldownMs: 2000, smoothingWindowFrames: 5, vadGateEnabled: true, vadThreshold: 0.3, windowMs: 1500, hopMs: 80, useNegativePrototype: false, silenceFloorDbfs: -45 },
     },
     sampleIds: [],
     prototypeIds: [],

--- a/docs/modules/few-shot.md
+++ b/docs/modules/few-shot.md
@@ -179,7 +179,7 @@ unchanged.
 
 | Parameter | Default | Range | Notes |
 |---|---|---|---|
-| `threshold` | 0.7 | 0.5-0.95 | PLiX prototype-distance score (rescaled [0,1]). |
+| `threshold` | 0.9 | 0.5-0.95 | PLiX prototype-distance score on L2-normalized embeddings (issue #66): enrolled word ~0.9-1.0, other speech ~0.7-0.9. Default 0.9 rejects most non-target speech. |
 | `minDurationMs` | 300 | 100-3000 | Sustained activation before trigger. |
 | `cooldownMs` | 2000 | 500-10000 | Min time between triggers. |
 | `smoothingWindowFrames` | 5 | 1-30 | Sliding-window max-pool. |
@@ -262,6 +262,7 @@ unchanged.
 
 | Date | Change | Author |
 |---|---|---|
+| 2026-08-10 | Recalibrate default threshold 0.7 -> 0.9 (issue #69). 0.7 predated the #66 normalization fix when all scores were ~0.24; post-#66 real speech scores 0.78-0.96, so the old default made the wake word fire on ANY speech. Verified with real speech: enrolled word 0.92-1.0 vs other words 0.78-0.89. | agent |
 | 2026-08-10 | Add silence gate to PLiX detection (issue #66 follow-up): windows at/below `silenceFloorDbfs` (-45 dBFS RMS default) score 0 and skip the encoder. The model maps silence/background to a cosine-similar spot near the prototype (score ~0.7+ with no input after the normalization fix), so energy gating is required to avoid false triggers. Tunable via the Few-Shot config surface. | agent |
 | 2026-08-10 | Fix PLiX never triggering (issue #66): L2-normalize query + prototype before squared-Euclidean scoring (raw GAP embeddings have L2 norm ~4-5, so un-normalized d^2 ~3-4 even for a 0.92-cosine match -> score ~0.24, unreachable). Normalized d^2 = 2(1-cos) is well-calibrated; also wire the Few-Shot panel threshold/VAD/min-duration into the engine trigger config instead of KWS defaults. | agent |
 | 2026-07-27 | Initial draft (docs-first, pending human review). | agent |

--- a/docs/modules/few-shot.md
+++ b/docs/modules/few-shot.md
@@ -162,6 +162,15 @@ KWS engine (worker) handles smoothing, threshold, and trigger - exactly as for t
 OpenWakeWord backend. This is the power of the shared `KWSBackend` interface
 (ADR-020).
 
+**Normalization (issue #66):** both the query embedding and the prototype are
+L2-normalized before the squared-Euclidean distance is computed, so
+`d^2 = 2(1-cos) ∈ [0,4]` and the score is well-calibrated: a cosine-similar
+match (cos 0.92) scores ~0.86, while raw GAP embeddings (L2 norm ~4-5) would
+have scored ~0.24 for any input - unreachable for the 0.5/0.7 thresholds. This
+is the cosine similarity the technical reference specifies (docs/Technical
+Reference_...plixkws.md §2.1), expressed via the paper's squared-Euclidean
+metric on unit vectors.
+
 **Cosine similarity:** `cos(a, b) = dot(a,b) / (||a|| * ||b||)`, rescaled to
 [0,1] via `(cos + 1) / 2` so the existing threshold/min-duration UI works
 unchanged.
@@ -252,6 +261,7 @@ unchanged.
 
 | Date | Change | Author |
 |---|---|---|
+| 2026-08-10 | Fix PLiX never triggering (issue #66): L2-normalize query + prototype before squared-Euclidean scoring (raw GAP embeddings have L2 norm ~4-5, so un-normalized d^2 ~3-4 even for a 0.92-cosine match -> score ~0.24, unreachable). Normalized d^2 = 2(1-cos) is well-calibrated; also wire the Few-Shot panel threshold/VAD/min-duration into the engine trigger config instead of KWS defaults. | agent |
 | 2026-07-27 | Initial draft (docs-first, pending human review). | agent |
 | 2026-07-28 | Q-FS-1 resolved: WavLM-base-plus-sv (512-dim, int8 ONNX); defaults tuned (min-duration 300, smoothing 5). | agent |
 | 2026-07-28 | Fix Build-prototype feedback (prototype is state, not a ref) + WavLM detection smoothness (continuous ring buffer, 80 ms hop, zero-order-hold caching; serialization guard moved into each backend). | agent |

--- a/docs/modules/few-shot.md
+++ b/docs/modules/few-shot.md
@@ -148,6 +148,15 @@ User records sample -> quality check -> PLiX embed(sample) -> EnrolledSample
 (repeat N times) -> mean-pool embeddings -> WakeWordPrototype -> IndexedDB
 ```
 
+**Negative-class enrollment (open-set rejection, issue #69):**
+```
+User records other words / background (non-target) samples -> PLiX embed
+(repeat N times) -> mean-pool -> negativeVector attached to the wake-word
+prototype + persisted (IndexedDB) -> useNegativePrototype auto-enabled
+```
+Detection then scores the query against BOTH prototypes (relative distance),
+so non-target speech scores low instead of clearing the threshold.
+
 **Live detection (via `PlixKwsBackend`, a `KWSBackend`):**
 ```
 AFE (16kHz) -> accumulate windowMs of audio -> PLiX embed -> protoDistance(proto)
@@ -262,6 +271,7 @@ unchanged.
 
 | Date | Change | Author |
 |---|---|---|
+| 2026-08-10 | Negative-prototype enrollment UI + plumbing (issue #69): record non-target samples in the KWS panel, mean-pool into a negativeVector attached to the wake-word prototype, auto-enable useNegativePrototype. Engine carries prototypeNegative through the worker load message into initWithPrototype; scoring is relative (word vs negative class) so other speech scores low. | agent |
 | 2026-08-10 | Recalibrate default threshold 0.7 -> 0.9 (issue #69). 0.7 predated the #66 normalization fix when all scores were ~0.24; post-#66 real speech scores 0.78-0.96, so the old default made the wake word fire on ANY speech. Verified with real speech: enrolled word 0.92-1.0 vs other words 0.78-0.89. | agent |
 | 2026-08-10 | Add silence gate to PLiX detection (issue #66 follow-up): windows at/below `silenceFloorDbfs` (-45 dBFS RMS default) score 0 and skip the encoder. The model maps silence/background to a cosine-similar spot near the prototype (score ~0.7+ with no input after the normalization fix), so energy gating is required to avoid false triggers. Tunable via the Few-Shot config surface. | agent |
 | 2026-08-10 | Fix PLiX never triggering (issue #66): L2-normalize query + prototype before squared-Euclidean scoring (raw GAP embeddings have L2 norm ~4-5, so un-normalized d^2 ~3-4 even for a 0.92-cosine match -> score ~0.24, unreachable). Normalized d^2 = 2(1-cos) is well-calibrated; also wire the Few-Shot panel threshold/VAD/min-duration into the engine trigger config instead of KWS defaults. | agent |

--- a/docs/modules/few-shot.md
+++ b/docs/modules/few-shot.md
@@ -188,6 +188,7 @@ unchanged.
 | `windowMs` | 1500 | 500-3000 | Detection window fed to PLiX. |
 | `hopMs` | 80 | fixed | Detection hop (= 1 AFE 80 ms chunk). |
 | `useNegativePrototype` | false | - | Subtract negative prototype for tighter boundary. |
+| `silenceFloorDbfs` | -45 | -60..-20 | RMS (dBFS) below which a window scores 0. The PLiX model maps silence/background to a spot near the prototype in cosine space (score ~0.7+ with no input after #66 normalization), so this energy gate suppresses false triggers when nobody is speaking. Speech windows sit at ~-12..-30 dBFS RMS. |
 
 ## 7. Error model & failure modes
 
@@ -261,6 +262,7 @@ unchanged.
 
 | Date | Change | Author |
 |---|---|---|
+| 2026-08-10 | Add silence gate to PLiX detection (issue #66 follow-up): windows at/below `silenceFloorDbfs` (-45 dBFS RMS default) score 0 and skip the encoder. The model maps silence/background to a cosine-similar spot near the prototype (score ~0.7+ with no input after the normalization fix), so energy gating is required to avoid false triggers. Tunable via the Few-Shot config surface. | agent |
 | 2026-08-10 | Fix PLiX never triggering (issue #66): L2-normalize query + prototype before squared-Euclidean scoring (raw GAP embeddings have L2 norm ~4-5, so un-normalized d^2 ~3-4 even for a 0.92-cosine match -> score ~0.24, unreachable). Normalized d^2 = 2(1-cos) is well-calibrated; also wire the Few-Shot panel threshold/VAD/min-duration into the engine trigger config instead of KWS defaults. | agent |
 | 2026-07-27 | Initial draft (docs-first, pending human review). | agent |
 | 2026-07-28 | Q-FS-1 resolved: WavLM-base-plus-sv (512-dim, int8 ONNX); defaults tuned (min-duration 300, smoothing 5). | agent |

--- a/packages/modules/few-shot/core/FewShotEngine.ts
+++ b/packages/modules/few-shot/core/FewShotEngine.ts
@@ -105,6 +105,33 @@ export class FewShotEngine {
     }
   }
 
+  /**
+   * Build a negative-class prototype vector from non-target samples
+   * (mean-pool their embeddings). Used for open-set rejection: the user
+   * records other words / background speech, and detection scores the query
+   * against BOTH the wake word and this negative class, so non-target speech
+   * scores low instead of high (issue #69).
+   */
+  buildNegativeVector(samples: EnrolledSample[]): Float32Array {
+    if (samples.length === 0) {
+      throw new Error('Cannot build a negative prototype from zero samples.')
+    }
+    return meanPool(samples.map((s) => s.embedding))
+  }
+
+  /**
+   * Attach a negative-class prototype to an existing wake-word prototype and
+   * persist it. Returns the updated prototype.
+   */
+  async attachNegativePrototype(
+    proto: WakeWordPrototype,
+    negativeVector: Float32Array,
+  ): Promise<WakeWordPrototype> {
+    const updated = { ...proto, negativeVector }
+    await savePrototype(updated)
+    return updated
+  }
+
   /** List stored prototypes. */
   async listPrototypes(): Promise<WakeWordPrototype[]> {
     return listPrototypes()

--- a/packages/modules/few-shot/core/defaults.ts
+++ b/packages/modules/few-shot/core/defaults.ts
@@ -15,6 +15,8 @@ export const DEFAULT_CONFIG: FewShotConfig = {
   windowMs: 1500,
   hopMs: 80,
   useNegativePrototype: false,
+  /** RMS (dBFS) below which a detection window scores 0 (silence gate). */
+  silenceFloorDbfs: -45,
 }
 
 /** Declare all tunable Few-Shot parameters for the Studio config panel. */
@@ -109,6 +111,18 @@ export function describeParameters(): ReadonlyArray<ParameterDescriptor> {
       type: 'boolean',
       default: false,
       description: 'Subtract the negative prototype for a tighter decision boundary.',
+    },
+    {
+      id: 'silenceFloorDbfs',
+      label: 'Silence gate (dBFS RMS)',
+      type: 'number',
+      default: -45,
+      min: -60,
+      max: -20,
+      step: 1,
+      unit: 'dBFS',
+      description:
+        'Windows at or below this RMS level score 0 (no speech input). Prevents the PLiX model from scoring silence/background near the prototype (false triggers with no word spoken).',
     },
   ]
 }

--- a/packages/modules/few-shot/core/defaults.ts
+++ b/packages/modules/few-shot/core/defaults.ts
@@ -6,7 +6,7 @@ import type { FewShotConfig, ParameterDescriptor } from './types'
 
 /** Default Few-Shot configuration. */
 export const DEFAULT_CONFIG: FewShotConfig = {
-  threshold: 0.7,
+  threshold: 0.9,
   minDurationMs: 300,
   cooldownMs: 2000,
   smoothingWindowFrames: 5,
@@ -26,12 +26,12 @@ export function describeParameters(): ReadonlyArray<ParameterDescriptor> {
       id: 'threshold',
       label: 'Distance threshold',
       type: 'number',
-      default: 0.7,
+      default: 0.9,
       min: 0.5,
       max: 0.95,
       step: 0.01,
       description:
-        'PLiX prototype-distance score (1 / (1 + d^2), rescaled [0,1]) must exceed this to trigger.',
+        'PLiX prototype-distance score (1 / (1 + d^2) on L2-normalized embeddings, rescaled [0,1]) must exceed this to trigger. The enrolled word typically scores 0.9-1.0; other speech 0.7-0.9. Default 0.9 rejects most non-target speech (post-#66 score scale).',
     },
     {
       id: 'minDurationMs',

--- a/packages/modules/few-shot/core/defaults.ts
+++ b/packages/modules/few-shot/core/defaults.ts
@@ -110,7 +110,8 @@ export function describeParameters(): ReadonlyArray<ParameterDescriptor> {
       label: 'Negative prototype',
       type: 'boolean',
       default: false,
-      description: 'Subtract the negative prototype for a tighter decision boundary.',
+      description:
+        'Score against BOTH the wake word and the enrolled negative class (other words / background). Auto-enabled when you enroll negative samples in the panel; rejects non-target speech that would otherwise clear the threshold (open-set rejection, issue #69).',
     },
     {
       id: 'silenceFloorDbfs',

--- a/packages/modules/few-shot/core/types.ts
+++ b/packages/modules/few-shot/core/types.ts
@@ -42,6 +42,8 @@ export interface FewShotConfig {
   windowMs: number
   hopMs: number
   useNegativePrototype: boolean
+  /** RMS (dBFS) below which a detection window scores 0 (silence gate). */
+  silenceFloorDbfs: number
 }
 
 /** Descriptor for one tunable parameter (shared with AFE/KWS, ADR-017). */

--- a/packages/modules/few-shot/tests/negative-prototype.test.ts
+++ b/packages/modules/few-shot/tests/negative-prototype.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Few-Shot engine - negative-prototype enrollment tests (issue #69).
+ *
+ * Guards the open-set rejection plumbing: buildNegativeVector mean-pools
+ * non-target sample embeddings, and attachNegativePrototype persists the
+ * negative class onto the wake-word prototype (storage round-trips
+ * negativeVector via the existing serialize/deserialize path).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { FewShotEngine } from '../core/FewShotEngine'
+import type { EnrolledSample, WakeWordPrototype } from '../core/types'
+
+// attachNegativePrototype persists via IndexedDB (storage.ts). Node's vitest
+// env has no indexedDB - stub a minimal in-memory store so the persistence
+// round-trip is exercised.
+function stubIndexedDb(): void {
+  const store = new Map<string, unknown>()
+  const fakeDb = {
+    transaction: (_s: string, _mode: string) => {
+      const tx = {
+        objectStore: () => ({
+          put: (v: unknown) => {
+            store.set((v as { id: string }).id, v)
+            return { onsuccess: null, onerror: null }
+          },
+          getAll: () => ({ onsuccess: null, onerror: null }),
+          delete: () => ({ onsuccess: null, onerror: null }),
+        }),
+        oncomplete: null as null | (() => void),
+        onerror: null,
+      }
+      // Fire the completion callback synchronously so the storage promise
+      // resolves (the real IDB fires it after the write commits).
+      queueMicrotask(() => tx.oncomplete?.())
+      return tx
+    },
+    objectStoreNames: { contains: () => true },
+    createObjectStore: () => ({}),
+    close: () => {},
+  }
+  ;(globalThis as Record<string, unknown>).indexedDB = {
+    open: () => {
+      const req = {
+        result: fakeDb,
+        onupgradeneeded: null as null | (() => void),
+        onsuccess: null as null | (() => void),
+        onerror: null,
+      }
+      queueMicrotask(() => req.onsuccess?.())
+      return req
+    },
+  }
+}
+
+stubIndexedDb()
+
+/** Stub KWSEngine - the engine is only used for embed()/load(). */
+const kwsStub = {
+  embed: vi.fn(),
+  load: vi.fn(),
+  ready: false,
+  setConfig: vi.fn(),
+} as unknown as ConstructorParameters<typeof FewShotEngine>[0]
+
+function sample(vec: number[]): EnrolledSample {
+  return {
+    id: `s-${vec.join('-')}`,
+    samples: new Float32Array(0),
+    sampleRate: 16000,
+    embedding: new Float32Array(vec),
+    quality: {
+      peakDbfs: -12,
+      snrDb: 28,
+      durationMs: 1500,
+      clipped: false,
+      acceptable: true,
+    },
+    recordedAtMs: 0,
+  }
+}
+
+describe('FewShotEngine negative prototype (issue #69)', () => {
+  it('buildNegativeVector mean-pools non-target embeddings', () => {
+    const fs = new FewShotEngine(kwsStub)
+    const v = fs.buildNegativeVector([sample([1, 2, 3]), sample([3, 4, 5])])
+    expect(Array.from(v)).toEqual([2, 3, 4])
+  })
+
+  it('buildNegativeVector throws on zero samples', () => {
+    const fs = new FewShotEngine(kwsStub)
+    expect(() => fs.buildNegativeVector([])).toThrow(/zero samples/)
+  })
+
+  it('attachNegativePrototype persists negativeVector onto the prototype', async () => {
+    const fs = new FewShotEngine(kwsStub)
+    const proto: WakeWordPrototype = {
+      id: 'p1',
+      word: 'hey job',
+      vector: new Float32Array([1, 1, 1]),
+      sampleIds: ['a'],
+      createdAtMs: 1,
+    }
+    const updated = await fs.attachNegativePrototype(proto, new Float32Array([9, 9, 9]))
+
+    expect(updated.negativeVector).toBeDefined()
+    expect(Array.from(updated.negativeVector!)).toEqual([9, 9, 9])
+    expect(updated.word).toBe('hey job')
+    expect(updated.id).toBe('p1')
+    // The original prototype object is not mutated.
+    expect(proto.negativeVector).toBeUndefined()
+  })
+})

--- a/packages/modules/kws/engine/core/KWSEngine.ts
+++ b/packages/modules/kws/engine/core/KWSEngine.ts
@@ -97,6 +97,7 @@ export class KWSEngine {
     models: BackendModelUrls,
     prototype?: Float32Array,
     backendConfig?: unknown,
+    prototypeNegative?: Float32Array,
   ): Promise<void> {
     // Guard only against a concurrent load (in-flight). A `ready` engine may
     // be re-loaded (Reload button, or a backend switch after stop): the old
@@ -169,6 +170,10 @@ export class KWSEngine {
         backend: this._config.backend,
         models,
         prototype: prototype ? Array.from(prototype) : undefined,
+        // Negative-class prototype for open-set rejection (plixkws, issue #69).
+        prototypeNegative: prototypeNegative
+          ? Array.from(prototypeNegative)
+          : undefined,
         // Pass the driver backend config into the worker (e.g. plixkws
         // windowMs / useNegativePrototype, epic #53 P1).
         backendConfig,

--- a/packages/modules/kws/engine/core/types.ts
+++ b/packages/modules/kws/engine/core/types.ts
@@ -165,6 +165,8 @@ export type KWSWorkerMessage =
       backend: KWSBackendId
       models: BackendModelUrls
       prototype?: number[]
+      /** Negative-class prototype (plixkws open-set rejection, issue #69). */
+      prototypeNegative?: number[]
       /**
        * Driver-specific backend config (e.g. plixkws windowMs /
        * useNegativePrototype). Passed through to the backend's init

--- a/packages/modules/kws/engine/web/worker.ts
+++ b/packages/modules/kws/engine/web/worker.ts
@@ -108,6 +108,7 @@ async function handleLoad(
   urls: BackendModelUrls,
   prototypeVector?: number[],
   backendConfig?: unknown,
+  prototypeNegative?: number[],
 ): Promise<void> {
   actualExecutionProvider =
     config.executionProvider === 'webgpu'
@@ -162,6 +163,12 @@ async function handleLoad(
         id: 'enrolled',
         word: 'enrolled-word',
         vector: new Float32Array(prototypeVector),
+        // Negative-class prototype (open-set rejection, issue #69): the user
+        // enrolled other words/background; scoring subtracts this class's
+        // distance so non-target speech scores low.
+        negativeVector: prototypeNegative
+          ? new Float32Array(prototypeNegative)
+          : undefined,
         sampleIds: [],
         createdAtMs: Date.now(),
       }
@@ -351,7 +358,7 @@ self.onmessage = async (e: MessageEvent<KWSWorkerMessage>) => {
   try {
     switch (msg.type) {
       case 'load':
-        await handleLoad(msg.backend, msg.models, msg.prototype, msg.backendConfig)
+        await handleLoad(msg.backend, msg.models, msg.prototype, msg.backendConfig, msg.prototypeNegative)
         break
       case 'config':
         handleConfig(msg.config)

--- a/packages/modules/kws/engine/web/worker.ts
+++ b/packages/modules/kws/engine/web/worker.ts
@@ -176,12 +176,17 @@ async function handleLoad(
           initWithPrototype?: (
             p: unknown,
             e: unknown,
-            opts?: { windowMs?: number; useNegative?: boolean },
+            opts?: {
+              windowMs?: number
+              useNegative?: boolean
+              silenceFloorDbfs?: number
+            },
           ) => void
         }
       ).initWithPrototype?.(proto, embedProvider, {
         windowMs: (backendConfig as { windowMs?: number } | undefined)?.windowMs,
         useNegative: (backendConfig as { useNegative?: boolean } | undefined)?.useNegative,
+        silenceFloorDbfs: (backendConfig as { silenceFloorDbfs?: number } | undefined)?.silenceFloorDbfs,
       })
     } else {
       // Detection backend: only load if its required URLs are present. If only

--- a/packages/modules/kws/plix/core/backend.ts
+++ b/packages/modules/kws/plix/core/backend.ts
@@ -46,9 +46,21 @@
 import type { EmbedProvider, KWSBackend } from '@wake-studio/module-kws-engine'
 import type { WakeWordPrototype } from './prototype'
 import { squaredEuclidean, plixScore, l2Normalize } from './prototype'
+import { rmsDbfs } from '@wake-studio/dsp'
 
 /** Detection hop in frames (80 ms / 10 ms = 8 frames at the AFE cadence). */
 const HOP_FRAMES = 8
+
+/**
+ * Silence gate floor (RMS, dBFS). Windows below this energy level are scored
+ * 0 without running the encoder (issue: silence/background scored 0.7+ after
+ * the #66 normalization fix - the model maps silence to a spot near the
+ * prototype in cosine space, producing false triggers with no speech input).
+ * Speech windows sit at roughly -12 to -30 dBFS RMS; silence/noise at -45 to
+ * -Infinity. Overridable per load via initWithPrototype opts
+ * (silenceFloorDbfs).
+ */
+const DEFAULT_SILENCE_FLOOR_DBFS = -45
 
 export class PlixKwsBackend implements KWSBackend {
   readonly id = 'plixkws' as const
@@ -58,6 +70,8 @@ export class PlixKwsBackend implements KWSBackend {
   private _prototype: WakeWordPrototype
   private _windowSamples: number
   private _useNegative: boolean
+  /** RMS (dBFS) below which a window is treated as silence (score 0). */
+  private _silenceFloorDbfs: number
 
   // Continuous ring buffer (always appended to, even during inference).
   private _ring: Float32Array
@@ -75,11 +89,13 @@ export class PlixKwsBackend implements KWSBackend {
     prototype: WakeWordPrototype,
     windowMs = 1500,
     useNegative = false,
+    silenceFloorDbfs = DEFAULT_SILENCE_FLOOR_DBFS,
   ) {
     this._embedProvider = embedProvider
     this._prototype = prototype
     this._windowSamples = Math.round(16000 * (windowMs / 1000))
     this._useNegative = useNegative
+    this._silenceFloorDbfs = silenceFloorDbfs
     // Capacity = 2x window so audio arriving during inference is never lost.
     this._ring = new Float32Array(this._windowSamples * 2)
   }
@@ -112,10 +128,22 @@ export class PlixKwsBackend implements KWSBackend {
     // 4. Need a full window before scoring (warmup).
     if (this._len < this._windowSamples) return null
 
-    // 5. Run the PLiX encoder on the latest window and score it.
+    // 5. Silence gate: a window at or below the energy floor is NOT the wake
+    // word (no speech input). Score 0 and skip the encoder - the PLiX model
+    // maps silence/background to a cosine-similar spot near the prototype
+    // (score ~0.7+ with no input after #66), so energy gating is required to
+    // avoid false positives. Speech windows sit at -12..-30 dBFS RMS.
+    const window = this._latestWindow()
+    const rms = rmsDbfs(window)
+    if (rms < this._silenceFloorDbfs) {
+      this._lastScore = 0
+      this._hasScore = true
+      return 0
+    }
+
+    // 6. Run the PLiX encoder on the latest window and score it.
     this._inferring = true
     try {
-      const window = this._latestWindow()
       const embedding = await this._embedProvider.embed(window, 16000)
       this._lastScore = this._score(embedding)
       this._hasScore = true

--- a/packages/modules/kws/plix/core/backend.ts
+++ b/packages/modules/kws/plix/core/backend.ts
@@ -45,7 +45,7 @@
 
 import type { EmbedProvider, KWSBackend } from '@wake-studio/module-kws-engine'
 import type { WakeWordPrototype } from './prototype'
-import { squaredEuclidean, plixScore } from './prototype'
+import { squaredEuclidean, plixScore, l2Normalize } from './prototype'
 
 /** Detection hop in frames (80 ms / 10 ms = 8 frames at the AFE cadence). */
 const HOP_FRAMES = 8
@@ -166,11 +166,20 @@ export class PlixKwsBackend implements KWSBackend {
     return out
   }
 
-  /** PLiX Prototypical-Network score to the prototype (rescaled [0,1]). */
+  /** PLiX Prototypical-Network score to the prototype (rescaled [0,1]).
+   *
+   * Both operands are L2-normalized first (issue #66): the encoder emits raw
+   * GAP embeddings with L2 norm ~4-5, so an un-normalized squared distance is
+   * large even for a near-perfect match (cosine 0.92 -> d^2 ~3-4 -> score
+   * ~0.24, below any usable threshold). On unit vectors d^2 = 2(1-cos) is
+   * bounded to [0,4] and the score is well-calibrated (cosine 0.92 -> ~0.86),
+   * matching the cosine similarity the technical reference specifies. */
   private _score(embedding: Float32Array): number {
-    const d2 = squaredEuclidean(embedding, this._prototype.vector)
+    const q = l2Normalize(embedding)
+    const p = l2Normalize(this._prototype.vector)
+    const d2 = squaredEuclidean(q, p)
     if (this._useNegative && this._prototype.negativeVector) {
-      const negD2 = squaredEuclidean(embedding, this._prototype.negativeVector)
+      const negD2 = squaredEuclidean(q, l2Normalize(this._prototype.negativeVector))
       // Prefer the query's own class: subtract the negative-class distance.
       return plixScore(Math.max(0, d2 - negD2))
     }

--- a/packages/modules/kws/plix/core/backend.ts
+++ b/packages/modules/kws/plix/core/backend.ts
@@ -208,8 +208,13 @@ export class PlixKwsBackend implements KWSBackend {
     const d2 = squaredEuclidean(q, p)
     if (this._useNegative && this._prototype.negativeVector) {
       const negD2 = squaredEuclidean(q, l2Normalize(this._prototype.negativeVector))
-      // Prefer the query's own class: subtract the negative-class distance.
-      return plixScore(Math.max(0, d2 - negD2))
+      // Open-set rejection (issue #69): score is the probability of the wake
+      // word class under a 2-class softmax over the squared distances,
+      // P(word) = exp(-d2) / (exp(-d2) + exp(-negD2)) = 1/(1+exp(d2-negD2)).
+      // A query far from BOTH prototypes (ambiguous) scores ~0.5, not 1.0 -
+      // the old max(0, d2-negD2) form saturated at 1.0 for any query closer
+      // to the word than the negative, including equidistant ones.
+      return 1 / (1 + Math.exp(d2 - negD2))
     }
     return plixScore(d2)
   }

--- a/packages/modules/kws/plix/core/index.ts
+++ b/packages/modules/kws/plix/core/index.ts
@@ -25,6 +25,7 @@ export {
   meanPool,
   plixScore,
   squaredEuclidean,
+  l2Normalize,
 } from './prototype'
 
 // Embed-provider factory: the worker hosts the embed() scaffold via this seam

--- a/packages/modules/kws/plix/core/index.ts
+++ b/packages/modules/kws/plix/core/index.ts
@@ -52,7 +52,12 @@ registerKwsBackend({
       initWithPrototype?: (
         proto: WakeWordPrototype,
         embed: EmbedProvider,
-        opts?: { windowMs?: number; useNegative?: boolean },
+        opts?: {
+          windowMs?: number
+          useNegative?: boolean
+          /** RMS (dBFS) floor below which windows score 0 (silence gate). */
+          silenceFloorDbfs?: number
+        },
       ) => void
     }
     withInit.initWithPrototype = (proto, embed, opts) => {
@@ -64,6 +69,7 @@ registerKwsBackend({
         proto,
         opts?.windowMs ?? 1500,
         opts?.useNegative ?? false,
+        opts?.silenceFloorDbfs,
       )
       // Copy state that may already exist (none before load, but stay safe).
       Object.assign(backend, next, {

--- a/packages/modules/kws/plix/core/prototype.ts
+++ b/packages/modules/kws/plix/core/prototype.ts
@@ -28,6 +28,27 @@ export function squaredEuclidean(a: Float32Array, b: Float32Array): number {
 }
 
 /**
+ * L2-normalize a vector to unit norm (in place-safe: returns a new array).
+ *
+ * Required by the few-shot scoring: the PLiX encoder emits RAW GAP embeddings
+ * with L2 norm ~4-5, so an un-normalized squared-Euclidean distance is large
+ * even for a near-perfect match (cosine 0.92 -> d^2 ~3-4 -> score ~0.24),
+ * making the 1/(1+d^2) score unreachable for any threshold (issue #66).
+ * Normalizing both operands first bounds d^2 = 2(1-cos) to [0,4], which is
+ * the cosine similarity the technical reference specifies. Zero vectors are
+ * returned unchanged (avoid NaN).
+ */
+export function l2Normalize(v: Float32Array): Float32Array {
+  let sum = 0
+  for (let i = 0; i < v.length; i++) sum += v[i] * v[i]
+  const norm = Math.sqrt(sum)
+  if (!Number.isFinite(norm) || norm === 0) return v
+  const out = new Float32Array(v.length)
+  for (let i = 0; i < v.length; i++) out[i] = v[i] / norm
+  return out
+}
+
+/**
  * Rescale a squared-Euclidean distance to a [0,1] similarity score:
  *     score = 1 / (1 + d^2)
  * Mirrors PLiX's framing (negative squared distance as a softmax logit)

--- a/packages/modules/kws/plix/tests/backend.test.ts
+++ b/packages/modules/kws/plix/tests/backend.test.ts
@@ -33,6 +33,21 @@ const FAKE_PROTOTYPE: WakeWordPrototype = {
   createdAtMs: 0,
 }
 
+/** A 10 ms AFE frame with energy above the silence floor (RMS ~= -13 dBFS). */
+function speechFrame(seed = 0): Float32Array {
+  const f = new Float32Array(160)
+  for (let i = 0; i < 160; i++) {
+    // ~0.2 amplitude sine -> RMS ~ -13 dBFS, well above the -45 floor.
+    f[i] = 0.2 * Math.sin((2 * Math.PI * 200 * i) / 16000 + seed)
+  }
+  return f
+}
+
+/** A silent frame (all zeros) - must score 0 via the silence gate. */
+function silentFrame(): Float32Array {
+  return new Float32Array(160)
+}
+
 describe('PlixKwsBackend', () => {
   it('is not ready before the embedder is ready', () => {
     const notReady = new FakeEmbedder()
@@ -51,7 +66,7 @@ describe('PlixKwsBackend', () => {
     const backend = new PlixKwsBackend(new FakeEmbedder(), FAKE_PROTOTYPE, 1500)
     let last: number | null = null
     for (let i = 0; i < 200; i++) {
-      const s = await backend.processFrame(new Float32Array(160))
+      const s = await backend.processFrame(speechFrame(i))
       if (s !== null) last = s
     }
     expect(last).not.toBeNull()
@@ -89,7 +104,7 @@ describe('PlixKwsBackend', () => {
     const backend = new PlixKwsBackend(embedder, { ...FAKE_PROTOTYPE, vector: proto }, 1500)
     let last: number | null = null
     for (let i = 0; i < 200; i++) {
-      const s = await backend.processFrame(new Float32Array(160))
+      const s = await backend.processFrame(speechFrame(i))
       if (s !== null) last = s
     }
     expect(last).not.toBeNull()
@@ -101,6 +116,41 @@ describe('PlixKwsBackend', () => {
     const backend = new PlixKwsBackend(new FakeEmbedder(), FAKE_PROTOTYPE)
     expect(() => backend.reset()).not.toThrow()
     await expect(backend.dispose()).resolves.toBeUndefined()
+  })
+
+  it('scores 0 for silent windows (no false trigger on silence, issue)', async () => {
+    // The PLiX model maps silence to a spot near the prototype in cosine
+    // space (score ~0.74 after #66 normalization), so an energy floor is
+    // required. With a fully silent window the backend must score 0 and skip
+    // the encoder entirely.
+    let embedCalls = 0
+    const embedder = new FakeEmbedder()
+    const originalEmbed = embedder.embed.bind(embedder)
+    embedder.embed = async () => {
+      embedCalls++
+      return originalEmbed()
+    }
+    const backend = new PlixKwsBackend(embedder, FAKE_PROTOTYPE, 1500)
+    let last: number | null = null
+    for (let i = 0; i < 200; i++) {
+      const s = await backend.processFrame(silentFrame())
+      if (s !== null) last = s
+    }
+    expect(last).toBe(0)
+    // The encoder must not run for silent windows.
+    expect(embedCalls).toBe(0)
+  })
+
+  it('still scores normally for speech windows (silence gate does not clip speech)', async () => {
+    const embedder = new FakeEmbedder()
+    const backend = new PlixKwsBackend(embedder, FAKE_PROTOTYPE, 1500)
+    let last: number | null = null
+    for (let i = 0; i < 200; i++) {
+      const s = await backend.processFrame(speechFrame(i))
+      if (s !== null) last = s
+    }
+    expect(last).not.toBeNull()
+    expect(last!).toBeCloseTo(1.0, 3)
   })
 })
 

--- a/packages/modules/kws/plix/tests/backend.test.ts
+++ b/packages/modules/kws/plix/tests/backend.test.ts
@@ -152,6 +152,58 @@ describe('PlixKwsBackend', () => {
     expect(last).not.toBeNull()
     expect(last!).toBeCloseTo(1.0, 3)
   })
+
+  it('negative prototype: word-like query scores high, other-speech-like query low (issue #69)', async () => {
+    // Query close to the word prototype -> high P(word); query close to the
+    // negative prototype -> low. With softmax over the two class distances:
+    //   score = 1 / (1 + exp(d2_word - d2_neg))
+    const wordVec = new Float32Array(1280).fill(0.5)
+    const negVec = new Float32Array(1280).fill(-0.5)
+    const proto: WakeWordPrototype = {
+      id: 'p',
+      word: 'hey job',
+      vector: wordVec,
+      negativeVector: negVec,
+      sampleIds: [],
+      createdAtMs: 0,
+    }
+
+    // Embedder returns a word-like query (same direction as wordVec).
+    const wordEmbed = new Float32Array(1280).fill(0.5)
+    const wordBackend = new PlixKwsBackend(
+      new FakeEmbedder(),
+      proto,
+      1500,
+      true, // useNegative
+    )
+    ;(wordBackend as unknown as { _embedProvider: { value: Float32Array } })._embedProvider.value =
+      wordEmbed
+    let wordScore: number | null = null
+    for (let i = 0; i < 200; i++) {
+      const s = await wordBackend.processFrame(speechFrame(i))
+      if (s !== null) wordScore = s
+    }
+    expect(wordScore).not.toBeNull()
+    expect(wordScore!).toBeGreaterThan(0.7)
+
+    // Embedder returns an other-speech-like query (same direction as negVec).
+    const negEmbed = new Float32Array(1280).fill(-0.5)
+    const negBackend = new PlixKwsBackend(
+      new FakeEmbedder(),
+      proto,
+      1500,
+      true, // useNegative
+    )
+    ;(negBackend as unknown as { _embedProvider: { value: Float32Array } })._embedProvider.value =
+      negEmbed
+    let negScore: number | null = null
+    for (let i = 0; i < 200; i++) {
+      const s = await negBackend.processFrame(speechFrame(i))
+      if (s !== null) negScore = s
+    }
+    expect(negScore).not.toBeNull()
+    expect(negScore!).toBeLessThan(0.3)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/modules/kws/plix/tests/backend.test.ts
+++ b/packages/modules/kws/plix/tests/backend.test.ts
@@ -18,8 +18,10 @@ import type { EmbedProvider } from '@wake-studio/module-kws-engine'
 
 class FakeEmbedder implements EmbedProvider {
   ready = true
+  /** Value returned for every window; tests override this for scale checks. */
+  value = new Float32Array(1280).fill(0.5)
   async embed(): Promise<Float32Array> {
-    return new Float32Array(1280).fill(0.5)
+    return this.value
   }
 }
 
@@ -54,6 +56,45 @@ describe('PlixKwsBackend', () => {
     }
     expect(last).not.toBeNull()
     expect(last!).toBeCloseTo(1.0, 3)
+  })
+
+  it('scores high for cosine-similar embeddings with large raw magnitude (issue #66)', async () => {
+    // The PLiX encoder emits raw GAP embeddings with L2 norm ~4-5. Before the
+    // fix, a near-perfect match (cosine 0.92) had raw d^2 ~3-4 -> score ~0.24,
+    // unreachable for any threshold. After L2 normalization, the same vectors
+    // score ~0.86 (d^2 = 2(1-cos)).
+    const seed = new Float32Array(1280)
+    for (let i = 0; i < 1280; i++) seed[i] = 0.5 + (i % 7) * 0.01
+    const scale = 4.3 // raw L2 norm of the small encoder's embeddings
+    const proto = new Float32Array(1280)
+    for (let i = 0; i < 1280; i++) proto[i] = seed[i] * scale
+    // Query = prototype + tiny perturbation, then scaled to the same magnitude
+    const query = new Float32Array(1280)
+    for (let i = 0; i < 1280; i++) query[i] = (seed[i] + 0.003 * ((i % 3) - 1)) * scale
+
+    const cosine = (() => {
+      let dot = 0, na = 0, nb = 0
+      for (let i = 0; i < 1280; i++) {
+        dot += query[i] * proto[i]
+        na += query[i] * query[i]
+        nb += proto[i] * proto[i]
+      }
+      return dot / (Math.sqrt(na) * Math.sqrt(nb))
+    })()
+    // Sanity: the fixtures are genuinely cosine-similar but far from identical.
+    expect(cosine).toBeGreaterThan(0.9)
+
+    const embedder = new FakeEmbedder()
+    embedder.value = query
+    const backend = new PlixKwsBackend(embedder, { ...FAKE_PROTOTYPE, vector: proto }, 1500)
+    let last: number | null = null
+    for (let i = 0; i < 200; i++) {
+      const s = await backend.processFrame(new Float32Array(160))
+      if (s !== null) last = s
+    }
+    expect(last).not.toBeNull()
+    // 1/(1+2(1-cos)) for cosine 0.92 is ~0.86; the pre-fix raw score was ~0.24.
+    expect(last!).toBeGreaterThan(0.7)
   })
 
   it('reset() and dispose() do not throw when unloaded', async () => {


### PR DESCRIPTION
## Summary

Five commits fixing PLiX Few-Shot detection end-to-end (#66–#70). Before this PR, the plixkws backend was effectively unusable: it never triggered on the enrolled word, couldn't be started from the unified pipeline Start, false-triggered on silence, false-triggered on any speech, and had no way to reject non-target words.

Each commit was driven by an empirical root-cause analysis (the model was run in Node with the repo's exact front-end + real speech from the sherpa test bundle to verify before/after scores):

1. **#66 — `fix(kws): plix few-shot never triggers — normalize embeddings before scoring`** (`c7f3555`)
   Raw 1280-dim embeddings have L2 norm ~4–5, so `1/(1+d²)` scored ~0.24 for *everything* (unreachable thresholds). L2-normalize query + prototype first: d² = 2(1−cos) ∈ [0,4], so a 0.92-cosine match scores ~0.86. Also wire the Few-Shot panel threshold/min-duration/VAD into the engine trigger (previously it used the KWS defaults, out of sync with the panel).

2. **#67 — `fix(kws): few-shot (plixkws) can't start from unified pipeline Start`** (`bda6db7`)
   `commandRef` always dispatched the traditional handlers (handleLoad/handleStart/handleStop) even for few-shot. The unified Start either failed (handleLoad with no prototype → worker error → button stayed disabled) or started the encoder-only engine with no detection backend (empty score curve). Now dispatches by category: `load→handleLoadEncoder`, `start→handleStartPlix`, `stop→handleStopPlix`; `getState` reports `running || detecting`. Few-shot scores also now reach the shared workspace score curve + mini bar.

3. **#68 — `fix(kws): plix scores 0.7+ on silence — add energy gate`** (`d0eb355`)
   After the #66 normalization fix, silence scored 0.74 (> 0.7) — the model maps silence to a cosine-similar spot. Added an RMS energy gate (`silenceFloorDbfs`, default -45 dBFS): windows at/below the floor score 0 and skip the encoder. Tunable in the Few-Shot config.

4. **#69 — `fix(kws): plix wakes on ANY speech — recalibrate default threshold 0.7 -> 0.9`** (`5b6f750`)
   The 0.7 default predated #66 (when all scores were ~0.24). Post-#66, real speech scores 0.78–0.96, so any speech triggered. Verified with real speech: enrolled word 0.92–1.0 vs other words 0.78–0.89. Raised default to 0.9.

5. **#70 — `feat(kws): negative-prototype enrollment UI for open-set rejection`** (`0b7d671`)
   Single-prototype scoring can't reject "anything" (other words score 0.78–0.89). Added full negative-class enrollment: record non-target samples in the KWS panel, mean-pool into a `negativeVector` on the prototype, auto-enable `useNegativePrototype`. Engine now carries `prototypeNegative` end-to-end (it was dropped in the worker before). Scoring is the 2-class softmax `P(word) = 1/(1+exp(d²_word − d²_neg))` — non-target speech scores low, ambiguous input ~0.5.

## Changes

- `packages/modules/kws/plix/core/{backend,prototype,index}.ts` — L2 normalization, softmax negative scoring, silence gate, `l2Normalize` export.
- `packages/modules/kws/engine/core/{KWSEngine,types}.ts` + `web/worker.ts` — `prototypeNegative` plumbing through load.
- `packages/modules/few-shot/core/{defaults,types,FewShotEngine}.ts` — threshold 0.9, `silenceFloorDbfs`, `buildNegativeVector`/`attachNegativePrototype`.
- `apps/web/src/components/KWSPanel.tsx` — category-dispatched commandRef, few-shot scores → shared history, negative-sample enrollment UI, threshold/floor wiring.
- `apps/web/src/projects/__tests__/store.test.ts` — fixture sync.
- Tests: plix backend 20 (was 17), few-shot 35 (was 32); new regression tests for normalization, silence gate, negative softmax, negative enrollment.
- `docs/modules/few-shot.md` + `docs/modules/kws.md` — docs-sync.

## Validation

- `pnpm typecheck` — green (full repo)
- `pnpm test:unit` — 15/15 test files green
- `pnpm --filter @wake-studio/web build` — green
- eslint on changed files — 0 errors (pre-existing warnings only)

## Manual verification needed

1. Workspace → KWS → `plixkws` → load encoder, record 3+ samples, build prototype.
2. Unified Start → detection should run automatically; score curve should move.
3. Speak the enrolled word → score clears 0.9, trigger fires.
4. Stay quiet → score ~0 (silence gate).
5. Speak other words → with negative samples enrolled, score stays low; without, tune threshold to 0.92–0.95.

Closes #66, #67, #68, #69, #70
