### PR TITLE
task: de-hardcode KWSPanel via backend registration seams (#75)

### DIFF
--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -20,6 +20,7 @@ import {
   KWSEngine,
   DEFAULT_CONFIG,
   describeParameters,
+  getBackendRegistration,
   getBackendRegistry,
 } from '@wake-studio/module-kws-engine'
 import type {
@@ -32,12 +33,9 @@ import type {
 import { MEL_WINDOW_SIZE } from '@wake-studio/module-kws-engine'
 import { loadRegistry, type ModelRegistry } from '@wake-studio/platform'
 import {
-  TRADITIONAL_MODEL_ROLES,
-  FEWSHOT_MODEL_ROLES,
-  KWS_STREAMING_MODEL_ROLES,
   driverParamsFor,
+  loadActionLabel,
   modelSourcesForRole,
-  type ModelSourceRole,
 } from '../workspace/kws-config'
 import { ParamRows, type ParamValue } from './UnifiedConfigPanel'
 import { drawScoreCurve } from './viz/ScoreCurve'
@@ -56,7 +54,6 @@ import {
 } from '@wake-studio/module-few-shot'
 import type { EnrolledSample, WakeWordPrototype } from '@wake-studio/module-few-shot'
 import { recorderWorkletUrl as recorderUrl } from '@wake-studio/module-few-shot/web'
-import { getPlixEncoderVariant } from '@wake-studio/module-kws-plix/encoders/plix-encoder'
 import {
   importModelFile,
   listUserModels,
@@ -84,44 +81,6 @@ function formatUrlDetail(value: BackendModelUrls[keyof BackendModelUrls]): strin
 // plixkws enrollment constants (mirrors the removed Few-Shot panel).
 const RECORD_MS = 1500
 const MIN_SAMPLES = 3
-
-/**
- * Resource descriptors shown in the Engine card, per backend. Each row is one
- * thing the engine loads or one piece of persistent data the user has created
- * (enrolled samples, wake-word lists). 'model' rows resolve their URL from the
- * platform registry (ADR-011); 'data' rows come from IndexedDB / driver params.
- */
-interface EngineResource {
-  id: string
-  label: string
-  kind: 'model' | 'data'
-  /** key into BackendModelUrls (kind: 'model'). */
-  urlKey?: keyof BackendModelUrls
-  /** Detail shown under the label (e.g. URL, sample count). */
-  detail?: string
-}
-
-/**
- * Static resource map per backend category. Model rows resolve their URL from
- * the engine's loaded URLs (ADR-011); 'ready' flips when the backend reports
- * loaded. 'data' rows show persisted artifacts (IndexedDB / driver params).
- */
-const ENGINE_RESOURCES: Record<string, EngineResource[]> = {
-  traditional: [
-    { id: 'melspectrogram', label: 'Mel-spectrogram front-end', kind: 'model', urlKey: 'melspectrogram' },
-    { id: 'embedding', label: 'Speech embedding backbone', kind: 'model', urlKey: 'embedding' },
-    { id: 'classifier', label: 'Wake-word classifier', kind: 'model', urlKey: 'classifier' },
-  ],
-  'asr-decoding': [
-    { id: 'wasm', label: 'sherpa-onnx KWS wasm runtime', kind: 'model' },
-    { id: 'keywords', label: 'Wake-word list', kind: 'data' },
-  ],
-  'few-shot': [
-    { id: 'encoder', label: 'PLiX encoder', kind: 'model', urlKey: 'plixkws' },
-    { id: 'prototypes', label: 'Enrolled prototypes', kind: 'data' },
-    { id: 'samples', label: 'Enrolled samples', kind: 'data' },
-  ],
-}
 
 interface Props {
   afePipeline: AFEPipeline | null
@@ -283,7 +242,7 @@ export const KWSPanel = memo(function KWSPanel({
 
   /** Import a local model file into the user model library for a role. */
   const handleImportModelFile = useCallback(
-    async (file: File | undefined, role: UserModel['role']) => {
+    async (file: File | undefined, role: string) => {
       if (!file) return
       try {
         const model = await importModelFile(file, role, `Imported from ${file.name}`)
@@ -302,7 +261,7 @@ export const KWSPanel = memo(function KWSPanel({
 
   /** Select a saved user model for a role; resolves its blob URL. */
   const handleSelectUserModel = useCallback(
-    async (role: UserModel['role'], modelId: string) => {
+    async (role: string, modelId: string) => {
       setModelSources((prev) => ({ ...prev, [role]: `user:${modelId}` }))
       const url = await blobUrlForModel(modelId)
       if (url) {
@@ -372,74 +331,33 @@ export const KWSPanel = memo(function KWSPanel({
 
   const params = describeParameters()
 
-  // plixkws enrollment: encoder variant + runtime are the driver's spec
-  // params (ADR-025). Seeded from driverValues (spec defaults) so a future
-  // few-shot driver with different options works unchanged.
-  const plixVariant =
-    (driverValues.encoder as 'base' | 'small' | undefined) ?? 'small'
-  const plixRuntime =
-    (driverValues.runtime as 'onnx' | 'transformers' | undefined) ?? 'onnx'
-
   /**
-   * Resolve the effective model URL for one role, honoring the user's
-   * selection: a registry built-in id or a custom URL. Falls back to the
-   * registry default when nothing is selected.
+   * Resolve the selected backend's model URLs through its registration
+   * (ADR-024): each driver owns its URL mapping (model sources + driver
+   * params + registry fallbacks). Backends that bundle their model (e.g.
+   * sherpa's wasm package) declare no resolver and get an empty URL set.
+   * Never hard-coded here - the UI shows the exact fetch command if absent.
    */
-  const resolveModelUrl = useCallback(
-    (
-      registry: ModelRegistry,
-      role:
-        | 'melspectrogram'
-        | 'embedding'
-        | 'classifier'
-        | 'plix-encoder'
-        | 'kws-streaming-model',
-      fallbackId: string,
-    ): string | undefined => {
-      const selected = modelSources[role]
-      const byId = new Map(registry.models.map((m) => [m.id, m.url]))
-      // User-library model: use the pre-resolved blob URL.
-      if (selected?.startsWith('user:')) {
-        return userBlobUrlRef.current[role]
+  const resolveModelUrlsFor = useCallback(
+    async (backendId: KWSConfig['backend']): Promise<BackendModelUrls> => {
+      const reg = getBackendRegistration(backendId)
+      let registry = registryModels
+      if (!registry) {
+        registry = await loadRegistry()
+        setRegistryModels(registry)
       }
-      if (selected && selected !== 'custom') {
-        return byId.get(selected)
+      if (reg?.resolveModelUrls) {
+        return reg.resolveModelUrls({
+          registry,
+          driverValues,
+          modelSources,
+          customUrls,
+          userBlobUrls: userBlobUrlRef.current,
+        })
       }
-      if (selected === 'custom') {
-        return customUrls[role]?.trim() || undefined
-      }
-      // Default: the built-in registry entry for this role.
-      return byId.get(fallbackId)
+      return {}
     },
-    [modelSources, customUrls],
-  )
-
-  /**
-   * Resolve the kws-streaming model + its sidecar manifest as a PAIR.
-   *
-   * The manifest declares the graph's tensor names, labels and window geometry,
-   * so a model must never be paired with a different model's manifest. Keeping
-   * both in one registry entry (`url` + `manifestUrl`) makes that impossible by
-   * construction; a custom URL therefore also needs its manifest alongside it,
-   * which we derive by swapping the .onnx extension for .json (what the
-   * exporter emits).
-   */
-  const resolveKwsStreamingUrls = useCallback(
-    (registry: ModelRegistry): { model: string; manifest: string } | undefined => {
-      const role = 'kws-streaming-model' as const
-      const selected = modelSources[role]
-      if (selected === 'custom') {
-        const model = customUrls[role]?.trim()
-        if (!model) return undefined
-        return { model, manifest: model.replace(/\.onnx$/i, '.json') }
-      }
-      const entry =
-        registry.models.find((m) => m.id === selected) ??
-        registry.models.find((m) => m.id === 'kws-streaming-kwt1')
-      if (!entry?.manifestUrl) return undefined
-      return { model: entry.url, manifest: entry.manifestUrl }
-    },
-    [modelSources, customUrls],
+    [registryModels, driverValues, modelSources, customUrls],
   )
 
   const handleLoad = useCallback(async () => {
@@ -450,23 +368,10 @@ export const KWSPanel = memo(function KWSPanel({
       setStatus('loading')
       // Ensure the engine has the latest backend selection before loading.
       engine.setConfig({ backend: config.backend, threshold: config.threshold })
-      // Resolve model URLs from the platform registry (ADR-011) - never
-      // hard-coded here; the UI shows the exact fetch command if absent.
-      // User-selected model sources (ModelSourceEditor) override the
-      // registry defaults: built-in pretrained models or a custom URL (e.g. a
-      // model trained with this platform).
-      const registry = await loadRegistry()
-      setRegistryModels(registry)
-      const urls: BackendModelUrls =
-        config.backend === 'plixkws'
-          ? { plixkws: resolveModelUrl(registry, 'plix-encoder', 'plixkws') }
-          : config.backend === 'kws-streaming'
-            ? { kwsStreaming: resolveKwsStreamingUrls(registry) }
-            : {
-                melspectrogram: resolveModelUrl(registry, 'melspectrogram', 'melspectrogram'),
-                embedding: resolveModelUrl(registry, 'embedding', 'speech_embedding'),
-                classifier: resolveModelUrl(registry, 'classifier', 'hey-buddy'),
-              }
+      // Model URLs come from the backend's own resolver (ADR-011/024); the
+      // user's model-source selections (built-in / saved / custom URL) are
+      // honored by the driver.
+      const urls = await resolveModelUrlsFor(config.backend)
       urlsRef.current = urls
       // Pass the driver's edited params as its backend config (unknown to the
       // engine; the driver's configure() interprets them, e.g. sherpa
@@ -483,7 +388,7 @@ export const KWSPanel = memo(function KWSPanel({
       setStatus('error')
       logError('kws', err instanceof Error ? err.message : String(err))
     }
-  }, [config.backend, config.threshold, driverValues, resolveModelUrl, resolveKwsStreamingUrls])
+  }, [config.backend, config.threshold, driverValues, resolveModelUrlsFor])
 
   // Auto-load: switching the backend selection loads that backend's models
   // automatically (registry is a local JSON, ADR-011). Initial mount keeps the
@@ -493,19 +398,12 @@ export const KWSPanel = memo(function KWSPanel({
   // (plixkws today, future drivers) get the enrollment flow automatically.
   const selectedBackend = getBackendRegistry().find((r) => r.id === config.backend)
   const isFewShot = selectedBackend?.category === 'few-shot'
-  // Model-source roles per category (ADR-024): traditional (openwakeword) and
-  // few-shot (plixkws) consume model URLs from the registry. asr-decoding
-  // (sherpa-onnx-kws) bundles its model into the wasm .data package and only
-  // takes a keyword list — it has NO registry model sources, so the section
-  // renders a note instead of the openwakeword pickers (issue #64).
-  const modelRoles: readonly ModelSourceRole[] =
-    selectedBackend?.category === 'few-shot'
-      ? FEWSHOT_MODEL_ROLES
-      : selectedBackend?.category === 'asr-decoding'
-        ? []
-        : config.backend === 'kws-streaming'
-          ? KWS_STREAMING_MODEL_ROLES
-          : TRADITIONAL_MODEL_ROLES
+  // Model-source roles come from the backend's registration (ADR-024): each
+  // driver declares the roles it consumes. asr-decoding (sherpa-onnx-kws)
+  // bundles its model into the wasm .data package and only takes a keyword
+  // list — it declares NO roles, so the section renders a note instead of the
+  // openwakeword pickers (issue #64).
+  const modelRoles = selectedBackend?.modelRoles ?? []
   // Backend switching is lightweight: it only updates the selection (and any
   // pending load state), it does NOT auto-load models. Loading a different
   // backend re-initializes the worker + model session, which is slow; the user
@@ -531,39 +429,6 @@ export const KWSPanel = memo(function KWSPanel({
   }, [config.backend, isFewShot])
 
   // --- plixkws enrollment + detection ---
-
-  /**
-   * Resolve the PLiX model locator for the selected variant + runtime.
-   * Honors the user's ModelSource selection: a custom encoder URL (e.g. a
-   * model trained with this platform) takes precedence over the variant's
-   * built-in ONNX URL. The transformers runtime always uses the locally
-   * served HF-style dir (variant.transformersLocalDir).
-   */
-  const resolvePlixLocator = useCallback((): { url: string; runtime: 'onnx' | 'transformers' } => {
-    const variant = getPlixEncoderVariant(plixVariant)
-    if (!variant) {
-      throw new Error(`Unknown PLiX variant: ${plixVariant}`)
-    }
-    const rt = plixRuntime
-    const customUrl = modelSources['plix-encoder'] === 'custom'
-      ? customUrls['plix-encoder']?.trim()
-      : undefined
-    let url: string
-    if (rt === 'transformers') {
-      url = variant.transformersLocalDir
-    } else if (modelSources['plix-encoder']?.startsWith('user:')) {
-      // User-library encoder (imported file / training artifact).
-      const blobUrl = userBlobUrlRef.current['plix-encoder']
-      if (!blobUrl) throw new Error('Selected PLiX encoder is not in the model library.')
-      url = blobUrl
-    } else if (customUrl) {
-      // User-supplied encoder URL overrides the built-in variant asset.
-      url = customUrl
-    } else {
-      url = variant.onnxUrl
-    }
-    return { url, runtime: rt }
-  }, [plixVariant, plixRuntime, modelSources, customUrls])
 
   const ensureFsEngines = useCallback(() => {
     if (!engineRef.current) {
@@ -611,16 +476,20 @@ export const KWSPanel = memo(function KWSPanel({
     const engine = ensureFsEngines()
     try {
       setStatus('loading')
+      // Embed-only boot: the few-shot detection path demands a prototype, so
+      // the engine loads the encoder through a traditional backend id. The
+      // selected few-shot driver still owns the URL resolution below.
       engine.setConfig({ ...DEFAULT_CONFIG, backend: 'openwakeword' })
-      const { url, runtime } = resolvePlixLocator()
-      await engine.load({ plixkws: url, runtime })
+      const urls = await resolveModelUrlsFor(config.backend)
+      urlsRef.current = urls
+      await engine.load(urls)
       setStatus(engine.status)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       setError(msg)
       setStatus('error')
     }
-  }, [ensureFsEngines, resolvePlixLocator])
+  }, [ensureFsEngines, resolveModelUrlsFor, config.backend])
 
   /** Record a 1.5 s sample from the mic at 16 kHz into the given bucket
    *  ('pos' = wake word samples, 'neg' = other-speech/background samples for
@@ -771,9 +640,12 @@ export const KWSPanel = memo(function KWSPanel({
         vadGateEnabled: fsConfig.vadGateEnabled,
         vadThreshold: fsConfig.vadThreshold,
       })
-      const { url, runtime } = resolvePlixLocator()
+      // Resolve the encoder URLs through the plix driver's registration
+      // (ADR-024): variant + runtime + model-source selection are driver
+      // knowledge, not the panel's.
+      const urls = await resolveModelUrlsFor(config.backend)
       await fresh.load(
-        { plixkws: url, runtime },
+        urls,
         proto.vector,
         // Few-Shot detection params from the config panel (epic #53 P1):
         // windowMs + useNegativePrototype reach the plix backend via the
@@ -801,7 +673,7 @@ export const KWSPanel = memo(function KWSPanel({
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
     }
-  }, [afePipeline, afeRunning, prototype, resolvePlixLocator, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype, fsConfig.silenceFloorDbfs])
+  }, [afePipeline, afeRunning, prototype, resolveModelUrlsFor, config.backend, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype, fsConfig.silenceFloorDbfs])
 
   const handleStopPlix = useCallback(() => {
     engineRef.current?.stop()
@@ -963,7 +835,7 @@ export const KWSPanel = memo(function KWSPanel({
           <div className="flex items-center gap-2">
             <h3 className="text-sm font-semibold text-ink-1">Engine</h3>
             <span className="text-xs text-ink-3">
-              {isFewShot ? 'PLiX Few-Shot' : config.backend} ·{' '}
+              {selectedBackend?.label ?? config.backend} ·{' '}
               {status === 'ready' && !isFewShot
                 ? `${executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}`
                 : status}
@@ -992,7 +864,7 @@ export const KWSPanel = memo(function KWSPanel({
                 disabled={status === 'loading'}
                 className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
               >
-                {status === 'loading' ? 'Loading PLiX…' : 'Load PLiX encoder'}
+                {status === 'loading' ? 'Loading…' : loadActionLabel(selectedBackend)}
               </button>
             )}
             {!isFewShot && canStart && (
@@ -1050,7 +922,7 @@ export const KWSPanel = memo(function KWSPanel({
             <span>Models loaded · EP: {executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}</span>
           )}
           {status === 'ready' && isFewShot && (
-            <span className="text-ink-2">PLiX encoder loaded — record samples to enroll</span>
+            <span className="text-ink-2">Encoder loaded — record samples to enroll</span>
           )}
           {isFewShot && detecting && (
             <span className="text-ink-2">Few-Shot detection running</span>
@@ -1061,35 +933,35 @@ export const KWSPanel = memo(function KWSPanel({
         </div>
 
         {/* Resources this backend needs (models + persistent data). Each row
-            shows its own state: not loaded / loading / ready / error. */}
+            shows its own state: not loaded / loading / ready / error. Rows are
+            declared by the backend's registration (ADR-024) - the host renders
+            'model' rows generically and delegates 'data' rows to the driver's
+            probe. */}
         <div className="space-y-1.5 border-t border-line pt-3">
           <div className="text-[11px] font-medium uppercase tracking-widest text-ink-3">
             Resources
           </div>
-          {(ENGINE_RESOURCES[isFewShot ? 'few-shot' : selectedBackend?.category ?? 'traditional'] ?? [])
+          {(selectedBackend?.resources ?? [])
             .map((res) => {
+              const isModel = res.kind === 'model'
+              const probe = res.state?.({
+                status,
+                urls: urlsRef.current,
+                driverValues,
+                saved: {
+                  prototypes: savedPrototypes,
+                  sampleCount: savedSampleCount,
+                },
+              })
               const ready =
-                res.kind === 'model'
-                  ? status === 'ready'
-                  : res.id === 'prototypes'
-                    ? savedPrototypes.length > 0
-                    : res.id === 'samples'
-                      ? savedSampleCount > 0
-                      : res.id === 'keywords'
-                        ? !!driverValues.keywords
-                        : false
+                probe?.ready ?? (isModel ? status === 'ready' : false)
               const detail =
-                res.id === 'prototypes'
-                  ? savedPrototypes.map((p) => p.word).join(', ') || 'none saved'
-                  : res.id === 'samples'
-                    ? `${savedSampleCount} sample(s) saved`
-                    : res.id === 'keywords'
-                      ? `${String(driverValues.keywords ?? '').split('\n').filter(Boolean).length} keyword(s)`
-                      : status === 'loading'
-                        ? 'loading…'
-                        : res.urlKey
-                          ? formatUrlDetail(urlsRef.current[res.urlKey])
-                          : ''
+                probe?.detail ??
+                (status === 'loading'
+                  ? 'loading…'
+                  : res.urlKey
+                    ? formatUrlDetail(urlsRef.current[res.urlKey])
+                    : '')
               return (
                 <div key={res.id} className="flex items-center gap-2 text-xs">
                   <span
@@ -1270,7 +1142,7 @@ export const KWSPanel = memo(function KWSPanel({
         <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-4">
             <h3 className="text-sm font-semibold text-ink-1">
-              PLiX Few-Shot enrollment{' '}
+              Few-Shot enrollment{' '}
               <span className="text-xs font-normal text-ink-3">
                 (Phase 3 · enroll a custom wake word, then detect)
               </span>

--- a/apps/web/src/model-library/store.ts
+++ b/apps/web/src/model-library/store.ts
@@ -24,17 +24,7 @@ const MODEL_STORE = 'models'
 export interface UserModel {
   id: string
   /** Role this model was imported for (classifier / melspectrogram / ...). */
-  role:
-    | 'melspectrogram'
-    | 'embedding'
-    | 'classifier'
-    | 'plix-encoder'
-    /**
-     * An exported kws_streaming graph. Note it needs a sidecar manifest to be
-     * usable, which the library does not store - so an imported file of this
-     * role only works when its manifest is reachable next to the model URL.
-     */
-    | 'kws-streaming-model'
+  role: string
   /** Original file name (e.g. my-wakeword-classifier.onnx). */
   name: string
   /** File size in bytes. */
@@ -85,7 +75,7 @@ function tx<T>(
 /** Import a local File into the user model library. */
 export async function importModelFile(
   file: File,
-  role: UserModel['role'],
+  role: string,
   notes?: string,
 ): Promise<UserModel> {
   const model: UserModel = {

--- a/apps/web/src/workspace/kws-config.ts
+++ b/apps/web/src/workspace/kws-config.ts
@@ -8,6 +8,7 @@
  */
 
 import { getBackendRegistry } from '@wake-studio/module-kws-engine'
+import type { KWSBackendRegistration } from '@wake-studio/module-kws-engine'
 import { normalizeSelectOptions } from '@wake-studio/module-kit'
 import type { BackendModelUrls } from '@wake-studio/module-kws-engine'
 import type { ParameterDescriptor } from '@wake-studio/module-afe-graph'
@@ -62,6 +63,16 @@ export function driverParamsFor(backendId: string): ReadonlyArray<ParameterDescr
   return (spec?.params ?? []).map(descriptorFromParam)
 }
 
+/** Label for a backend's spec 'load' action (ADR-025); generic fallback. */
+export function loadActionLabel(
+  reg: KWSBackendRegistration | undefined,
+): string {
+  const action = (reg?.spec as ModuleSpec | undefined)?.actions?.find(
+    (a) => a.kind === 'load',
+  )
+  return action?.label ?? 'Load models'
+}
+
 /** Resolve the three openwakeword model roles from a registry, or a remote
  *  assets path (ADR-025) for local models, remote for the classifier. */
 export function modelUrlsFromRegistry(registry: ModelRegistry): BackendModelUrls {
@@ -103,7 +114,7 @@ export interface ModelSourceOption {
  */
 export function modelSourcesForRole(
   registry: ModelRegistry,
-  role: 'melspectrogram' | 'embedding' | 'classifier' | 'plix-encoder' | 'kws-streaming-model',
+  role: string,
   current?: string,
 ): ModelSourceOption[] {
   const builtIns = registry.models
@@ -155,34 +166,4 @@ export function modelSourcesForRole(
 }
 
 /** One model role the Model-source editor offers for a backend. */
-export interface ModelSourceRole {
-  role: 'melspectrogram' | 'embedding' | 'classifier' | 'plix-encoder' | 'kws-streaming-model'
-  label: string
-  fallbackId: string
-}
-
-/** Model roles for the traditional (openwakeword) backend. */
-export const TRADITIONAL_MODEL_ROLES: ModelSourceRole[] = [
-  { role: 'melspectrogram', label: 'Mel front-end', fallbackId: 'melspectrogram' },
-  { role: 'embedding', label: 'Embedding backbone', fallbackId: 'speech_embedding' },
-  { role: 'classifier', label: 'Wake-word classifier', fallbackId: 'hey-buddy' },
-]
-
-/** Model roles for the few-shot (plixkws) backend. */
-export const FEWSHOT_MODEL_ROLES: ModelSourceRole[] = [
-  { role: 'plix-encoder', label: 'PLiX encoder', fallbackId: 'plixkws' },
-]
-
-/**
- * Model roles for the kws-streaming backend (ADR-024 Traditional).
- *
- * One role: the exported graph. Its sidecar manifest travels with it via the
- * registry's `manifestUrl`, so the user picks a model, not a pair of files.
- */
-export const KWS_STREAMING_MODEL_ROLES: ModelSourceRole[] = [
-  {
-    role: 'kws-streaming-model',
-    label: 'kws_streaming model',
-    fallbackId: 'kws-streaming-kwt1',
-  },
-]
+export type { ModelSourceRole } from '@wake-studio/module-kws-engine'

--- a/packages/modules/kws/engine/core/backend.ts
+++ b/packages/modules/kws/engine/core/backend.ts
@@ -13,6 +13,9 @@ import type {
   KWSBackendId,
   KWSBackendCategory,
   BackendModelUrls,
+  BackendModelResolveContext,
+  BackendResourceDescriptor,
+  ModelSourceRole,
 } from './types'
 import type { ModuleSpec } from '@wake-studio/contracts'
 
@@ -51,6 +54,27 @@ export interface KWSBackendRegistration {
    * default).
    */
   hasRequiredUrls?: (urls: BackendModelUrls) => boolean
+  /**
+   * Model-source roles this backend consumes (ADR-024). The host renders the
+   * Model-source editor from this; a backend that bundles its model (e.g.
+   * sherpa's wasm package) declares none. Defaults to [].
+   */
+  modelRoles?: ModelSourceRole[]
+  /**
+   * Resolve this backend's model URLs (ADR-011/024) from the user's model
+   * sources + driver params. Backends own their URL mapping, so the host
+   * never branches per backend id. Omitted for backends that load no model
+   * URLs (e.g. sherpa bundles its model in the wasm package).
+   */
+  resolveModelUrls?: (
+    ctx: BackendModelResolveContext,
+  ) => BackendModelUrls | Promise<BackendModelUrls>
+  /**
+   * Resource rows for the host's Engine card (models + persistent data).
+   * Declared per driver (ADR-024); the host renders them generically.
+   * Defaults to [].
+   */
+  resources?: BackendResourceDescriptor[]
   /**
    * Optional: a main-thread-only backend factory (e.g. sherpa-onnx-kws runs
    * on the main thread - its classic emscripten wasm needs DOM, ADR-018).
@@ -116,6 +140,29 @@ export function backendHasRequiredUrls(
   const reg = getBackendRegistration(id)
   if (reg?.hasRequiredUrls) return reg.hasRequiredUrls(urls)
   return Boolean(urls.melspectrogram && urls.embedding && urls.classifier)
+}
+
+/**
+ * Resolve one model role's URL from the user's selection, honoring:
+ *  - a user-library model ('user:<id>') -> its pre-resolved blob URL
+ *  - a registry model id -> the registry's URL for that id
+ *  - 'custom' -> the user-supplied custom URL
+ *  - nothing selected -> the built-in registry entry for `fallbackId`
+ *
+ * Shared by drivers that consume registry-backed model roles, so the
+ * selection semantics live in ONE place (ADR-024).
+ */
+export function resolveRoleUrl(
+  ctx: BackendModelResolveContext,
+  role: string,
+  fallbackId: string,
+): string | undefined {
+  const selected = ctx.modelSources[role]
+  const byId = new Map(ctx.registry.models.map((m) => [m.id, m.url]))
+  if (selected?.startsWith('user:')) return ctx.userBlobUrls[role]
+  if (selected && selected !== 'custom') return byId.get(selected)
+  if (selected === 'custom') return ctx.customUrls[role]?.trim() || undefined
+  return byId.get(fallbackId)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/modules/kws/engine/core/index.ts
+++ b/packages/modules/kws/engine/core/index.ts
@@ -21,11 +21,16 @@ export {
   getBackendRegistry,
   registerEmbedProviderFactory,
   registerKwsBackend,
+  resolveRoleUrl,
 } from './backend'
 export type { KWSBackendRegistration, EmbedProviderFactory } from './backend'
 
 export type {
+  BackendModelResolveContext,
   BackendModelUrls,
+  BackendResourceDescriptor,
+  BackendResourceState,
+  BackendResourceStateContext,
   EmbedProvider,
   KWSBackend,
   KWSBackendCategory,
@@ -34,6 +39,7 @@ export type {
   KWSScoreSample,
   KWSTriggerEvent,
   KWSStatus,
+  ModelSourceRole,
   ParameterDescriptor,
   SherpaOnnxKwsConfig,
 } from './types'

--- a/packages/modules/kws/engine/core/types.ts
+++ b/packages/modules/kws/engine/core/types.ts
@@ -9,7 +9,7 @@
 // Public API types (docs/modules/kws.md §4)
 // ---------------------------------------------------------------------------
 
-import type { ModelRuntime } from '@wake-studio/platform'
+import type { ModelRegistry, ModelRuntime } from '@wake-studio/platform'
 import { DEFAULT_MODEL_RUNTIME } from '@wake-studio/platform'
 /**
  * Pluggable KWS backend identifiers (ADR-020). The engine delegates inference
@@ -136,6 +136,80 @@ export interface BackendModelUrls {
   }
   /** Model-runtime hint for the model(s) addressed by these URLs. @see ModelRuntime */
   runtime?: ModelRuntime
+}
+
+// ---------------------------------------------------------------------------
+// Backend registration extras (ADR-024/025): host-facing declarations.
+//
+// Drivers declare these at registration time so the host panel renders the
+// Model-source editor, the Engine-card resources and the load URL mapping
+// generically - adding a backend never edits the host.
+// ---------------------------------------------------------------------------
+
+/** One model role the Model-source editor offers for a backend. */
+export interface ModelSourceRole {
+  /** Role key; also the modelSources/customUrls map key in the host. */
+  role: string
+  /** Label shown in the Model-source editor. */
+  label: string
+  /** Registry model id used when the user has not selected anything. */
+  fallbackId: string
+}
+
+/** Context handed to a backend's resolveModelUrls() (ADR-024). */
+export interface BackendModelResolveContext {
+  /** The loaded platform model registry (ADR-011). */
+  registry: ModelRegistry
+  /** The driver's own param values (spec params), keyed by id. */
+  driverValues: Record<string, unknown>
+  /** User model-source selection per role: registry id | 'custom' | 'user:<id>'. */
+  modelSources: Record<string, string | undefined>
+  /** Custom URLs per role (when the user selected 'custom'). */
+  customUrls: Record<string, string>
+  /** Blob URLs for user-library models (role -> blob URL). */
+  userBlobUrls: Record<string, string>
+}
+
+/** Readiness/detail computed by a driver's resource-row probe. */
+export interface BackendResourceState {
+  ready: boolean
+  /** Detail line shown under the row label (e.g. URL, sample count). */
+  detail?: string
+}
+
+/** Context handed to a backend's resource-row state() probe. */
+export interface BackendResourceStateContext {
+  /** Current engine status (idle | loading | ready | running | error). */
+  status: KWSStatus
+  /** Model URLs of the current load (BackendModelUrls). */
+  urls: BackendModelUrls
+  /** The driver's own param values (spec params), keyed by id. */
+  driverValues: Record<string, unknown>
+  /**
+   * Persisted artifacts the host has loaded (e.g. few-shot prototypes and
+   * sample counts). Shape is driver-defined; the probe reads what it
+   * declared. Empty when the host has no artifacts for this backend.
+   */
+  saved: Record<string, unknown>
+}
+
+/**
+ * One resource row in the host's Engine card: a model the backend loads or
+ * persistent data the user has created. Declared per driver at registration
+ * so adding a backend never edits the host panel.
+ */
+export interface BackendResourceDescriptor {
+  id: string
+  label: string
+  kind: 'model' | 'data'
+  /** 'model' rows: key into BackendModelUrls whose loaded URL is shown. */
+  urlKey?: keyof BackendModelUrls
+  /**
+   * 'data' rows (or custom model rows): driver-owned readiness/detail. When
+   * absent on a 'model' row, the host derives readiness from engine status
+   * and detail from the loaded URL.
+   */
+  state?: (ctx: BackendResourceStateContext) => BackendResourceState
 }
 
 /**

--- a/packages/modules/kws/openwakeword/core/index.ts
+++ b/packages/modules/kws/openwakeword/core/index.ts
@@ -5,7 +5,7 @@
  * decoupling: adding a driver never edits the engine).
  */
 
-import { registerKwsBackend } from '@wake-studio/module-kws-engine'
+import { registerKwsBackend, resolveRoleUrl } from '@wake-studio/module-kws-engine'
 import { OpenWakeWordBackend } from './backend'
 import type { ModuleSpec } from '@wake-studio/contracts'
 import openWakeWordSpec from '../spec/module.spec.json'
@@ -22,4 +22,22 @@ registerKwsBackend({
   // The driver's own spec (ADR-025): hosts render its params (threshold)
   // from the registry instead of hard-coding per-backend cases.
   spec: openWakeWordSpec as unknown as ModuleSpec,
+  // The three openwakeword model roles (ADR-024): the host renders the
+  // Model-source editor from this, and the driver owns the URL mapping.
+  modelRoles: [
+    { role: 'melspectrogram', label: 'Mel front-end', fallbackId: 'melspectrogram' },
+    { role: 'embedding', label: 'Embedding backbone', fallbackId: 'speech_embedding' },
+    { role: 'classifier', label: 'Wake-word classifier', fallbackId: 'hey-buddy' },
+  ],
+  resolveModelUrls: (ctx) => ({
+    melspectrogram: resolveRoleUrl(ctx, 'melspectrogram', 'melspectrogram'),
+    embedding: resolveRoleUrl(ctx, 'embedding', 'speech_embedding'),
+    classifier: resolveRoleUrl(ctx, 'classifier', 'hey-buddy'),
+  }),
+  // Engine-card resources (ADR-024): one row per model this backend loads.
+  resources: [
+    { id: 'melspectrogram', label: 'Mel-spectrogram front-end', kind: 'model', urlKey: 'melspectrogram' },
+    { id: 'embedding', label: 'Speech embedding backbone', kind: 'model', urlKey: 'embedding' },
+    { id: 'classifier', label: 'Wake-word classifier', kind: 'model', urlKey: 'classifier' },
+  ],
 })

--- a/packages/modules/kws/plix/core/index.ts
+++ b/packages/modules/kws/plix/core/index.ts
@@ -15,6 +15,7 @@ import type { EmbedProvider } from '@wake-studio/module-kws-engine'
 import type { ModuleSpec } from '@wake-studio/contracts'
 import { PlixKwsBackend } from './backend'
 import { PlixKwsEmbedProvider } from '../encoders/plixkws-embed'
+import { getPlixEncoderVariant } from '../encoders/plix-encoder'
 import type { WakeWordPrototype } from './prototype'
 import plixSpec from '../spec/module.spec.json'
 
@@ -86,4 +87,70 @@ registerKwsBackend({
   // The driver's own spec (ADR-025): hosts render its params (encoder)
   // from the registry instead of hard-coding per-backend cases.
   spec: plixSpec as unknown as ModuleSpec,
+  // Few-Shot encoder model role (ADR-024): the Model-source editor is
+  // rendered from this; the URL mapping below lives in the driver.
+  modelRoles: [
+    { role: 'plix-encoder', label: 'PLiX encoder', fallbackId: 'plixkws' },
+  ],
+  // Few-Shot encoder URL resolution. The encoder variant + runtime are the
+  // driver's spec params (ADR-025) and the variant->asset mapping lives in
+  // the encoder module, so the host never names a PLiX variant or asset.
+  resolveModelUrls: (ctx) => {
+    const variant = getPlixEncoderVariant(
+      (ctx.driverValues.encoder as 'base' | 'small' | undefined) ?? 'small',
+    )
+    if (!variant) {
+      throw new Error(`Unknown PLiX variant: ${String(ctx.driverValues.encoder)}`)
+    }
+    const rt =
+      (ctx.driverValues.runtime as 'onnx' | 'transformers' | undefined) ?? 'onnx'
+    const selected = ctx.modelSources['plix-encoder']
+    const customUrl =
+      selected === 'custom' ? ctx.customUrls['plix-encoder']?.trim() : undefined
+    let url: string
+    if (rt === 'transformers') {
+      url = variant.transformersLocalDir
+    } else if (selected?.startsWith('user:')) {
+      // User-library encoder (imported file / training artifact).
+      const blobUrl = ctx.userBlobUrls['plix-encoder']
+      if (!blobUrl) {
+        throw new Error('Selected PLiX encoder is not in the model library.')
+      }
+      url = blobUrl
+    } else if (customUrl) {
+      // User-supplied encoder URL overrides the built-in variant asset.
+      url = customUrl
+    } else {
+      url = variant.onnxUrl
+    }
+    return { plixkws: url, runtime: rt }
+  },
+  // Engine-card resources (ADR-024): the encoder model plus the persisted
+  // enrollment artifacts. The data rows read the host-provided saved summary.
+  resources: [
+    { id: 'encoder', label: 'PLiX encoder', kind: 'model', urlKey: 'plixkws' },
+    {
+      id: 'prototypes',
+      label: 'Enrolled prototypes',
+      kind: 'data',
+      state: (ctx) => {
+        const protos = ctx.saved.prototypes as
+          | Array<{ word?: string }>
+          | undefined
+        const words = (protos ?? [])
+          .map((p) => p.word)
+          .filter((w): w is string => Boolean(w))
+        return { ready: words.length > 0, detail: words.join(', ') || 'none saved' }
+      },
+    },
+    {
+      id: 'samples',
+      label: 'Enrolled samples',
+      kind: 'data',
+      state: (ctx) => ({
+        ready: Number(ctx.saved.sampleCount) > 0,
+        detail: `${Number(ctx.saved.sampleCount) || 0} sample(s) saved`,
+      }),
+    },
+  ],
 })

--- a/packages/modules/kws/sherpa/core/index.ts
+++ b/packages/modules/kws/sherpa/core/index.ts
@@ -27,4 +27,20 @@ registerKwsBackend({
   spec: sherpaSpec as unknown as ModuleSpec,
   // Main-thread backend: the classic emscripten wasm needs DOM.
   mainThreadFactory: () => new SherpaOnnxKwsBackend(),
+  // Engine-card resources (ADR-024). The wasm package bundles the model, so
+  // there are no model sources and no URL mapping; only the wasm runtime and
+  // the editable wake-word list (a driver param) are shown.
+  resources: [
+    { id: 'wasm', label: 'sherpa-onnx KWS wasm runtime', kind: 'model' },
+    {
+      id: 'keywords',
+      label: 'Wake-word list',
+      kind: 'data',
+      state: (ctx) => {
+        const text = String(ctx.driverValues.keywords ?? '')
+        const count = text.split('\n').filter(Boolean).length
+        return { ready: count > 0, detail: `${count} keyword(s)` }
+      },
+    },
+  ],
 })

--- a/packages/modules/kws/streaming/core/index.ts
+++ b/packages/modules/kws/streaming/core/index.ts
@@ -42,4 +42,39 @@ registerKwsBackend({
   hasRequiredUrls: (urls) =>
     Boolean(urls.kwsStreaming?.model && urls.kwsStreaming?.manifest),
   spec: kwsStreamingSpec as unknown as ModuleSpec,
+  // One model role: the exported graph. Its sidecar manifest travels with it
+  // via the registry's manifestUrl, so the user picks a model, not a pair.
+  modelRoles: [
+    { role: 'kws-streaming-model', label: 'kws_streaming model', fallbackId: 'kws-streaming-kwt1' },
+  ],
+  // The graph + manifest must stay paired by construction; a custom URL
+  // therefore also needs its manifest, derived by swapping .onnx -> .json
+  // (what the exporter emits).
+  resolveModelUrls: (ctx) => {
+    const role = 'kws-streaming-model'
+    const selected = ctx.modelSources[role]
+    if (selected === 'custom') {
+      const model = ctx.customUrls[role]?.trim()
+      if (!model) return {}
+      return {
+        kwsStreaming: { model, manifest: model.replace(/\.onnx$/i, '.json') },
+      }
+    }
+    const entry =
+      ctx.registry.models.find((m) => m.id === selected) ??
+      ctx.registry.models.find((m) => m.id === 'kws-streaming-kwt1')
+    if (!entry?.manifestUrl) return {}
+    return {
+      kwsStreaming: { model: entry.url, manifest: entry.manifestUrl },
+    }
+  },
+  // Engine-card resource: the graph + its sidecar manifest as one row.
+  resources: [
+    {
+      id: 'kws-streaming-model',
+      label: 'kws_streaming model + manifest',
+      kind: 'model',
+      urlKey: 'kwsStreaming',
+    },
+  ],
 })


### PR DESCRIPTION
## Goal

De-hardcode `KWSPanel` (issue #75): the host panel no longer branches on
backend ids, imports driver modules, or carries a static resource map. Each
KWS driver now declares its host-facing surface at registration (ADR-024) —
`modelRoles`, `resolveModelUrls`, `resources` — and the panel renders it
generically.

## What changed

**Engine seam (`@wake-studio/module-kws-engine`)**
- `KWSBackendRegistration` gains three optional declarations:
  - `modelRoles` — Model-source editor roles (id/label/fallback registry id)
  - `resolveModelUrls(ctx)` — driver-owned URL mapping (registry, driver
    params, user model sources, custom URLs)
  - `resources` — Engine-card rows (`model` rows keyed into
    `BackendModelUrls`; `data` rows with a driver probe for
    readiness/detail)
- New shared `resolveRoleUrl()` helper: one implementation of the
  registry-id / user-library / custom-URL / fallback selection semantics.
- New contract types exported: `ModelSourceRole`, `BackendModelResolveContext`,
  `BackendResourceDescriptor`, `BackendResourceState(Context)`.

**Drivers own their surface**
- **openwakeword**: 3 roles + triple resolver + 3 resource rows.
- **plix**: encoder role; the variant→asset mapping (encoder/runtime spec
  params, user-library/custom overrides) moved **out of the panel** into the
  driver; resources include encoder + prototypes/samples probes.
- **sherpa**: no roles (model bundled in wasm), resources = wasm runtime +
  keyword-list probe.
- **kws-streaming**: one role; the model+manifest pairing moved into the
  driver.

**Panel (`apps/web`)**
- `ENGINE_RESOURCES` and the inline `res.id === 'prototypes' ? …` readiness
  chain deleted; the Resources card renders from `registration.resources`.
- `handleLoad` / `handleLoadEncoder` / `handleStartPlix` all resolve URLs
  through one `resolveModelUrlsFor(backendId)` → registration resolver; the
  `backend === 'plixkws' ? … : 'kws-streaming' ? …` ternary is gone.
- `apps/web` no longer imports `@wake-studio/module-kws-plix`
  (`getPlixEncoderVariant` usage moved into the plix driver).
- Engine-card header uses `registration.label`; the few-shot load button
  label comes from the driver spec's `load` action (ADR-025) — no
  hard-coded "PLiX" strings.
- `kws-config` role constants deleted; `ModelSourceRole` moved to the
  engine contract; model-library role params widened to `string`.

## Bug fixes that fell out

- **kws-streaming Resources card** previously showed the openwakeword rows
  (mel/embedding/classifier) because the old map keyed by *category*; it now
  shows the real "model + manifest" row.
- After "Load PLiX encoder", the encoder resource row showed "not loaded" —
  `urlsRef` is now set in that path too, so the loaded URL displays.

## Verification

- `pnpm typecheck` green in `apps/web` + all touched module packages.
- Unit tests green: apps/web 68, kws-engine 43, plix 20, streaming 70,
  sherpa 10, openwakeword 8.
- `pnpm lint` clean for touched files (only pre-existing warnings).
- Manual check recommended: load each backend in the console and confirm the
  Resources card + few-shot enrollment flow behave as before.

Closes #75
