### PR TITLE
feat(kws): provisioning capability — one abstract wake-word artifact flow (ADR-033, #76)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -837,6 +837,119 @@ Status legend: `Proposed` · `Accepted` · `Superseded` · `Deprecated`
 
 ---
 
+## ADR-033 — Provisioning capability: one abstract wake-word artifact flow for all KWS backends
+
+- **Status:** Accepted (2026-08-11; decision points confirmed by human - issue #76)
+- **Origin:** Issue #76 (Part 2 of the KWSPanel decoupling series; depends on the
+  registration seams #75, pairs with Q15 #74)
+- **Decision:**
+  1. **A provisioning capability on `KWSBackendRegistration`.** Producing "the
+     wake-word artifact a backend needs" is the same abstract behavior across
+     drivers (plix enrollment, sherpa keyword list, future training) with
+     different input collection. Add an optional `provision?: ProvisionCapability`
+     to the registration (ADR-024 seam pattern):
+     ```ts
+     // contracts/src/provision.ts - pure data contract (no engine types)
+     type ProvisionKind = 'prototype' | 'list' | 'train'   // extensible
+
+     // serializable payloads (wire + persistence form; Float32Array -> number[])
+     interface ProvisionPrototypePayload {
+       id: string; word: string; vector: number[]
+       negativeVector?: number[]; sampleIds: string[]; createdAtMs: number
+     }
+     interface ProvisionListPayload { keywords: string }
+     interface ProvisionTrainPayload { urls: Record<string, string>; registryEntry?: string }
+
+     type ProvisionArtifact =
+       | { kind: 'prototype'; backendId: string; payload: ProvisionPrototypePayload }
+       | { kind: 'list';      backendId: string; payload: ProvisionListPayload }
+       | { kind: 'train';     backendId: string; payload: ProvisionTrainPayload }
+     ```
+     The capability **interface** lives in `kws-engine` next to the registration
+     (it binds contract payloads to engine types):
+     ```ts
+     interface ProvisionCapability {
+       kind: ProvisionKind
+       /** Provisioning panel spec - rendered by the generator, host stays generic. */
+       spec?: ModuleSpec
+       /** Input in (mic samples / dataset / keyword text), artifact out. */
+       produce(input: unknown): Promise<ProvisionArtifact>
+       /** Feed the artifact into engine.load: urls and/or backend config. */
+       apply(artifact: ProvisionArtifact): {
+         urls?: BackendModelUrls
+         backendConfig?: Record<string, unknown>
+       }
+     }
+     ```
+  2. **Prerequisite inversion (#74 §5).** `WakeWordPrototype` + the scoring
+     primitives (`squaredEuclidean` / `plixScore` / `l2Normalize` / `meanPool`)
+     move out of the `kws-plix` driver module into `few-shot` (a capability
+     module); `plix` imports them. `few-shot`'s current re-export of plix
+     symbols is deleted. Only this way can a future `train`-kind driver
+     (openwakeword training) produce the same artifact type without importing
+     an impl module (#74 rule).
+  3. **Unified host flow: collect → produce → persist → load-with-artifact.**
+     The host renders the capability's provisioning spec, collects input
+     (shared recorder from `few-shot/web`, a capability module), calls
+     `produce(input)`, persists the artifact, then feeds `apply(artifact)` into
+     `engine.load(urls, undefined, backendConfig)` - the artifact rides in
+     `backendConfig` (opaque to the host), which for plix carries the prototype
+     vectors. Traditional backends without a capability keep today's
+     registration-driven `resolveModelUrls` → `engine.load` path unchanged.
+  4. **`commandRef` dispatch collapses to "ask the capability".** The
+     `isFewShot` branch in the host's load/start/stop dispatch is replaced by
+     a check for `provision` presence. A second few-shot driver or a list-based
+     driver needs zero host edits (ADR-024 rule preserved).
+  5. **Artifacts persist in the shared user artifact library.** The app-level
+     user model library (`apps/web/src/model-library`, IndexedDB) generalizes
+     to store both imported models and provisioned artifacts
+     (`kind: 'model' | 'artifact'` + typed payload). Prototypes today, keyword
+     lists and trained classifiers later become one browsable collection.
+     The few-shot module's **prototype** storage moves host-side (persist is a
+     host responsibility per the unified flow); its **sample** store stays
+     module-owned (input clips are not artifacts). Existing
+     `wake-studio-few-shot` prototypes migrate into the library lazily once.
+     This supersedes migration-plan Q-F1's module-owned-prototype-storage
+     default for prototypes specifically.
+- **Rationale:** Every backend needs "produce the artifact, then load with it";
+  today the host branches on `isFewShot` and embeds plix's enrollment UI
+  inline, which does not scale to a second few-shot driver or to training
+  outputs. The capability keeps the host generic (ADR-024/025), moves the
+  enrollment flow behind a driver-owned spec + `produce`/`apply` pair, and
+  gives training (Phase 5) a contract to implement against.
+- **Open questions resolved in this ADR (flagged for human):**
+  1. *ProvisionKind taxonomy* - declare all three kinds now ('train' included)
+     but implement only 'prototype' in this change; 'list' (sherpa) and 'train'
+     (openwakeword/kws-streaming, waits for the Phase 5 train-runner) are
+     follow-ups. Hosts render unimplemented kinds as disabled with the driver's
+     availabilityNote.
+  2. *Artifact persistence* - the shared user artifact library stays app-level
+     (its only consumer today is the host; the platform move waits for a second
+     consumer per the YAGNI scope guard).
+  3. *commandRef* - dispatch on `provision` presence, not category (agreed per
+     the issue body).
+  4. *Panel rendering* - provisioning panels render from the driver's
+     provisioning spec via module-kit's generator (params/actions/status; the
+     spec schema already has `ActionKind 'record'` and `StatusRenderer
+     'curve'`/`'bar'`). If an enrollment action kind is needed, extend
+     `ActionKind` - a spec schema change, never a hand panel.
+- **Consequences:**
+  - `ProvisionKind`/`ProvisionArtifact` land in `packages/contracts` (pure
+    types); `ProvisionCapability` + `provision?` land in `kws-engine` next to
+    `KWSBackendRegistration`.
+  - `few-shot` owns `WakeWordPrototype` + scoring; `kws-plix` imports them.
+    `few-shot/core/index.ts` no longer re-exports from plix.
+  - KWSPanel's enrollment section becomes a generic provisioning section driven
+    by the selected backend's capability spec; plix-specific strings move into
+    the plix spec. Enrollment UX is unchanged (acceptance criterion).
+  - Out of scope for this change (follow-ups): sherpa `list` capability,
+    `train` capability + train-runner wiring (Phase 5), shrinking
+    `BackendModelUrls`/worker `prototype` fields into `backendConfig` (#74 §5).
+  - ADR-030/024 decoupling rule preserved: adding a provisioning backend = a
+    capability + spec in its driver module, zero host edits.
+
+---
+
 _Open questions still pending human input: Q10 (self-hosted training engine) is
 open for Phase 5. Q9 (training backends) is ADR-013 (amended: in-browser training
 removed, Cloud Providers unified, Colab added as ADR-023); targets are ADR-019

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -52,7 +52,8 @@ import {
   DEFAULT_CONFIG as FS_DEFAULTS,
   describeParameters as fewShotDescribeParameters,
 } from '@wake-studio/module-few-shot'
-import type { EnrolledSample, WakeWordPrototype } from '@wake-studio/module-few-shot'
+import type { EnrolledSample } from '@wake-studio/module-few-shot'
+import { serializePrototype } from '@wake-studio/module-few-shot'
 import { recorderWorkletUrl as recorderUrl } from '@wake-studio/module-few-shot/web'
 import {
   importModelFile,
@@ -60,8 +61,12 @@ import {
   deleteUserModel,
   exportUserModel,
   blobUrlForModel,
+  saveProvisionArtifact,
+  listProvisionArtifacts,
+  deleteProvisionArtifact,
 } from '../model-library'
-import type { UserModel } from '../model-library'
+import type { UserModel, UserArtifact } from '../model-library'
+import { provisionActionLabel } from '../workspace/kws-config'
 
 const HISTORY_MAX = 300 // ~3 s at ~100 fps
 
@@ -142,7 +147,11 @@ export const KWSPanel = memo(function KWSPanel({
   const [recordingNeg, setRecordingNeg] = useState(false)
   const [building, setBuilding] = useState(false)
   const [buildingNeg, setBuildingNeg] = useState(false)
-  const [prototype, setPrototype] = useState<WakeWordPrototype | null>(null)
+  // The persisted provisioning artifact (user artifact library, ADR-033): the
+  // enrolled prototype this backend loads with. Produced via the backend's
+  // provisioning capability, persisted, then applied at load - the host never
+  // touches driver-specific prototype types.
+  const [artifact, setArtifact] = useState<UserArtifact | null>(null)
   const [detecting, setDetecting] = useState(false)
   const { projectConfig: fsProjCfg, persist: persistFs } = useProjectStageConfig('fewShot')
   const [fsConfig, setFsConfig] = useState<{
@@ -162,9 +171,10 @@ export const KWSPanel = memo(function KWSPanel({
   })
   const fsCanvasRef = useRef<HTMLCanvasElement>(null)
   const fsHistoryRef = useRef<KWSScoreSample[]>([])
-  // Persisted few-shot artifacts (IndexedDB, ADR-013): shown in the Engine
-  // card's resource list so previously-enrolled data is visible on load.
-  const [savedPrototypes, setSavedPrototypes] = useState<WakeWordPrototype[]>([])
+  // Persisted provisioning artifacts (user artifact library, ADR-033): shown
+  // in the Engine card's resource list so previously-enrolled data is visible
+  // on load.
+  const [savedPrototypes, setSavedPrototypes] = useState<UserArtifact[]>([])
   const [savedSampleCount, setSavedSampleCount] = useState(0)
 
   const { historyRef, setThreshold, setLastScore } = useLiveKws()
@@ -394,10 +404,14 @@ export const KWSPanel = memo(function KWSPanel({
   // automatically (registry is a local JSON, ADR-011). Initial mount keeps the
   // manual Load button (no surprise model fetches on visit); "Reload" re-applies
   const prevBackendRef = useRef(config.backend)
-  // The backend's KWS functional category (ADR-024): few-shot backends
-  // (plixkws today, future drivers) get the enrollment flow automatically.
+  // The backend's provisioning capability (ADR-033): few-shot backends
+  // (plixkws today, future enrollment drivers) declare one, and the host's
+  // load/start/stop dispatch + the enrollment section follow it instead of
+  // branching on the KWS category (which would not scale to a second
+  // few-shot driver or to training outputs).
   const selectedBackend = getBackendRegistry().find((r) => r.id === config.backend)
-  const isFewShot = selectedBackend?.category === 'few-shot'
+  const provision = selectedBackend?.provision
+  const hasProvision = Boolean(provision)
   // Model-source roles come from the backend's registration (ADR-024): each
   // driver declares the roles it consumes. asr-decoding (sherpa-onnx-kws)
   // bundles its model into the wasm .data package and only takes a keyword
@@ -426,7 +440,7 @@ export const KWSPanel = memo(function KWSPanel({
       // does not keep running detection for the previous model.
       engineRef.current?.dispose()
     }
-  }, [config.backend, isFewShot])
+  }, [config.backend, hasProvision])
 
   // --- plixkws enrollment + detection ---
 
@@ -447,19 +461,44 @@ export const KWSPanel = memo(function KWSPanel({
     return engineRef.current
   }, [])
 
-  // Load persisted few-shot artifacts (IndexedDB) on mount + when a new
-  // prototype is built, so the Engine card's resource list stays fresh.
+  // Load persisted provisioning artifacts (user artifact library, ADR-033) on
+  // mount + when a new artifact is produced, so the Engine card's resource
+  // list stays fresh. Legacy few-shot prototypes (pre-ADR-033 IndexedDB store)
+  // migrate into the library lazily once.
+  const migratedRef = useRef(false)
   useEffect(() => {
     let cancelled = false
     void (async () => {
       try {
         ensureFsEngines()
-        const fs = fsEngineRef.current
-        if (!fs) return
-        const protos = await fs.listPrototypes()
+        let lib = await listProvisionArtifacts()
+        const protos = lib.filter((e) => e.artifactType === 'prototype')
+        // One-time migration from the legacy few-shot module store (only when
+        // the library has no prototype artifacts yet - prevents re-running).
+        if (protos.length === 0 && !migratedRef.current) {
+          migratedRef.current = true
+          const legacy = (await fsEngineRef.current?.listPrototypes()) ?? []
+          for (const p of legacy) {
+            await saveProvisionArtifact(
+              {
+                kind: 'prototype',
+                backendId: 'plixkws',
+                payload: serializePrototype(p),
+              },
+              { name: p.word, notes: 'Migrated from the legacy few-shot store' },
+            )
+          }
+          if (legacy.length > 0) lib = await listProvisionArtifacts()
+        }
+        const stored = lib.filter((e) => e.artifactType === 'prototype')
         if (!cancelled) {
-          setSavedPrototypes(protos)
-          setSavedSampleCount(protos.reduce((acc, p) => acc + p.sampleIds.length, 0))
+          setSavedPrototypes(stored)
+          setSavedSampleCount(
+            stored.reduce((acc, e) => {
+              if (e.artifact.kind !== 'prototype') return acc
+              return acc + e.artifact.payload.sampleIds.length
+            }, 0),
+          )
         }
       } catch {
         // IndexedDB unavailable - ignore; the list stays empty.
@@ -468,17 +507,20 @@ export const KWSPanel = memo(function KWSPanel({
     return () => {
       cancelled = true
     }
-  }, [prototype, ensureFsEngines])
+  }, [artifact, ensureFsEngines])
 
   /** Load the PLiX encoder (embed-only, no detection backend yet). */
-  const handleLoadEncoder = useCallback(async () => {
+  const handleProvisionLoad = useCallback(async () => {
     setError(null)
     const engine = ensureFsEngines()
     try {
       setStatus('loading')
-      // Embed-only boot: the few-shot detection path demands a prototype, so
-      // the engine loads the encoder through a traditional backend id. The
-      // selected few-shot driver still owns the URL resolution below.
+      // Embed-only boot: the provisioning detection path demands an artifact
+      // (prototype), so the encoder alone is loaded through a traditional
+      // backend id - the worker boots the embed provider whenever a plixkws
+      // URL is present and skips the detection backend when no traditional
+      // URLs are (ADR-033). The selected provisioning driver still owns the
+      // URL resolution below.
       engine.setConfig({ ...DEFAULT_CONFIG, backend: 'openwakeword' })
       const urls = await resolveModelUrlsFor(config.backend)
       urlsRef.current = urls
@@ -555,47 +597,71 @@ export const KWSPanel = memo(function KWSPanel({
     setError(null)
     setBuilding(true)
     try {
-      const fs = fsEngineRef.current!
-      const proto = fs.buildPrototype('custom-word', samples)
-      await fs.savePrototype(proto, samples)
-      setPrototype(proto)
+      const cap = provision
+      if (!cap) throw new Error('This backend has no provisioning capability.')
+      // produce(): the driver turns the enrolled samples into the artifact
+      // (prototype). The host persists it to the user artifact library and
+      // holds the library entry as the load source (ADR-033).
+      const produced = await cap.produce({
+        word: 'custom-word',
+        samples,
+      })
+      const saved = await saveProvisionArtifact(produced, {
+        name: produced.kind === 'prototype' ? produced.payload.word : 'prototype',
+      })
+      setArtifact(saved)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setBuilding(false)
     }
-  }, [samples])
+  }, [provision, samples])
 
   /** Build + persist the negative-class prototype from non-target samples. */
   const handleBuildNegative = useCallback(async () => {
     setError(null)
     setBuildingNeg(true)
     try {
-      const fs = fsEngineRef.current!
-      if (!prototype) {
+      const cap = provision
+      if (!cap) throw new Error('This backend has no provisioning capability.')
+      const current = artifact
+      if (!current) {
         setError('Build the wake-word prototype first, then enroll negative samples.')
         return
       }
-      const negVector = fs.buildNegativeVector(negSamples)
-      const updated = await fs.attachNegativePrototype(prototype, negVector)
-      setPrototype(updated)
+      if (current.artifact.kind !== 'prototype') return
+      // Re-produce with the negative-class samples included (the negative
+      // vector is part of the same prototype artifact, issue #69) and
+      // supersede the previous library entry.
+      const next = await cap.produce({
+        word: current.artifact.payload.word,
+        samples,
+        negativeSamples: negSamples,
+      })
+      await deleteProvisionArtifact(current.id)
+      const saved = await saveProvisionArtifact(next, {
+        name: next.kind === 'prototype' ? next.payload.word : 'prototype',
+      })
+      setArtifact(saved)
       // Open-set rejection is only meaningful when a negative class exists:
       // auto-enable it so detection uses the relative score.
       setFsConfig((prev) => ({ ...prev, useNegativePrototype: true }))
-      logInfo('kws', `Negative prototype built (${negSamples.length} samples, ${negVector.length}-dim)`)
+      logInfo('kws', `Negative prototype built (${negSamples.length} samples)`)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setBuildingNeg(false)
     }
-  }, [prototype, negSamples])
+  }, [provision, artifact, samples, negSamples])
 
-  /** Load the plixkws detection backend with the prototype and start. */
-  const handleStartPlix = useCallback(async () => {
+  /** Load the provisioning backend with its artifact and start. */
+  const handleProvisionStart = useCallback(async () => {
     setError(null)
     const engine = engineRef.current!
-    const proto = prototype
-    if (!proto) {
+    const cap = provision
+    if (!cap) throw new Error('This backend has no provisioning capability.')
+    const saved = artifact
+    if (!saved) {
       setError('Build a prototype first.')
       return
     }
@@ -605,13 +671,26 @@ export const KWSPanel = memo(function KWSPanel({
       return
     }
     try {
-      // Fresh worker + engine: dispose and recreate so the plixkws backend
-      // boots cleanly with the prototype (KWSEngine.load guards re-entry).
+      // apply(): the driver maps the artifact into the engine load inputs
+      // (backend config; prototype vector(s) ride inside it, opaque to the
+      // host). The live few-shot detection params (the few-shot module's own
+      // config surface) are overlaid on top - the backend reads the same
+      // param ids (windowMs / useNegativePrototype / silenceFloorDbfs).
+      const applied = cap.apply(saved.artifact)
+      const backendConfig = {
+        ...applied.backendConfig,
+        windowMs: fsConfig.windowMs,
+        useNegativePrototype: fsConfig.useNegativePrototype,
+        silenceFloorDbfs: fsConfig.silenceFloorDbfs,
+      }
+      // Fresh worker + engine: dispose and recreate so the provisioning
+      // backend boots cleanly with the artifact (KWSEngine.load guards
+      // re-entry).
       engine.dispose()
       const fresh = new KWSEngine()
       fresh.onScore((s) => {
         setLastScore(s.smoothedScore)
-        // Few-shot scores must reach BOTH the panel's own curve (fsHistoryRef)
+        // Scores must reach BOTH the panel's own curve (fsHistoryRef)
         // and the shared workspace history (historyRef) that ScoreCurvePanel /
         // the top-bar mini bar render (issue #67: previously only fsHistoryRef
         // was written, so the workspace score curve stayed empty).
@@ -632,7 +711,7 @@ export const KWSPanel = memo(function KWSPanel({
       // the same threshold the score curve renders (issue #66 secondary).
       fresh.setConfig({
         ...DEFAULT_CONFIG,
-        backend: 'plixkws',
+        backend: config.backend,
         threshold: fsConfig.threshold,
         minDurationMs: fsConfig.minDurationMs,
         cooldownMs: fsConfig.cooldownMs,
@@ -640,26 +719,10 @@ export const KWSPanel = memo(function KWSPanel({
         vadGateEnabled: fsConfig.vadGateEnabled,
         vadThreshold: fsConfig.vadThreshold,
       })
-      // Resolve the encoder URLs through the plix driver's registration
-      // (ADR-024): variant + runtime + model-source selection are driver
-      // knowledge, not the panel's.
-      const urls = await resolveModelUrlsFor(config.backend)
-      await fresh.load(
-        urls,
-        proto.vector,
-        // Few-Shot detection params from the config panel (epic #53 P1):
-        // windowMs + useNegativePrototype reach the plix backend via the
-        // worker load message -> initWithPrototype opts. silenceFloorDbfs
-        // gates silent windows to score 0 (no false triggers on silence).
-        {
-          windowMs: fsConfig.windowMs,
-          useNegative: fsConfig.useNegativePrototype,
-          silenceFloorDbfs: fsConfig.silenceFloorDbfs,
-        },
-        // Negative-class prototype (open-set rejection, issue #69): reaches
-        // the worker as prototypeNegative -> initWithPrototype proto.
-        proto.negativeVector,
-      )
+      // Model URLs come from the driver's registration resolver (ADR-024)
+      // unless the artifact itself carries them (e.g. a train artifact).
+      const urls = applied.urls ?? (await resolveModelUrlsFor(config.backend))
+      await fresh.load(urls, undefined, backendConfig)
       const afe2 = afeRef?.current ?? afePipeline
       fresh.start({
         onOutput: (cb) => {
@@ -673,9 +736,9 @@ export const KWSPanel = memo(function KWSPanel({
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
     }
-  }, [afePipeline, afeRunning, prototype, resolveModelUrlsFor, config.backend, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype, fsConfig.silenceFloorDbfs])
+  }, [provision, artifact, afePipeline, afeRunning, resolveModelUrlsFor, config.backend, setThreshold, historyRef, fsConfig.threshold, fsConfig.minDurationMs, fsConfig.cooldownMs, fsConfig.smoothingWindowFrames, fsConfig.vadGateEnabled, fsConfig.vadThreshold, fsConfig.windowMs, fsConfig.useNegativePrototype, fsConfig.silenceFloorDbfs])
 
-  const handleStopPlix = useCallback(() => {
+  const handleProvisionStop = useCallback(() => {
     engineRef.current?.stop()
     setDetecting(false)
     fsHistoryRef.current = []
@@ -706,22 +769,21 @@ export const KWSPanel = memo(function KWSPanel({
   // (epic #53 P4). The runner drives the unified Start/Stop; the panel keeps
   // its own Load/Reload buttons.
   //
-  // Dispatch on the backend's few-shot category (issue #67): the few-shot
-  // flow needs its own load/start/stop (handleLoadEncoder/handleStartPlix/
-  // handleStopPlix) because the plixkws backend must be booted WITH the
-  // enrolled prototype. Using the traditional handlers here made the unified
-  // Start either fail (handleLoad with no prototype -> worker error) or start
-  // the encoder-only engine with no detection backend (empty score curve).
+  // Dispatch on the backend's provisioning capability (ADR-033), not on its
+  // category: a provisioning backend (plixkws today, any future enrollment or
+  // keyword-list driver) boots WITH its produced artifact, so it needs its
+  // own load/start/stop. Traditional backends keep the plain load/start/stop.
+  // Adding a provisioning driver never edits this dispatch.
   useEffect(() => {
     if (commandRef) {
       commandRef.current = {
-        load: isFewShot ? handleLoadEncoder : handleLoad,
-        start: isFewShot ? handleStartPlix : handleStart,
-        stop: isFewShot ? handleStopPlix : handleStop,
-        getState: () => ({ status, running: running || detecting, isFewShot }),
+        load: hasProvision ? handleProvisionLoad : handleLoad,
+        start: hasProvision ? handleProvisionStart : handleStart,
+        stop: hasProvision ? handleProvisionStop : handleStop,
+        getState: () => ({ status, running: running || detecting, hasProvision }),
       }
     }
-  }, [commandRef, handleLoad, handleLoadEncoder, handleStart, handleStartPlix, handleStop, handleStopPlix, status, running, detecting, isFewShot])
+  }, [commandRef, hasProvision, handleLoad, handleProvisionLoad, handleStart, handleProvisionStart, handleStop, handleProvisionStop, status, running, detecting])
 
   const updateConfig = useCallback((patch: Partial<KWSConfig>) => {
     setConfig((prev) => {
@@ -787,6 +849,13 @@ export const KWSPanel = memo(function KWSPanel({
   }, [config.backend, config.threshold])
 
   const canStart = status === 'ready' && afeRunning && !running
+  // The prototype payload of the current artifact (narrowed). Undefined when
+  // the artifact is absent or not a prototype kind - keeps the enrollment JSX
+  // generic over the artifact type (ADR-033).
+  const artifactProto =
+    artifact && artifact.artifact.kind === 'prototype'
+      ? artifact.artifact.payload
+      : undefined
 
   return (
     <section className="space-y-6">
@@ -836,13 +905,13 @@ export const KWSPanel = memo(function KWSPanel({
             <h3 className="text-sm font-semibold text-ink-1">Engine</h3>
             <span className="text-xs text-ink-3">
               {selectedBackend?.label ?? config.backend} ·{' '}
-              {status === 'ready' && !isFewShot
+              {status === 'ready' && !hasProvision
                 ? `${executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}`
                 : status}
             </span>
           </div>
           <div className="flex items-center gap-2">
-            {!isFewShot && status === 'idle' && (
+            {!hasProvision && status === 'idle' && (
               <button
                 onClick={handleLoad}
                 className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-400"
@@ -850,7 +919,7 @@ export const KWSPanel = memo(function KWSPanel({
                 Load models
               </button>
             )}
-            {!isFewShot && (status === 'ready' || status === 'error') && (
+            {!hasProvision && (status === 'ready' || status === 'error') && (
               <button
                 onClick={handleLoad}
                 className="rounded-lg bg-surface-3 px-4 py-2 text-sm font-medium text-ink-2 transition-colors hover:bg-surface-4"
@@ -858,16 +927,16 @@ export const KWSPanel = memo(function KWSPanel({
                 Reload models
               </button>
             )}
-            {isFewShot && status !== 'ready' && status !== 'running' && !detecting && (
+            {hasProvision && status !== 'ready' && status !== 'running' && !detecting && (
               <button
-                onClick={handleLoadEncoder}
+                onClick={handleProvisionLoad}
                 disabled={status === 'loading'}
                 className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
               >
                 {status === 'loading' ? 'Loading…' : loadActionLabel(selectedBackend)}
               </button>
             )}
-            {!isFewShot && canStart && (
+            {!hasProvision && canStart && (
               <button
                 onClick={handleStart}
                 className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-emerald-500"
@@ -875,7 +944,7 @@ export const KWSPanel = memo(function KWSPanel({
                 Start detection
               </button>
             )}
-            {!isFewShot && running && (
+            {!hasProvision && running && (
               <button
                 onClick={handleStop}
                 className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-red-500"
@@ -883,21 +952,21 @@ export const KWSPanel = memo(function KWSPanel({
                 Stop detection
               </button>
             )}
-            {isFewShot && prototype && !detecting && (
+            {hasProvision && artifact && !detecting && (
               <button
-                onClick={handleStartPlix}
+                onClick={handleProvisionStart}
                 disabled={!afeRunning}
                 className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500 disabled:opacity-50"
               >
-                Start Few-Shot detection
+                {provisionActionLabel(config.backend, 'start') ?? 'Start detection'}
               </button>
             )}
-            {isFewShot && detecting && (
+            {hasProvision && detecting && (
               <button
-                onClick={handleStopPlix}
+                onClick={handleProvisionStop}
                 className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-red-500"
               >
-                Stop Few-Shot detection
+                {provisionActionLabel(config.backend, 'stop') ?? 'Stop detection'}
               </button>
             )}
           </div>
@@ -908,7 +977,7 @@ export const KWSPanel = memo(function KWSPanel({
           {status === 'loading' && (
             <span className="text-ink-2">Loading models…</span>
           )}
-          {status === 'ready' && !isFewShot && !afeRunning && (
+          {status === 'ready' && !hasProvision && !afeRunning && (
             <span className="text-warning">
               Start the AFE microphone first
             </span>
@@ -918,16 +987,16 @@ export const KWSPanel = memo(function KWSPanel({
               Warming up… (collecting ~2 s of audio context)
             </span>
           )}
-          {status === 'ready' && !isFewShot && (
+          {status === 'ready' && !hasProvision && (
             <span>Models loaded · EP: {executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}</span>
           )}
-          {status === 'ready' && isFewShot && (
+          {status === 'ready' && hasProvision && (
             <span className="text-ink-2">Encoder loaded — record samples to enroll</span>
           )}
-          {isFewShot && detecting && (
-            <span className="text-ink-2">Few-Shot detection running</span>
+          {hasProvision && detecting && (
+            <span className="text-ink-2">Detection running</span>
           )}
-          {error && status === 'error' && !isFewShot && (
+          {error && status === 'error' && !hasProvision && (
             <span className="text-danger">Load failed — check the registry / assets</span>
           )}
         </div>
@@ -1138,13 +1207,14 @@ export const KWSPanel = memo(function KWSPanel({
       {/* plixkws enrollment + detection (Few-Shot, Phase 3) - inline in the KWS
           panel; the standalone Few-Shot panel was merged here. The encoder
           variant + runtime are the plix driver's spec params (ADR-025). */}
-      {isFewShot && (
+      {hasProvision && (
         <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-4">
             <h3 className="text-sm font-semibold text-ink-1">
-              Few-Shot enrollment{' '}
+              Provisioning{' '}
               <span className="text-xs font-normal text-ink-3">
-                (Phase 3 · enroll a custom wake word, then detect)
+                (enroll a custom wake word, then detect — driven by the backend's
+                provisioning capability, ADR-033)
               </span>
             </h3>
           </div>
@@ -1156,9 +1226,9 @@ export const KWSPanel = memo(function KWSPanel({
             </p>
           )}
 
-          {/* plix driver config (ADR-025): the encoder/runtime params from the
-              plix driver spec, rendered via module-kit controls. The enrollment
-              flow below consumes these values via driverValues. */}
+          {/* Driver config (ADR-025): the driver's own params from its
+              registration spec, rendered via module-kit controls. The
+              provisioning flow below consumes these values via driverValues. */}
           {driverParams.length > 0 && !detecting && (
             <div className="space-y-1 border-t border-line pt-3">
               <div className="text-[11px] font-medium uppercase tracking-widest text-ink-3">
@@ -1186,7 +1256,9 @@ export const KWSPanel = memo(function KWSPanel({
                   disabled={recording}
                   className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500 disabled:opacity-50"
                 >
-                  {recording ? `Recording… (${RECORD_MS}ms)` : 'Record sample'}
+                  {recording
+                    ? `Recording… (${RECORD_MS}ms)`
+                    : (provisionActionLabel(config.backend, 'record') ?? 'Record sample')}
                 </button>
                 {samples.length >= MIN_SAMPLES && (
                   <button
@@ -1194,7 +1266,9 @@ export const KWSPanel = memo(function KWSPanel({
                     disabled={building}
                     className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
                   >
-                    {building ? 'Building…' : `Build prototype (${samples.length} samples)`}
+                    {building
+                      ? 'Building…'
+                      : `${provisionActionLabel(config.backend, 'enroll') ?? 'Build prototype'} (${samples.length} samples)`}
                   </button>
                 )}
                 {samples.length > 0 && (
@@ -1220,10 +1294,10 @@ export const KWSPanel = memo(function KWSPanel({
                 </div>
               )}
 
-              {prototype && (
+              {artifactProto && (
                 <div className="space-y-2">
                   <p className="text-xs text-success">
-                    Prototype built: {prototype.word} ({prototype.vector.length}-dim
+                    Prototype built: {artifactProto.word} ({artifactProto.vector.length}-dim
                     vector). Ready for detection.
                   </p>
                   {!afeRunning && (
@@ -1247,7 +1321,7 @@ export const KWSPanel = memo(function KWSPanel({
                       (optional — other words / background, for open-set rejection)
                     </span>
                   </h4>
-                  {prototype?.negativeVector && (
+                  {artifactProto?.negativeVector && (
                     <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300">
                       enrolled
                     </span>
@@ -1261,7 +1335,7 @@ export const KWSPanel = memo(function KWSPanel({
                   >
                     {recordingNeg ? `Recording… (${RECORD_MS}ms)` : 'Record non-target sample'}
                   </button>
-                  {negSamples.length >= MIN_SAMPLES && prototype && (
+                  {negSamples.length >= MIN_SAMPLES && artifactProto && (
                     <button
                       onClick={handleBuildNegative}
                       disabled={buildingNeg}
@@ -1269,9 +1343,9 @@ export const KWSPanel = memo(function KWSPanel({
                     >
                       {buildingNeg
                         ? 'Building…'
-                        : prototype.negativeVector
+                        : artifactProto.negativeVector
                           ? 'Re-enroll negative prototype'
-                          : `Build negative prototype (${negSamples.length} samples)`}
+                          : `${provisionActionLabel(config.backend, 'enroll-negative') ?? 'Build negative prototype'} (${negSamples.length} samples)`}
                     </button>
                   )}
                   {negSamples.length > 0 && (
@@ -1280,7 +1354,7 @@ export const KWSPanel = memo(function KWSPanel({
                     </span>
                   )}
                 </div>
-                {prototype && !prototype.negativeVector && negSamples.length === 0 && (
+                {artifactProto && !artifactProto.negativeVector && negSamples.length === 0 && (
                   <p className="text-[10px] text-ink-3">
                     Say other words you don't want to trigger on (e.g. "hello", "hi",
                     background conversation) — the detector then scores them against this
@@ -1325,9 +1399,10 @@ export const KWSPanel = memo(function KWSPanel({
             </div>
           )}
 
-          {/* Few-Shot detection params (from the few-shot module's spec) - shown
-              once a prototype exists so the user can tune before/while running. */}
-          {prototype && (
+          {/* Detection params (from the few-shot module's spec) - shown
+              once a prototype artifact exists so the user can tune
+              before/while running. */}
+          {artifactProto && (
             <div className="space-y-1 border-t border-line pt-3">
               <div className="text-[11px] font-medium uppercase tracking-widest text-ink-3">
                 Few-Shot detection parameters
@@ -1358,7 +1433,7 @@ export const KWSPanel = memo(function KWSPanel({
           §4.1). Rendered whenever a backend is selected (even before load): the
           params come from the specs, not from the engine state, so they are
           editable up front and applied on the next Load. */}
-      {!isFewShot && (
+      {!hasProvision && (
         <div className="space-y-3">
           <h3 className="mb-4 text-sm font-semibold text-ink-1">
             Configuration{' '}

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -412,6 +412,10 @@ export const KWSPanel = memo(function KWSPanel({
   const selectedBackend = getBackendRegistry().find((r) => r.id === config.backend)
   const provision = selectedBackend?.provision
   const hasProvision = Boolean(provision)
+  // Which provisioning kind the selected backend declares: 'prototype'
+  // (enrollment UI) vs 'list' (keyword-list editor). The panel renders the
+  // matching section; a new kind needs one branch here, never per-driver code.
+  const provisionKind = provision?.kind
   // Model-source roles come from the backend's registration (ADR-024): each
   // driver declares the roles it consumes. asr-decoding (sherpa-onnx-kws)
   // bundles its model into the wasm .data package and only takes a keyword
@@ -532,6 +536,43 @@ export const KWSPanel = memo(function KWSPanel({
       setStatus('error')
     }
   }, [ensureFsEngines, resolveModelUrlsFor, config.backend])
+
+  /**
+   * List-kind load (ADR-033): produce the keyword-list artifact from the
+   * driver's keywords param, then load through apply() -> backendConfig
+   * (merged with the live driver values, e.g. threshold).
+   */
+  const handleListLoad = useCallback(async () => {
+    setError(null)
+    const cap = provision
+    if (!cap || cap.kind !== 'list') {
+      throw new Error('This backend has no keyword-list provisioning capability.')
+    }
+    const engine = engineRef.current!
+    try {
+      setStatus('loading')
+      const produced = await cap.produce({
+        keywords: String(driverValues.keywords ?? ''),
+      })
+      const applied = cap.apply(produced)
+      engine.setConfig({ backend: config.backend, threshold: config.threshold })
+      const urls = applied.urls ?? (await resolveModelUrlsFor(config.backend))
+      // The applied keyword list + the driver's live values (threshold) ride
+      // in backendConfig, consumed by the backend's configure().
+      const backendConfig = {
+        ...applied.backendConfig,
+        ...driverValues,
+      }
+      await engine.load(urls, undefined, backendConfig)
+      setStatus(engine.status)
+      setExecutionProvider(engine.executionProvider)
+      logInfo('kws', `Keyword list loaded (backend: ${config.backend})`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setStatus('error')
+      logError('kws', err instanceof Error ? err.message : String(err))
+    }
+  }, [provision, driverValues, config.backend, config.threshold, resolveModelUrlsFor])
 
   /** Record a 1.5 s sample from the mic at 16 kHz into the given bucket
    *  ('pos' = wake word samples, 'neg' = other-speech/background samples for
@@ -770,20 +811,30 @@ export const KWSPanel = memo(function KWSPanel({
   // its own Load/Reload buttons.
   //
   // Dispatch on the backend's provisioning capability (ADR-033), not on its
-  // category: a provisioning backend (plixkws today, any future enrollment or
-  // keyword-list driver) boots WITH its produced artifact, so it needs its
-  // own load/start/stop. Traditional backends keep the plain load/start/stop.
-  // Adding a provisioning driver never edits this dispatch.
+  // category: a provisioning backend boots WITH its produced artifact, so it
+  // needs its own load/start/stop per kind. prototype-kind (plixkws today)
+  // loads the encoder + starts with the artifact; list-kind (sherpa today)
+  // loads with the keyword-list artifact but uses the plain start/stop.
+  // Traditional backends keep the plain load/start/stop. Adding a
+  // provisioning driver never edits this dispatch.
   useEffect(() => {
     if (commandRef) {
       commandRef.current = {
-        load: hasProvision ? handleProvisionLoad : handleLoad,
-        start: hasProvision ? handleProvisionStart : handleStart,
-        stop: hasProvision ? handleProvisionStop : handleStop,
+        load: !hasProvision
+          ? handleLoad
+          : provisionKind === 'list'
+            ? handleListLoad
+            : handleProvisionLoad,
+        start: !hasProvision || provisionKind === 'list'
+          ? handleStart
+          : handleProvisionStart,
+        stop: !hasProvision || provisionKind === 'list'
+          ? handleStop
+          : handleProvisionStop,
         getState: () => ({ status, running: running || detecting, hasProvision }),
       }
     }
-  }, [commandRef, hasProvision, handleLoad, handleProvisionLoad, handleStart, handleProvisionStart, handleStop, handleProvisionStop, status, running, detecting])
+  }, [commandRef, hasProvision, provisionKind, handleLoad, handleListLoad, handleProvisionLoad, handleStart, handleProvisionStart, handleStop, handleProvisionStop, status, running, detecting])
 
   const updateConfig = useCallback((patch: Partial<KWSConfig>) => {
     setConfig((prev) => {
@@ -905,29 +956,33 @@ export const KWSPanel = memo(function KWSPanel({
             <h3 className="text-sm font-semibold text-ink-1">Engine</h3>
             <span className="text-xs text-ink-3">
               {selectedBackend?.label ?? config.backend} ·{' '}
-              {status === 'ready' && !hasProvision
+              {status === 'ready' && provisionKind !== 'prototype'
                 ? `${executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}`
                 : status}
             </span>
           </div>
           <div className="flex items-center gap-2">
-            {!hasProvision && status === 'idle' && (
+            {provisionKind !== 'prototype' && status === 'idle' && (
               <button
-                onClick={handleLoad}
+                onClick={provisionKind === 'list' ? handleListLoad : handleLoad}
                 className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-400"
               >
-                Load models
+                {provisionKind === 'list'
+                  ? (provisionActionLabel(config.backend, 'load-with-list') ?? 'Load')
+                  : 'Load models'}
               </button>
             )}
-            {!hasProvision && (status === 'ready' || status === 'error') && (
+            {provisionKind !== 'prototype' && (status === 'ready' || status === 'error') && (
               <button
-                onClick={handleLoad}
+                onClick={provisionKind === 'list' ? handleListLoad : handleLoad}
                 className="rounded-lg bg-surface-3 px-4 py-2 text-sm font-medium text-ink-2 transition-colors hover:bg-surface-4"
               >
-                Reload models
+                {provisionKind === 'list'
+                  ? (provisionActionLabel(config.backend, 'load-with-list') ?? 'Reload')
+                  : 'Reload models'}
               </button>
             )}
-            {hasProvision && status !== 'ready' && status !== 'running' && !detecting && (
+            {provisionKind === 'prototype' && status !== 'ready' && status !== 'running' && !detecting && (
               <button
                 onClick={handleProvisionLoad}
                 disabled={status === 'loading'}
@@ -936,7 +991,7 @@ export const KWSPanel = memo(function KWSPanel({
                 {status === 'loading' ? 'Loading…' : loadActionLabel(selectedBackend)}
               </button>
             )}
-            {!hasProvision && canStart && (
+            {provisionKind !== 'prototype' && canStart && (
               <button
                 onClick={handleStart}
                 className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-emerald-500"
@@ -944,7 +999,7 @@ export const KWSPanel = memo(function KWSPanel({
                 Start detection
               </button>
             )}
-            {!hasProvision && running && (
+            {provisionKind !== 'prototype' && running && (
               <button
                 onClick={handleStop}
                 className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-red-500"
@@ -952,7 +1007,7 @@ export const KWSPanel = memo(function KWSPanel({
                 Stop detection
               </button>
             )}
-            {hasProvision && artifact && !detecting && (
+            {provisionKind === 'prototype' && artifact && !detecting && (
               <button
                 onClick={handleProvisionStart}
                 disabled={!afeRunning}
@@ -961,7 +1016,7 @@ export const KWSPanel = memo(function KWSPanel({
                 {provisionActionLabel(config.backend, 'start') ?? 'Start detection'}
               </button>
             )}
-            {hasProvision && detecting && (
+            {provisionKind === 'prototype' && detecting && (
               <button
                 onClick={handleProvisionStop}
                 className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-red-500"
@@ -977,7 +1032,7 @@ export const KWSPanel = memo(function KWSPanel({
           {status === 'loading' && (
             <span className="text-ink-2">Loading models…</span>
           )}
-          {status === 'ready' && !hasProvision && !afeRunning && (
+          {status === 'ready' && provisionKind !== 'prototype' && !afeRunning && (
             <span className="text-warning">
               Start the AFE microphone first
             </span>
@@ -987,16 +1042,16 @@ export const KWSPanel = memo(function KWSPanel({
               Warming up… (collecting ~2 s of audio context)
             </span>
           )}
-          {status === 'ready' && !hasProvision && (
+          {status === 'ready' && provisionKind !== 'prototype' && (
             <span>Models loaded · EP: {executionProvider === 'webgpu' ? 'WebGPU' : 'WASM'}</span>
           )}
-          {status === 'ready' && hasProvision && (
+          {status === 'ready' && provisionKind === 'prototype' && (
             <span className="text-ink-2">Encoder loaded — record samples to enroll</span>
           )}
-          {hasProvision && detecting && (
+          {provisionKind === 'prototype' && detecting && (
             <span className="text-ink-2">Detection running</span>
           )}
-          {error && status === 'error' && !hasProvision && (
+          {error && status === 'error' && provisionKind !== 'prototype' && (
             <span className="text-danger">Load failed — check the registry / assets</span>
           )}
         </div>
@@ -1204,22 +1259,25 @@ export const KWSPanel = memo(function KWSPanel({
           }
       </div>
 
-      {/* plixkws enrollment + detection (Few-Shot, Phase 3) - inline in the KWS
-          panel; the standalone Few-Shot panel was merged here. The encoder
-          variant + runtime are the plix driver's spec params (ADR-025). */}
+      {/* Provisioning (ADR-033) - the selected backend produces the wake-word
+          artifact it loads with (enrolled prototype for plixkws, keyword list
+          for sherpa). The section is kind-driven: driver params + the
+          capability's own panel; no per-driver code paths. */}
       {hasProvision && (
         <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-4">
             <h3 className="text-sm font-semibold text-ink-1">
               Provisioning{' '}
               <span className="text-xs font-normal text-ink-3">
-                (enroll a custom wake word, then detect — driven by the backend's
-                provisioning capability, ADR-033)
+                {provisionKind === 'list'
+                  ? '(keyword-list backend — edit the wake words below, then load with the list)'
+                  : '(enroll a custom wake word, then detect)'}
+                {' '}· ADR-033
               </span>
             </h3>
           </div>
 
-          {status === 'error' && !detecting && (
+          {provisionKind === 'prototype' && status === 'error' && !detecting && (
             <p className="text-sm text-danger">
               Encoder load failed: {error} — check the encoder variant/runtime
               or the exported model assets.
@@ -1227,8 +1285,10 @@ export const KWSPanel = memo(function KWSPanel({
           )}
 
           {/* Driver config (ADR-025): the driver's own params from its
-              registration spec, rendered via module-kit controls. The
-              provisioning flow below consumes these values via driverValues. */}
+              registration spec, rendered via module-kit controls. For plixkws
+              these are the encoder variant/runtime; for sherpa the keyword
+              list + threshold. The provisioning flow below consumes these
+              values via driverValues. */}
           {driverParams.length > 0 && !detecting && (
             <div className="space-y-1 border-t border-line pt-3">
               <div className="text-[11px] font-medium uppercase tracking-widest text-ink-3">
@@ -1248,7 +1308,23 @@ export const KWSPanel = memo(function KWSPanel({
             </div>
           )}
 
-          {status === 'ready' && !detecting && (
+          {provisionKind === 'list' && (
+            <div className="space-y-1 border-t border-line pt-3">
+              <p className="text-xs text-ink-3">
+                The keyword list above is the wake-word artifact (ADR-033):
+                {' '}
+                {(() => {
+                  const text = String(driverValues.keywords ?? '')
+                  const count = text.split('\n').filter((l) => l.trim()).length
+                  return count > 0
+                    ? `${count} wake word(s) will be loaded with the keyword-list artifact.`
+                    : 'enter at least one wake word to load.'
+                })()}
+              </p>
+            </div>
+          )}
+
+          {provisionKind === 'prototype' && status === 'ready' && !detecting && (
             <div className="space-y-4">
               <div className="flex flex-wrap items-center gap-3">
                 <button
@@ -1380,7 +1456,7 @@ export const KWSPanel = memo(function KWSPanel({
             </div>
           )}
 
-          {detecting && (
+          {provisionKind === 'prototype' && detecting && (
             <div className="space-y-2 border-t border-line pt-3">
               <div className="mb-2 flex items-center justify-between text-xs text-ink-3">
                 <span>Few-Shot score curve (prototype-distance similarity)</span>
@@ -1402,7 +1478,7 @@ export const KWSPanel = memo(function KWSPanel({
           {/* Detection params (from the few-shot module's spec) - shown
               once a prototype artifact exists so the user can tune
               before/while running. */}
-          {artifactProto && (
+          {provisionKind === 'prototype' && artifactProto && (
             <div className="space-y-1 border-t border-line pt-3">
               <div className="text-[11px] font-medium uppercase tracking-widest text-ink-3">
                 Few-Shot detection parameters
@@ -1430,10 +1506,11 @@ export const KWSPanel = memo(function KWSPanel({
       )}
 
       {/* Config panel (ADR-017) - dual-layer: Primary + Advanced (kws-categories
-          §4.1). Rendered whenever a backend is selected (even before load): the
-          params come from the specs, not from the engine state, so they are
-          editable up front and applied on the next Load. */}
-      {!hasProvision && (
+          §4.1). Rendered for traditional + list-kind backends (prototype-kind
+          config lives in its provisioning section): the params come from the
+          specs, not from the engine state, so they are editable up front and
+          applied on the next Load. */}
+      {provisionKind !== 'prototype' && (
         <div className="space-y-3">
           <h3 className="mb-4 text-sm font-semibold text-ink-1">
             Configuration{' '}
@@ -1443,8 +1520,10 @@ export const KWSPanel = memo(function KWSPanel({
           </h3>
 
           {/* Driver params from the selected backend's registration spec
-              (ADR-025) - flat rows, no nested panel (epic #53 UX). */}
-          {driverParams.length > 0 && (
+              (ADR-025) - flat rows, no nested panel (epic #53 UX). Rendered
+              here only for non-provisioning backends; provisioning backends
+              show them in the provisioning section. */}
+          {!hasProvision && driverParams.length > 0 && (
             <div className="mt-3 border-t border-line pt-3">
               <div className="mb-1 text-xs font-semibold uppercase tracking-widest text-ink-3">
                 {config.backend} driver

--- a/apps/web/src/model-library/__tests__/store.test.ts
+++ b/apps/web/src/model-library/__tests__/store.test.ts
@@ -130,4 +130,45 @@ describe('user model library store', () => {
     const all = await listUserModels()
     expect(all).toHaveLength(0)
   })
+
+  it('stores provisioned artifacts alongside models (ADR-033)', async () => {
+    const { importModelFile, saveProvisionArtifact, listProvisionArtifacts, listUserModels } =
+      await freshStore()
+    await importModelFile(FILE, 'classifier')
+    const saved = await saveProvisionArtifact(
+      {
+        kind: 'prototype',
+        backendId: 'plixkws',
+        payload: {
+          id: 'p1',
+          word: 'hey-buddy',
+          vector: [1, 2, 3],
+          sampleIds: ['s1', 's2'],
+          createdAtMs: Date.now(),
+        },
+      },
+      { name: 'hey-buddy' },
+    )
+    expect(saved.kind).toBe('artifact')
+    expect(saved.artifactType).toBe('prototype')
+    expect(saved.id).toMatch(/^artifact-/)
+
+    // One browsable collection: both the model and the artifact are listed.
+    const artifacts = await listProvisionArtifacts()
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0].artifact.kind).toBe('prototype')
+    // Models are not artifacts (and legacy entries without kind are models).
+    expect(await listUserModels()).toHaveLength(1)
+  })
+
+  it('deletes a provisioned artifact', async () => {
+    const { saveProvisionArtifact, deleteProvisionArtifact, listProvisionArtifacts } =
+      await freshStore()
+    const saved = await saveProvisionArtifact(
+      { kind: 'list', backendId: 'sherpa-onnx-kws', payload: { keywords: 'x iǎo ài tóng xué @test' } },
+      { name: 'test-keywords' },
+    )
+    await deleteProvisionArtifact(saved.id)
+    expect(await listProvisionArtifacts()).toHaveLength(0)
+  })
 })

--- a/apps/web/src/model-library/index.ts
+++ b/apps/web/src/model-library/index.ts
@@ -2,7 +2,8 @@
  * User model library - index.
  *
  * IndexedDB-backed store for user-supplied KWS models (local file imports and
- * future training artifacts). See store.ts for the full contract.
+ * future training artifacts) AND provisioned artifacts (enrolled prototypes
+ * today; ADR-033) - one browsable collection.
  */
 
 export {
@@ -11,5 +12,9 @@ export {
   deleteUserModel,
   exportUserModel,
   blobUrlForModel,
+  saveProvisionArtifact,
+  listProvisionArtifacts,
+  getProvisionArtifact,
+  deleteProvisionArtifact,
 } from './store'
-export type { UserModel } from './store'
+export type { UserModel, UserArtifact } from './store'

--- a/apps/web/src/model-library/store.ts
+++ b/apps/web/src/model-library/store.ts
@@ -17,11 +17,15 @@
  * a model can be moved to another machine or re-imported.
  */
 
+import type { ProvisionArtifact, ProvisionKind } from '@wake-studio/contracts'
+
 const DB_NAME = 'wake-studio-user-models'
 const DB_VERSION = 1
 const MODEL_STORE = 'models'
 
 export interface UserModel {
+  /** Legacy entries (pre-ADR-033) have no kind; treated as models. */
+  kind?: 'model'
   id: string
   /** Role this model was imported for (classifier / melspectrogram / ...). */
   role: string
@@ -92,10 +96,13 @@ export async function importModelFile(
   return model
 }
 
-/** List all stored user models. */
+/** List all stored user models (artifacts excluded - they are provisioned
+ *  artifacts, not importable model binaries). */
 export async function listUserModels(): Promise<UserModel[]> {
-  const all = await tx<UserModel[]>('readonly', (s) => s.getAll())
-  return (all as UserModel[]).sort((a, b) => b.createdAtMs - a.createdAtMs)
+  const all = await tx<unknown[]>('readonly', (s) => s.getAll())
+  return (all as Array<UserModel | UserArtifact>)
+    .filter((e): e is UserModel => e.kind !== 'artifact')
+    .sort((a, b) => b.createdAtMs - a.createdAtMs)
 }
 
 /** Delete a stored user model. */
@@ -147,4 +154,77 @@ export async function blobUrlForModel(id: string): Promise<string | null> {
   const model = await tx<UserModel | undefined>('readonly', (s) => s.get(id))
   if (!model) return null
   return URL.createObjectURL(model.blob)
+}
+
+// ---------------------------------------------------------------------------
+// Provisioned artifacts (ADR-033).
+//
+// The same library that holds imported models also holds provisioning
+// artifacts (enrolled prototypes today; keyword lists and trained classifiers
+// later) so they are one browsable collection. Entries are plain JSON
+// (structured-clone-able: number[] vectors, no Float32Array/Blob), so they
+// share the existing 'models' object store without a schema bump - entries
+// without a `kind` are legacy models.
+// ---------------------------------------------------------------------------
+
+/** A provisioned artifact stored in the user library (ADR-033). */
+export interface UserArtifact {
+  kind: 'artifact'
+  id: string
+  /** Which provisioning kind produced it ('prototype' | 'list' | 'train'). */
+  artifactType: ProvisionKind
+  /** The backend this artifact provisions (e.g. 'plixkws'). */
+  backendId: string
+  /** Display name (e.g. the enrolled wake word). */
+  name: string
+  /** Approximate size in bytes of the serialized payload. */
+  sizeBytes: number
+  createdAtMs: number
+  notes?: string
+  /** The serialized artifact (contracts provisioning payload). */
+  artifact: ProvisionArtifact
+}
+
+/** Persist a provisioned artifact into the shared user library. */
+export async function saveProvisionArtifact(
+  artifact: ProvisionArtifact,
+  meta: { name: string; notes?: string },
+): Promise<UserArtifact> {
+  const entry: UserArtifact = {
+    kind: 'artifact',
+    id: `artifact-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    artifactType: artifact.kind,
+    backendId: artifact.backendId,
+    name: meta.name,
+    sizeBytes: JSON.stringify(artifact).length,
+    createdAtMs: Date.now(),
+    notes: meta.notes,
+    artifact,
+  }
+  await tx('readwrite', (s) => s.put(entry))
+  return entry
+}
+
+/** List all stored provisioning artifacts (newest first). */
+export async function listProvisionArtifacts(): Promise<UserArtifact[]> {
+  const all = await tx<unknown[]>('readonly', (s) => s.getAll())
+  return (all as Array<UserArtifact | UserModel>)
+    .filter((e): e is UserArtifact => e.kind === 'artifact')
+    .sort((a, b) => b.createdAtMs - a.createdAtMs)
+}
+
+/** Look up one stored provisioning artifact. */
+export async function getProvisionArtifact(
+  id: string,
+): Promise<UserArtifact | undefined> {
+  const entry = await tx<UserArtifact | UserModel | undefined>(
+    'readonly',
+    (s) => s.get(id),
+  )
+  return entry && entry.kind === 'artifact' ? (entry as UserArtifact) : undefined
+}
+
+/** Delete a stored provisioning artifact. */
+export async function deleteProvisionArtifact(id: string): Promise<void> {
+  await tx('readwrite', (s) => s.delete(id))
 }

--- a/apps/web/src/workspace/__tests__/pipelineOrchestrator.test.ts
+++ b/apps/web/src/workspace/__tests__/pipelineOrchestrator.test.ts
@@ -48,7 +48,7 @@ function makeKws(initialStatus = 'idle'): PanelCommands & {
       running = false
       calls.stops++
     },
-    getState: () => ({ status, running, isFewShot: false }),
+    getState: () => ({ status, running, hasProvision: false }),
     calls,
   }
   return commands

--- a/apps/web/src/workspace/kws-config.ts
+++ b/apps/web/src/workspace/kws-config.ts
@@ -13,7 +13,7 @@ import { normalizeSelectOptions } from '@wake-studio/module-kit'
 import type { BackendModelUrls } from '@wake-studio/module-kws-engine'
 import type { ParameterDescriptor } from '@wake-studio/module-afe-graph'
 import type { ModelRegistry } from '@wake-studio/platform'
-import type { ModuleSpec, ModuleParam } from '@wake-studio/contracts'
+import type { ModuleSpec, ModuleParam, ModuleAction } from '@wake-studio/contracts'
 
 /**
  * Normalize a spec param's `options` into the panel's `{value,label}` shape.
@@ -71,6 +71,23 @@ export function loadActionLabel(
     (a) => a.kind === 'load',
   )
   return action?.label ?? 'Load models'
+}
+
+/** Actions declared by a backend's provisioning spec (ADR-033). */
+export function provisionActionsFor(
+  backendId: string,
+): ReadonlyArray<ModuleAction> {
+  const reg = getBackendRegistry().find((r) => r.id === backendId)
+  const spec = reg?.provision?.spec as ModuleSpec | undefined
+  return spec?.actions ?? []
+}
+
+/** Label for a provisioning action by id (ADR-033); generic fallback. */
+export function provisionActionLabel(
+  backendId: string,
+  actionId: string,
+): string | undefined {
+  return provisionActionsFor(backendId).find((a) => a.id === actionId)?.label
 }
 
 /** Resolve the three openwakeword model roles from a registry, or a remote

--- a/apps/web/src/workspace/pipelineOrchestrator.ts
+++ b/apps/web/src/workspace/pipelineOrchestrator.ts
@@ -45,7 +45,7 @@ export async function runPipelineStart(
   // 2. KWS if enabled + available.
   if (!flags.kwsEnabled || !kws) return { ok: true }
 
-  const kwsState = kws.getState?.() ?? { status: 'idle', running: false, isFewShot: false }
+  const kwsState = kws.getState?.() ?? { status: 'idle', running: false, hasProvision: false }
 
   // Auto-load when preload is ON and the engine is not ready yet.
   let kwsLoaded = false

--- a/apps/web/src/workspace/usePipelineRunner.ts
+++ b/apps/web/src/workspace/usePipelineRunner.ts
@@ -31,7 +31,7 @@ export interface PanelCommands {
   /** KWS-specific: load models. */
   load?: () => Promise<void>
   /** KWS-specific: read current engine state. */
-  getState?: () => { status: string; running: boolean; isFewShot: boolean }
+  getState?: () => { status: string; running: boolean; hasProvision: boolean }
 }
 
 export type PipelinePhase =

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -394,7 +394,8 @@ package and offers to train a clean replacement instead.
   ADR-020 (pluggable KWS backends), ADR-021 (device-side SDK), ADR-022 (data-source
   layer), ADR-023 (Colab backend), ADR-024 (3-category KWS taxonomy + decoupling
   rule + unified panel spec), ADR-025 (module platform + monorepo), ADR-026
-  (testing layers), ADR-027 (build-artifact SOP), ADR-028 (uv for train scripts);
+  (testing layers), ADR-027 (build-artifact SOP), ADR-028 (uv for train scripts),
+  ADR-032 (shared DSP package), ADR-033 (provisioning capability);
   ADR-013 amended (in-browser training removed, Cloud Providers unified, Colab
   added) and ADR-011 amended (asset pre-fetch).
 - **License matrix:** `LICENSES.md`.

--- a/docs/modules/few-shot.md
+++ b/docs/modules/few-shot.md
@@ -5,10 +5,11 @@
 - **Plan phase:** Phase 3
 - **Related ADRs:** ADR-002 (PLiX Few-Shot encoder), ADR-013 (enrollment is client-side,
   not training), ADR-017 (config panel), ADR-020 (EmbedProvider/KWSBackend),
-  ADR-021 (device SDK shares the interface)
+  ADR-021 (device SDK shares the interface), ADR-033 (provisioning capability)
 - **Depends on (modules):** KWS (`embed(audio)` scaffold + `PlixKwsEmbedProvider`),
-  AFE (16 kHz output stream for live detection); consumes `WakeWordPrototype` +
-  scoring from the plix driver (single source of truth)
+  AFE (16 kHz output stream for live detection); owns `WakeWordPrototype` +
+  scoring primitives (ADR-033 inversion - moved out of the plix driver so any
+  enrollment/training driver can produce the same artifact type)
 - **Last updated:** 2026-08-05
 - **Last updated:** 2026-07-28
 
@@ -87,7 +88,7 @@ export interface SampleQuality {
   acceptable: boolean   // overall pass/fail
 }
 
-/** A stored wake-word prototype. */
+/** A stored wake-word prototype (owned by this module, ADR-033). */
 export interface WakeWordPrototype {
   id: string
   word: string
@@ -273,6 +274,7 @@ unchanged.
 |---|---|---|
 | 2026-08-10 | Negative-prototype enrollment UI + plumbing (issue #69): record non-target samples in the KWS panel, mean-pool into a negativeVector attached to the wake-word prototype, auto-enable useNegativePrototype. Engine carries prototypeNegative through the worker load message into initWithPrototype; scoring is relative (word vs negative class) so other speech scores low. | agent |
 | 2026-08-10 | Recalibrate default threshold 0.7 -> 0.9 (issue #69). 0.7 predated the #66 normalization fix when all scores were ~0.24; post-#66 real speech scores 0.78-0.96, so the old default made the wake word fire on ANY speech. Verified with real speech: enrolled word 0.92-1.0 vs other words 0.78-0.89. | agent |
+| 2026-08-11 | ADR-033: `WakeWordPrototype` + scoring primitives moved INTO this module (from the plix driver) so any enrollment/training driver can produce the same artifact type; serialize helpers (`serializePrototype`/`deserializePrototype`/`uid`) exported; prototype persistence moves host-side (user artifact library); sample store stays module-owned. | agent |
 | 2026-08-10 | Add silence gate to PLiX detection (issue #66 follow-up): windows at/below `silenceFloorDbfs` (-45 dBFS RMS default) score 0 and skip the encoder. The model maps silence/background to a cosine-similar spot near the prototype (score ~0.7+ with no input after the normalization fix), so energy gating is required to avoid false triggers. Tunable via the Few-Shot config surface. | agent |
 | 2026-08-10 | Fix PLiX never triggering (issue #66): L2-normalize query + prototype before squared-Euclidean scoring (raw GAP embeddings have L2 norm ~4-5, so un-normalized d^2 ~3-4 even for a 0.92-cosine match -> score ~0.24, unreachable). Normalized d^2 = 2(1-cos) is well-calibrated; also wire the Few-Shot panel threshold/VAD/min-duration into the engine trigger config instead of KWS defaults. | agent |
 | 2026-07-27 | Initial draft (docs-first, pending human review). | agent |

--- a/docs/modules/kws.md
+++ b/docs/modules/kws.md
@@ -436,6 +436,28 @@ All parameters are surfaced in the **Studio config panel** with the defaults bel
 
 All Phase 2 open questions are resolved (ADR-018); the contract is locked.
 
+- **[ADR-033] Provisioning capability (one abstract wake-word artifact flow).**
+  Producing "the wake-word artifact a backend needs" (enrolled prototype /
+  keyword list / trained classifier) is one abstract behavior with different
+  input collection per driver. `KWSBackendRegistration` gains an optional
+  `provision?: ProvisionCapability` (ADR-033):
+  - **contracts** (`packages/contracts/src/provision.ts`) owns the pure data
+    contract: `ProvisionKind` (`'prototype' | 'list' | 'train'`) and the
+    serializable `ProvisionArtifact` payloads (wire + persistence form;
+    `Float32Array -> number[]`).
+  - **kws-engine** binds them to engine types: `ProvisionCapability`
+    (`{ kind, spec?, produce(input), apply(artifact) }`) on the registration.
+  - **Host flow:** collect (driver's provisioning spec renders the panel) →
+    `produce(input)` → persist (user artifact library, IndexedDB - same store
+    as imported models) → `apply(artifact)` into `engine.load` (the artifact
+    rides in `backendConfig`, opaque to the host).
+  - The host's `commandRef` load/start/stop dispatch follows `provision`
+    presence instead of the KWS category (`isFewShot` removed); a second
+    few-shot driver or a keyword-list driver needs zero host edits.
+  - Today only the plix `prototype` kind is implemented; `list` (sherpa) and
+    `train` (Phase 5 train-runner) are declared but unimplemented.
+  - The worker's plixkws load branch reads the prototype from `backendConfig`
+    (the legacy `prototype` message field remains supported).
 - **[Q-KWS-1] Demo model -> `hey-buddy`** (`benjamin-paine/hey-buddy`, CC-BY-4.0,
   commercially clean) (ADR-018, amended). Originally planned as openWakeWord
   `alexa.onnx` (CC BY-NC-SA, demo-only); switched to hey-buddy because it is
@@ -485,3 +507,4 @@ All Phase 2 open questions are resolved (ADR-018); the contract is locked.
 | 2026-07-28 | Migrate the Few-Shot encoder from WavLM-base-plus to **PLiX** (`aaqibsaeed/plixkws`, Apache-2.0). WavLM-base-plus was too heavy for end-side devices; PLiX is a compact CNN (EfficientNet-v2 "base" / TinyNet-E "small") with Prototypical-Network scoring (embedding -> mean prototype -> distance). New `plixkws` backend id + `PlixKwsEmbedProvider` (log-Mel front-end, WASM-pinned). Scoring uses squared-Euclidean distance to the prototype, rescaled to [0,1] via `1/(1+d^2)`. Replaces `wavlm-few-shot` / `WavLMEmbedProvider`. | agent |
 | 2026-07-31 | Add `sherpa-onnx-kws` backend (real KWS transducer, emscripten WASM, main-thread) to the backend union, `KWSBackend` optional `onDetection`/`configure`, `SherpaOnnxKwsConfig`, `BackendModelUrls.sherpaKws`, `KWSConfig.runtime`. Threading §5 amended (sherpa runs main-thread), config table + error model + testing strategy updated. Docs-only sync with ba52a61. | agent |
 | 2026-08-07 | Add the `kws-streaming` driver (§0 layout, backend-id union, `BackendModelUrls.kwsStreaming`) - `google-research/kws_streaming` external-state streaming graphs, Traditional category (#72). Contract detail lives in `docs/modules/kws-streaming.md`. | agent |
+| 2026-08-11 | ADR-033 provisioning capability: `ProvisionCapability` on the backend registration (contracts payload types + kws-engine interface), plix `prototype` capability (produce/apply), worker reads the prototype from backendConfig, host dispatch on `provision` presence (no `isFewShot`), artifacts persist in the shared user artifact library (prototypes today). | agent |

--- a/docs/modules/kws.md
+++ b/docs/modules/kws.md
@@ -454,8 +454,11 @@ All Phase 2 open questions are resolved (ADR-018); the contract is locked.
   - The host's `commandRef` load/start/stop dispatch follows `provision`
     presence instead of the KWS category (`isFewShot` removed); a second
     few-shot driver or a keyword-list driver needs zero host edits.
-  - Today only the plix `prototype` kind is implemented; `list` (sherpa) and
-    `train` (Phase 5 train-runner) are declared but unimplemented.
+  - Today two kinds are implemented: plix `prototype` (enrollment) and sherpa
+    `list` (keyword list); `train` (Phase 5 train-runner) is declared but
+    unimplemented. The host branches on `provision.kind` for the panel
+    section (prototype enrollment UI vs list keyword editor) - adding a
+    driver of either kind needs zero host edits.
   - The worker's plixkws load branch reads the prototype from `backendConfig`
     (the legacy `prototype` message field remains supported).
 - **[Q-KWS-1] Demo model -> `hey-buddy`** (`benjamin-paine/hey-buddy`, CC-BY-4.0,
@@ -508,3 +511,4 @@ All Phase 2 open questions are resolved (ADR-018); the contract is locked.
 | 2026-07-31 | Add `sherpa-onnx-kws` backend (real KWS transducer, emscripten WASM, main-thread) to the backend union, `KWSBackend` optional `onDetection`/`configure`, `SherpaOnnxKwsConfig`, `BackendModelUrls.sherpaKws`, `KWSConfig.runtime`. Threading §5 amended (sherpa runs main-thread), config table + error model + testing strategy updated. Docs-only sync with ba52a61. | agent |
 | 2026-08-07 | Add the `kws-streaming` driver (§0 layout, backend-id union, `BackendModelUrls.kwsStreaming`) - `google-research/kws_streaming` external-state streaming graphs, Traditional category (#72). Contract detail lives in `docs/modules/kws-streaming.md`. | agent |
 | 2026-08-11 | ADR-033 provisioning capability: `ProvisionCapability` on the backend registration (contracts payload types + kws-engine interface), plix `prototype` capability (produce/apply), worker reads the prototype from backendConfig, host dispatch on `provision` presence (no `isFewShot`), artifacts persist in the shared user artifact library (prototypes today). | agent |
+| 2026-08-11 | sherpa `list` capability (ADR-033): produce/apply wrap the keyword-list artifact; the host's provisioning section is kind-driven (prototype enrollment UI vs list keyword editor); `commandRef` load for list-kind produces + applies + loads. | agent |

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -30,3 +30,11 @@ export type {
   AFEStageResult,
   AFEStageKind,
 } from './module-spec'
+export type {
+  ProvisionArtifact,
+  ProvisionKind,
+  ProvisionListPayload,
+  ProvisionPrototypePayload,
+  ProvisionTrainPayload,
+} from './provision'
+export { isProvisionArtifactKind } from './provision'

--- a/packages/contracts/src/module-spec.schema.json
+++ b/packages/contracts/src/module-spec.schema.json
@@ -188,7 +188,8 @@
               "export",
               "train",
               "record",
-              "reset"
+              "reset",
+              "enroll"
             ]
           },
           "confirm": {

--- a/packages/contracts/src/module-spec.ts
+++ b/packages/contracts/src/module-spec.ts
@@ -42,7 +42,7 @@ export interface ModuleParam {
   validation?: ParamValidation
 }
 
-export type ActionKind = 'load' | 'start' | 'stop' | 'export' | 'train' | 'record' | 'reset'
+export type ActionKind = 'load' | 'start' | 'stop' | 'export' | 'train' | 'record' | 'reset' | 'enroll'
 
 export interface ModuleAction {
   id: string

--- a/packages/contracts/src/provision.ts
+++ b/packages/contracts/src/provision.ts
@@ -1,0 +1,70 @@
+/**
+ * Provisioning contract (ADR-033) - pure data types, no engine imports.
+ *
+ * Producing "the wake-word artifact a backend needs" is one abstract behavior
+ * with different input collection per driver:
+ *
+ *   | kind       | backend example | input (collect)      | artifact           |
+ *   |------------|-----------------|----------------------|--------------------|
+ *   | prototype  | plixkws         | mic recordings       | prototype vector(s)|
+ *   | list       | sherpa-onnx-kws | keyword text         | keyword list       |
+ *   | train      | openwakeword    | dataset -> train-runner | classifier onnx |
+ *
+ * These payloads are the wire + persistence form (Float32Array -> number[]),
+ * shared by hosts, driver modules and the future train-runner (Phase 5).
+ *
+ * @see DECISIONS.md ADR-033
+ */
+
+/** Which kind of wake-word artifact a backend provisions. Extensible. */
+export type ProvisionKind = 'prototype' | 'list' | 'train'
+
+/** Serialized few-shot prototype (enrollment output; number[] = wire form). */
+export interface ProvisionPrototypePayload {
+  id: string
+  word: string
+  vector: number[]
+  /** Negative-class prototype (open-set rejection, issue #69). */
+  negativeVector?: number[]
+  /** Ids of the enrolled sample clips that produced this prototype. */
+  sampleIds: string[]
+  createdAtMs: number
+}
+
+/** Keyword-list artifact (e.g. sherpa-onnx-kws keyword list). */
+export interface ProvisionListPayload {
+  /**
+   * Driver-formatted keyword text. sherpa expects one
+   * `spaced tokens @display name` per line; other list drivers define their
+   * own format in their capability spec.
+   */
+  keywords: string
+}
+
+/**
+ * Training artifact (declared for Phase 5; no driver implements it yet).
+ * A trained model's URLs plus an optional registry entry to upsert (ADR-027).
+ */
+export interface ProvisionTrainPayload {
+  /** Artifact URLs produced by training (e.g. classifier onnx, manifest). */
+  urls: Record<string, string>
+  /** Optional model-registry entry id to upsert (ADR-027). */
+  registryEntry?: string
+}
+
+/** The artifact a provisioning capability produces. */
+export type ProvisionArtifact =
+  | { kind: 'prototype'; backendId: string; payload: ProvisionPrototypePayload }
+  | { kind: 'list'; backendId: string; payload: ProvisionListPayload }
+  | { kind: 'train'; backendId: string; payload: ProvisionTrainPayload }
+
+/**
+ * Narrow a provision artifact to a specific kind. Hosts use this to read the
+ * typed payload (e.g. for persistence) without importing any driver module.
+ */
+export function isProvisionArtifactKind<K extends ProvisionKind>(
+  artifact: ProvisionArtifact,
+  kind: K,
+): artifact is Extract<ProvisionArtifact, { kind: K }> {
+  return artifact.kind === kind
+}

--- a/packages/modules/few-shot/core/FewShotEngine.ts
+++ b/packages/modules/few-shot/core/FewShotEngine.ts
@@ -18,6 +18,7 @@ import { DEFAULT_CONFIG } from './defaults'
 import { describeParameters } from './defaults'
 import { meanPool } from './quality'
 import { checkSampleQuality } from './quality'
+import { uid } from './serialize'
 import {
   savePrototype,
   listPrototypes,
@@ -25,14 +26,6 @@ import {
   saveSample,
   deleteSample,
 } from './storage'
-
-/** Generate a unique id (crypto.randomUUID with fallback). */
-function uid(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID()
-  }
-  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
-}
 
 export class FewShotEngine {
   private _kws: KWSEngine

--- a/packages/modules/few-shot/core/index.ts
+++ b/packages/modules/few-shot/core/index.ts
@@ -14,7 +14,12 @@ export {
   estimateSnrDb,
   checkSampleQuality,
 } from './quality'
-export { squaredEuclidean, plixScore, meanPool } from '@wake-studio/module-kws-plix'
+export { squaredEuclidean, plixScore, meanPool, l2Normalize } from './prototype'
+export {
+  deserializePrototype,
+  serializePrototype,
+  uid,
+} from './serialize'
 export type {
   EnrolledSample,
   FewShotConfig,
@@ -22,4 +27,4 @@ export type {
   SampleQuality,
   SerializedPrototype,
 } from './types'
-export type { WakeWordPrototype } from '@wake-studio/module-kws-plix'
+export type { WakeWordPrototype } from './prototype'

--- a/packages/modules/few-shot/core/prototype.ts
+++ b/packages/modules/few-shot/core/prototype.ts
@@ -1,9 +1,13 @@
 /**
- * kws-plix driver module - Few-Shot scoring types + DSP.
+ * Few-Shot module - wake-word prototype type + scoring primitives (ADR-033).
  *
- * Owned by the plix driver: the prototype type and the squared-Euclidean /
- * plixScore rescaling are the encoder's own contract (ADR-024). The Few-Shot
- * module (§6.4) consumes these from here rather than redefining them.
+ * Owned by the few-shot capability module, NOT by any KWS driver: the
+ * prototype type and the squared-Euclidean / plixScore rescaling are the
+ * enrollment contract, and a future `train`-kind driver (openwakeword
+ * training, ADR-033) must produce the same artifact type without importing an
+ * impl module (#74 rule). The plix driver imports these from here.
+ *
+ * @see docs/modules/few-shot.md §4-§5
  */
 
 /** A stored wake-word prototype (Few-Shot enrollment output). */

--- a/packages/modules/few-shot/core/quality.ts
+++ b/packages/modules/few-shot/core/quality.ts
@@ -48,7 +48,7 @@ export {
   squaredEuclidean,
   plixScore,
   meanPool,
-} from '@wake-studio/module-kws-plix'
+} from './prototype'
 
 /** Quality metrics for an enrollment sample. */
 export interface SampleQuality {

--- a/packages/modules/few-shot/core/serialize.ts
+++ b/packages/modules/few-shot/core/serialize.ts
@@ -1,0 +1,51 @@
+/**
+ * Few-Shot module - prototype serialization bridge (ADR-033).
+ *
+ * WakeWordPrototype (in-memory, Float32Array) <-> ProvisionPrototypePayload
+ * (wire + persistence form, number[]). The payload type is the contracts
+ * provisioning contract so any driver (plix enrollment today, a future
+ * train-kind driver) can produce/persist the same artifact type.
+ */
+
+import type { ProvisionPrototypePayload } from '@wake-studio/contracts'
+import type { WakeWordPrototype } from './prototype'
+
+/** Generate a unique id (crypto.randomUUID with fallback). */
+export function uid(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+/** Serialize a prototype to its wire/persistence payload. */
+export function serializePrototype(
+  proto: WakeWordPrototype,
+): ProvisionPrototypePayload {
+  return {
+    id: proto.id,
+    word: proto.word,
+    vector: Array.from(proto.vector),
+    negativeVector: proto.negativeVector
+      ? Array.from(proto.negativeVector)
+      : undefined,
+    sampleIds: proto.sampleIds,
+    createdAtMs: proto.createdAtMs,
+  }
+}
+
+/** Deserialize a provisioning payload back into an in-memory prototype. */
+export function deserializePrototype(
+  s: ProvisionPrototypePayload,
+): WakeWordPrototype {
+  return {
+    id: s.id,
+    word: s.word,
+    vector: new Float32Array(s.vector),
+    negativeVector: s.negativeVector
+      ? new Float32Array(s.negativeVector)
+      : undefined,
+    sampleIds: s.sampleIds,
+    createdAtMs: s.createdAtMs,
+  }
+}

--- a/packages/modules/few-shot/core/storage.ts
+++ b/packages/modules/few-shot/core/storage.ts
@@ -11,6 +11,7 @@ import type {
   SerializedPrototype,
   WakeWordPrototype,
 } from './types'
+import { deserializePrototype, serializePrototype } from './serialize'
 
 const DB_NAME = 'wake-studio-few-shot'
 const DB_VERSION = 1
@@ -39,29 +40,11 @@ function openDb(): Promise<IDBDatabase> {
 }
 
 function serialize(proto: WakeWordPrototype): SerializedPrototype {
-  return {
-    id: proto.id,
-    word: proto.word,
-    vector: Array.from(proto.vector),
-    negativeVector: proto.negativeVector
-      ? Array.from(proto.negativeVector)
-      : undefined,
-    sampleIds: proto.sampleIds,
-    createdAtMs: proto.createdAtMs,
-  }
+  return serializePrototype(proto)
 }
 
 function deserialize(s: SerializedPrototype): WakeWordPrototype {
-  return {
-    id: s.id,
-    word: s.word,
-    vector: new Float32Array(s.vector),
-    negativeVector: s.negativeVector
-      ? new Float32Array(s.negativeVector)
-      : undefined,
-    sampleIds: s.sampleIds,
-    createdAtMs: s.createdAtMs,
-  }
+  return deserializePrototype(s)
 }
 
 export async function savePrototype(

--- a/packages/modules/few-shot/core/types.ts
+++ b/packages/modules/few-shot/core/types.ts
@@ -2,11 +2,13 @@
  * Few-Shot module - shared types.
  *
  * Public API surface: see docs/modules/few-shot.md §4.
- * WakeWordPrototype is owned by the plix driver (module-migration §6.3) and
- * re-exported here for callers; this module defines its own enrollment types.
+ * WakeWordPrototype is owned by this capability module (ADR-033; moved out of
+ * the plix driver so any enrollment/training driver can produce the same
+ * artifact type) and re-exported here for callers.
  */
 
-import type { WakeWordPrototype } from '@wake-studio/module-kws-plix'
+import type { ProvisionPrototypePayload } from '@wake-studio/contracts'
+import type { WakeWordPrototype } from './prototype'
 
 export type { WakeWordPrototype }
 
@@ -28,7 +30,7 @@ export interface SampleQuality {
   acceptable: boolean
 }
 
-/** A stored wake-word prototype (owned by the plix driver, §6.3). */
+/** A stored wake-word prototype (owned by the few-shot module, ADR-033). */
 // (re-exported above)
 
 /** Few-Shot configuration (ADR-017 config panel). */
@@ -60,12 +62,6 @@ export interface ParameterDescriptor {
   description: string
 }
 
-/** Serialized form for IndexedDB (Float32Array -> number[]). */
-export interface SerializedPrototype {
-  id: string
-  word: string
-  vector: number[]
-  negativeVector?: number[]
-  sampleIds: string[]
-  createdAtMs: number
-}
+/** Serialized form for IndexedDB (Float32Array -> number[]); the contracts
+ *  provisioning payload (ADR-033) is the canonical shape. */
+export type SerializedPrototype = ProvisionPrototypePayload

--- a/packages/modules/few-shot/package.json
+++ b/packages/modules/few-shot/package.json
@@ -2,7 +2,7 @@
   "name": "@wake-studio/module-few-shot",
   "version": "0.1.0",
   "private": true,
-  "description": "Few-Shot custom wake-word enrollment module (ADR-002/013/020): sample recording + quality, prototype mean-pooling, IndexedDB persistence. Consumes the plix driver's EmbedProvider + prototype scoring.",
+  "description": "Few-Shot custom wake-word enrollment module (ADR-002/013/020): sample recording + quality, prototype mean-pooling, IndexedDB persistence. Owns the WakeWordPrototype type + scoring primitives (ADR-033); consumes the plix driver's EmbedProvider.",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -21,7 +21,6 @@
     "@wake-studio/contracts": "workspace:*",
     "@wake-studio/dsp": "workspace:*",
     "@wake-studio/module-kws-engine": "workspace:^",
-    "@wake-studio/module-kws-plix": "workspace:^",
     "@wake-studio/platform": "workspace:^"
   },
   "devDependencies": {

--- a/packages/modules/kws/engine/core/backend.ts
+++ b/packages/modules/kws/engine/core/backend.ts
@@ -16,6 +16,7 @@ import type {
   BackendModelResolveContext,
   BackendResourceDescriptor,
   ModelSourceRole,
+  ProvisionCapability,
 } from './types'
 import type { ModuleSpec } from '@wake-studio/contracts'
 
@@ -75,6 +76,14 @@ export interface KWSBackendRegistration {
    * Defaults to [].
    */
   resources?: BackendResourceDescriptor[]
+  /**
+   * Optional provisioning capability (ADR-033): how this backend produces the
+   * wake-word artifact it loads with (enrolled prototype / keyword list /
+   * trained classifier). The host renders the capability's spec, collects
+   * input, calls produce(), persists the artifact, then feeds apply() into
+   * engine.load. Omitted for backends that load plain pretrained models.
+   */
+  provision?: ProvisionCapability
   /**
    * Optional: a main-thread-only backend factory (e.g. sherpa-onnx-kws runs
    * on the main thread - its classic emscripten wasm needs DOM, ADR-018).

--- a/packages/modules/kws/engine/core/index.ts
+++ b/packages/modules/kws/engine/core/index.ts
@@ -41,6 +41,7 @@ export type {
   KWSStatus,
   ModelSourceRole,
   ParameterDescriptor,
+  ProvisionCapability,
   SherpaOnnxKwsConfig,
 } from './types'
 export { KWSLoadError, KWSUnsupportedError } from './types'

--- a/packages/modules/kws/engine/core/types.ts
+++ b/packages/modules/kws/engine/core/types.ts
@@ -11,6 +11,11 @@
 
 import type { ModelRegistry, ModelRuntime } from '@wake-studio/platform'
 import { DEFAULT_MODEL_RUNTIME } from '@wake-studio/platform'
+import type {
+  ModuleSpec,
+  ProvisionArtifact,
+  ProvisionKind,
+} from '@wake-studio/contracts'
 /**
  * Pluggable KWS backend identifiers (ADR-020). The engine delegates inference
  * to a `KWSBackend` adapter; selection is per-target / per-word.
@@ -210,6 +215,48 @@ export interface BackendResourceDescriptor {
    * and detail from the loaded URL.
    */
   state?: (ctx: BackendResourceStateContext) => BackendResourceState
+}
+
+// ---------------------------------------------------------------------------
+// Provisioning capability (ADR-033).
+//
+// Producing "the wake-word artifact a backend needs" (enrolled prototype /
+// keyword list / trained classifier) is one abstract behavior with different
+// input collection per driver. The pure payload types live in contracts
+// (ProvisionKind / ProvisionArtifact); this interface binds them to engine
+// types. Hosts render the capability's spec, collect input, call produce(),
+// persist the artifact, then feed apply() into engine.load - the host never
+// branches on a backend id.
+// ---------------------------------------------------------------------------
+
+/**
+ * A backend's provisioning capability (ADR-033). Optional on the
+ * registration; traditional backends (openwakeword, sherpa, kws-streaming)
+ * omit it and keep the plain resolveModelUrls -> engine.load path.
+ */
+export interface ProvisionCapability {
+  /** Which artifact kind this capability produces. */
+  kind: ProvisionKind
+  /**
+   * Provisioning panel spec (ADR-025) - rendered by the generator, host stays
+   * generic. Declares the collect/produce actions + status (e.g. record,
+   * enroll, start) and any input params.
+   */
+  spec?: ModuleSpec
+  /**
+   * Run the provisioning: mic samples / dataset / keyword text in, artifact
+   * out. The input shape is driver-defined (see the capability's spec).
+   */
+  produce(input: unknown): Promise<ProvisionArtifact>
+  /**
+   * Feed the artifact into engine.load: resolved model URLs and/or driver
+   * backend config. For few-shot the artifact's prototype vector(s) ride in
+   * backendConfig (opaque to the host, read by the worker's load handler).
+   */
+  apply(artifact: ProvisionArtifact): {
+    urls?: BackendModelUrls
+    backendConfig?: Record<string, unknown>
+  }
 }
 
 /**

--- a/packages/modules/kws/engine/web/worker.ts
+++ b/packages/modules/kws/engine/web/worker.ts
@@ -167,7 +167,20 @@ async function handleLoad(
           'PLiX Few-Shot backend requires a loaded PLiX encoder (provide a plixkws URL).',
         )
       }
-      if (!prototypeVector || prototypeVector.length === 0) {
+      // The prototype arrives via backendConfig in the provisioning flow
+      // (ADR-033: the driver's apply() maps the artifact into backendConfig,
+      // so the host stays generic). The message's legacy `prototype` field is
+      // still honoured for direct callers (playground / older hosts).
+      const protoConfig = (backendConfig ?? {}) as {
+        prototype?: number[]
+        prototypeNegative?: number[]
+        windowMs?: number
+        useNegativePrototype?: boolean
+        silenceFloorDbfs?: number
+      }
+      const protoVector = protoConfig.prototype ?? prototypeVector
+      const protoNegative = protoConfig.prototypeNegative ?? prototypeNegative
+      if (!protoVector || protoVector.length === 0) {
         throw new Error(
           'PLiX Few-Shot backend requires a prototype vector in the load message.',
         )
@@ -175,12 +188,12 @@ async function handleLoad(
       const proto = {
         id: 'enrolled',
         word: 'enrolled-word',
-        vector: new Float32Array(prototypeVector),
+        vector: new Float32Array(protoVector),
         // Negative-class prototype (open-set rejection, issue #69): the user
         // enrolled other words/background; scoring subtracts this class's
         // distance so non-target speech scores low.
-        negativeVector: prototypeNegative
-          ? new Float32Array(prototypeNegative)
+        negativeVector: protoNegative
+          ? new Float32Array(protoNegative)
           : undefined,
         sampleIds: [],
         createdAtMs: Date.now(),
@@ -198,15 +211,15 @@ async function handleLoad(
             e: unknown,
             opts?: {
               windowMs?: number
-              useNegative?: boolean
+              useNegativePrototype?: boolean
               silenceFloorDbfs?: number
             },
           ) => void
         }
       ).initWithPrototype?.(proto, embedProvider, {
-        windowMs: (backendConfig as { windowMs?: number } | undefined)?.windowMs,
-        useNegative: (backendConfig as { useNegative?: boolean } | undefined)?.useNegative,
-        silenceFloorDbfs: (backendConfig as { silenceFloorDbfs?: number } | undefined)?.silenceFloorDbfs,
+        windowMs: protoConfig.windowMs,
+        useNegativePrototype: protoConfig.useNegativePrototype,
+        silenceFloorDbfs: protoConfig.silenceFloorDbfs,
       })
     } else {
       // Detection backend: only load if its required URLs are present. If only

--- a/packages/modules/kws/plix/core/backend.ts
+++ b/packages/modules/kws/plix/core/backend.ts
@@ -44,8 +44,8 @@
  */
 
 import type { EmbedProvider, KWSBackend } from '@wake-studio/module-kws-engine'
-import type { WakeWordPrototype } from './prototype'
-import { squaredEuclidean, plixScore, l2Normalize } from './prototype'
+import type { WakeWordPrototype } from '@wake-studio/module-few-shot'
+import { squaredEuclidean, plixScore, l2Normalize } from '@wake-studio/module-few-shot'
 import { rmsDbfs } from '@wake-studio/dsp'
 
 /** Detection hop in frames (80 ms / 10 ms = 8 frames at the AFE cadence). */

--- a/packages/modules/kws/plix/core/index.ts
+++ b/packages/modules/kws/plix/core/index.ts
@@ -12,22 +12,36 @@ import {
   registerEmbedProviderFactory,
 } from '@wake-studio/module-kws-engine'
 import type { EmbedProvider } from '@wake-studio/module-kws-engine'
-import type { ModuleSpec } from '@wake-studio/contracts'
+import type { ModuleSpec, ProvisionArtifact } from '@wake-studio/contracts'
+import type { WakeWordPrototype, EnrolledSample } from '@wake-studio/module-few-shot'
+import { meanPool, serializePrototype } from '@wake-studio/module-few-shot'
 import { PlixKwsBackend } from './backend'
 import { PlixKwsEmbedProvider } from '../encoders/plixkws-embed'
 import { getPlixEncoderVariant } from '../encoders/plix-encoder'
-import type { WakeWordPrototype } from './prototype'
 import plixSpec from '../spec/module.spec.json'
+import plixProvisionSpec from '../spec/provision.spec.json'
 
 export { PlixKwsBackend } from './backend'
 export { PlixKwsEmbedProvider } from '../encoders/plixkws-embed'
-export {
-  type WakeWordPrototype,
-  meanPool,
-  plixScore,
-  squaredEuclidean,
-  l2Normalize,
-} from './prototype'
+
+/**
+ * Input shape for the plix provisioning capability's produce(): enrolled
+ * mic samples (already embedded by the host's FewShotEngine) plus optional
+ * negative-class samples for open-set rejection (issue #69).
+ */
+export interface PlixProduceInput {
+  word: string
+  samples: EnrolledSample[]
+  negativeSamples?: EnrolledSample[]
+}
+
+/** Unique id for a produced prototype (crypto.randomUUID with fallback). */
+function cryptoRandomUuid(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
 
 // Embed-provider factory: the worker hosts the embed() scaffold via this seam
 // without importing the plix module directly (ADR-024).
@@ -55,7 +69,7 @@ registerKwsBackend({
         embed: EmbedProvider,
         opts?: {
           windowMs?: number
-          useNegative?: boolean
+          useNegativePrototype?: boolean
           /** RMS (dBFS) floor below which windows score 0 (silence gate). */
           silenceFloorDbfs?: number
         },
@@ -69,7 +83,7 @@ registerKwsBackend({
         embed,
         proto,
         opts?.windowMs ?? 1500,
-        opts?.useNegative ?? false,
+        opts?.useNegativePrototype ?? false,
         opts?.silenceFloorDbfs,
       )
       // Copy state that may already exist (none before load, but stay safe).
@@ -125,6 +139,58 @@ registerKwsBackend({
     }
     return { plixkws: url, runtime: rt }
   },
+  // Provisioning capability (ADR-033): this driver produces the wake-word
+  // artifact it loads with - an enrolled prototype. The host renders the
+  // provisioning spec (record/enroll/start actions), collects mic samples,
+  // calls produce() to build the artifact, persists it to the user library,
+  // then feeds apply() into engine.load. No plix-specific code paths in the
+  // host.
+  provision: {
+    kind: 'prototype',
+    // The provisioning panel spec (separate from the driver config spec):
+    // enrollment actions + status, rendered by the panel generator.
+    spec: plixProvisionSpec as unknown as ModuleSpec,
+    // Input: enrolled mic samples (embeddings) + optional negative-class
+    // samples. Builds the prototype via mean-pooling (pure; the encoder is
+    // already embedded into the samples by the host's FewShotEngine).
+    produce: async (input) => {
+      const { word, samples, negativeSamples } = input as PlixProduceInput
+      if (samples.length === 0) {
+        throw new Error('Cannot build a prototype from zero samples.')
+      }
+      const proto: WakeWordPrototype = {
+        id: cryptoRandomUuid(),
+        word,
+        vector: meanPool(samples.map((s) => s.embedding)),
+        sampleIds: samples.map((s) => s.id),
+        createdAtMs: Date.now(),
+      }
+      if (negativeSamples && negativeSamples.length > 0) {
+        proto.negativeVector = meanPool(negativeSamples.map((s) => s.embedding))
+      }
+      return {
+        kind: 'prototype',
+        backendId: 'plixkws',
+        payload: serializePrototype(proto),
+      }
+    },
+    // Load-time mapping: the prototype vector(s) ride in backendConfig
+    // (opaque to the host; the worker's plixkws load branch reads them). The
+    // encoder URLs still come from resolveModelUrls above. The few-shot
+    // detection params (windowMs / useNegativePrototype / silenceFloorDbfs)
+    // are overlaid by the host from the few-shot module's config surface.
+    apply: (artifact: ProvisionArtifact) => {
+      if (artifact.kind !== 'prototype') {
+        throw new Error('plixkws only consumes prototype artifacts.')
+      }
+      return {
+        backendConfig: {
+          prototype: artifact.payload.vector,
+          prototypeNegative: artifact.payload.negativeVector,
+        },
+      }
+    },
+  },
   // Engine-card resources (ADR-024): the encoder model plus the persisted
   // enrollment artifacts. The data rows read the host-provided saved summary.
   resources: [
@@ -134,11 +200,14 @@ registerKwsBackend({
       label: 'Enrolled prototypes',
       kind: 'data',
       state: (ctx) => {
-        const protos = ctx.saved.prototypes as
-          | Array<{ word?: string }>
+        // The host passes the user artifact library's prototype entries
+        // (ADR-033): { artifactType: 'prototype', artifact: { payload: { word } } }.
+        const entries = ctx.saved.prototypes as
+          | Array<{ artifactType?: string; artifact?: { payload?: { word?: string } } }>
           | undefined
-        const words = (protos ?? [])
-          .map((p) => p.word)
+        const words = (entries ?? [])
+          .filter((e) => e.artifactType === 'prototype')
+          .map((e) => e.artifact?.payload?.word)
           .filter((w): w is string => Boolean(w))
         return { ready: words.length > 0, detail: words.join(', ') || 'none saved' }
       },

--- a/packages/modules/kws/plix/package.json
+++ b/packages/modules/kws/plix/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@wake-studio/contracts": "workspace:*",
     "@wake-studio/dsp": "workspace:*",
+    "@wake-studio/module-few-shot": "workspace:^",
     "@wake-studio/module-kws-engine": "workspace:^",
     "@wake-studio/platform": "workspace:^",
     "onnxruntime-web": "^1.27.0"

--- a/packages/modules/kws/plix/spec/provision.spec.json
+++ b/packages/modules/kws/plix/spec/provision.spec.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../../../contracts/src/module-spec.schema.json",
+  "meta": {
+    "id": "kws-plix-provision",
+    "name": "PLiX Few-Shot enrollment (provisioning)",
+    "category": "kws",
+    "version": "0.1.0",
+    "maturity": "draft",
+    "owner": "WakeStudio team",
+    "license": "Apache-2.0 (plixkws) + MIT (integration)",
+    "status": "proposed"
+  },
+  "params": [],
+  "actions": [
+    {
+      "id": "record",
+      "label": "Record sample",
+      "kind": "record",
+      "progress": "indeterminate",
+      "requires": ["platform.mic"]
+    },
+    {
+      "id": "enroll",
+      "label": "Build prototype",
+      "kind": "enroll",
+      "progress": "determinate",
+      "requires": ["samples"]
+    },
+    {
+      "id": "enroll-negative",
+      "label": "Enroll negative prototype",
+      "kind": "enroll",
+      "progress": "determinate",
+      "requires": ["samples", "negativeSamples"]
+    },
+    {
+      "id": "start",
+      "label": "Start Few-Shot detection",
+      "kind": "start",
+      "requires": ["prototype", "platform.afe"]
+    },
+    {
+      "id": "stop",
+      "label": "Stop Few-Shot detection",
+      "kind": "stop"
+    }
+  ],
+  "status": [
+    {
+      "id": "samples",
+      "label": "Enrolled samples",
+      "renderer": "badge",
+      "source": "engine:samples",
+      "refreshMs": 250
+    },
+    {
+      "id": "prototype",
+      "label": "Prototype",
+      "renderer": "badge",
+      "source": "engine:prototype",
+      "refreshMs": 250
+    }
+  ],
+  "runtime": {
+    "web": {
+      "engine": "PlixKwsBackend",
+      "worker": true
+    }
+  },
+  "tests": {
+    "l1": "packages/modules/kws/plix/tests/backend.test.ts",
+    "required": ["l1"]
+  },
+  "playground": {
+    "route": "/playground/kws/plix/provision",
+    "entry": "packages/modules/kws/plix/web/playground.tsx"
+  },
+  "interfaces": {
+    "provides": ["ProvisionCapability"],
+    "consumes": ["EmbedProvider", "KWSBackend"]
+  }
+}

--- a/packages/modules/kws/plix/tests/backend.test.ts
+++ b/packages/modules/kws/plix/tests/backend.test.ts
@@ -13,7 +13,7 @@ import {
   getPlixEncoderVariant,
   plixVariantOnnxUrl,
 } from '../encoders/plix-encoder'
-import type { WakeWordPrototype } from '../core/prototype'
+import type { WakeWordPrototype } from '@wake-studio/module-few-shot'
 import type { EmbedProvider } from '@wake-studio/module-kws-engine'
 
 class FakeEmbedder implements EmbedProvider {

--- a/packages/modules/kws/plix/tests/provision.test.ts
+++ b/packages/modules/kws/plix/tests/provision.test.ts
@@ -1,0 +1,113 @@
+/**
+ * kws-plix provisioning capability tests (ADR-033).
+ *
+ * The plix driver produces the wake-word artifact it loads with: an enrolled
+ * prototype. produce() turns enrolled mic samples (embeddings) into the
+ * serialized artifact; apply() maps it into the engine load backend config.
+ *
+ * The capability is read through the registry (the registration is the only
+ * surface hosts see), so these tests also lock the registration shape.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getBackendRegistration } from '@wake-studio/module-kws-engine'
+import type { EnrolledSample } from '@wake-studio/module-few-shot'
+import '@wake-studio/module-kws-plix'
+
+function makeSample(seed: number, id: string): EnrolledSample {
+  // Two-dim embeddings for easy assertions (mean-pooling, vectors).
+  const embedding = new Float32Array([seed, seed + 1])
+  return {
+    id,
+    samples: new Float32Array(16000),
+    sampleRate: 16000,
+    embedding,
+    quality: {
+      peakDbfs: -20,
+      snrDb: 20,
+      durationMs: 1000,
+      clipped: false,
+      acceptable: true,
+    },
+    recordedAtMs: Date.now(),
+  }
+}
+
+type PlixProvision = NonNullable<
+  NonNullable<ReturnType<typeof getBackendRegistration>>['provision']
+>
+
+describe('plixkws provisioning capability (ADR-033)', () => {
+  let provision: PlixProvision
+
+  beforeEach(() => {
+    const reg = getBackendRegistration('plixkws')
+    expect(reg?.provision).toBeDefined()
+    provision = reg!.provision!
+  })
+
+  it('declares kind prototype with a provisioning spec', () => {
+    expect(provision.kind).toBe('prototype')
+    // The spec drives the enrollment panel: record/enroll/start actions.
+    const actionIds = provision.spec?.actions.map((a) => a.id) ?? []
+    expect(actionIds).toContain('record')
+    expect(actionIds).toContain('enroll')
+    expect(actionIds).toContain('start')
+  })
+
+  it('produce() mean-pools sample embeddings into a prototype artifact', async () => {
+    const artifact = await provision.produce({
+      word: 'hey-buddy',
+      samples: [makeSample(1, 'a'), makeSample(3, 'b')],
+    })
+    expect(artifact.kind).toBe('prototype')
+    expect(artifact.backendId).toBe('plixkws')
+    if (artifact.kind !== 'prototype') return
+    expect(artifact.payload.word).toBe('hey-buddy')
+    // mean of [1,2] and [3,4]
+    expect(artifact.payload.vector).toEqual([2, 3])
+    expect(artifact.payload.sampleIds).toEqual(['a', 'b'])
+    expect(artifact.payload.negativeVector).toBeUndefined()
+  })
+
+  it('produce() includes the negative-class vector when negative samples are given', async () => {
+    const artifact = await provision.produce({
+      word: 'hey-buddy',
+      samples: [makeSample(1, 'a')],
+      negativeSamples: [makeSample(10, 'n1'), makeSample(12, 'n2')],
+    })
+    if (artifact.kind !== 'prototype') return
+    expect(artifact.payload.negativeVector).toEqual([11, 12])
+  })
+
+  it('produce() rejects zero samples', async () => {
+    await expect(provision.produce({ word: 'x', samples: [] })).rejects.toThrow(
+      'zero samples',
+    )
+  })
+
+  it('apply() maps the prototype artifact into the backendConfig', async () => {
+    const artifact = await provision.produce({
+      word: 'hey-buddy',
+      samples: [makeSample(1, 'a'), makeSample(3, 'b')],
+      negativeSamples: [makeSample(10, 'n1')],
+    })
+    const applied = provision.apply(artifact)
+    // Prototype vectors ride in backendConfig (opaque to the host; the
+    // worker's plixkws load branch reads them). No URLs - the encoder URLs
+    // come from the driver's resolveModelUrls.
+    expect(applied.urls).toBeUndefined()
+    expect(applied.backendConfig?.prototype).toEqual([2, 3])
+    expect(applied.backendConfig?.prototypeNegative).toEqual([10, 11])
+  })
+
+  it('apply() rejects a non-prototype artifact', () => {
+    expect(() =>
+      provision.apply({
+        kind: 'list',
+        backendId: 'plixkws',
+        payload: { keywords: 'x' },
+      }),
+    ).toThrow('only consumes prototype artifacts')
+  })
+})

--- a/packages/modules/kws/sherpa/core/index.ts
+++ b/packages/modules/kws/sherpa/core/index.ts
@@ -9,8 +9,9 @@
 
 import { registerKwsBackend } from '@wake-studio/module-kws-engine'
 import { SherpaOnnxKwsBackend } from './backend'
-import type { ModuleSpec } from '@wake-studio/contracts'
+import type { ModuleSpec, ProvisionArtifact } from '@wake-studio/contracts'
 import sherpaSpec from '../spec/module.spec.json'
+import sherpaProvisionSpec from '../spec/provision.spec.json'
 
 export { SherpaOnnxKwsBackend } from './backend'
 export type { SherpaOnnxKwsConfig } from '@wake-studio/module-kws-engine'
@@ -27,6 +28,41 @@ registerKwsBackend({
   spec: sherpaSpec as unknown as ModuleSpec,
   // Main-thread backend: the classic emscripten wasm needs DOM.
   mainThreadFactory: () => new SherpaOnnxKwsBackend(),
+  // Provisioning capability (ADR-033): this backend loads WITH a keyword
+  // list artifact. The host renders the driver's keywords param, calls
+  // produce() to validate/normalize the keyword text into an artifact, then
+  // feeds apply() into engine.load (the keyword list rides in backendConfig,
+  // which the main-thread backend's configure() already consumes).
+  provision: {
+    kind: 'list',
+    // The provisioning panel spec (separate from the driver config spec):
+    // the load-with-list action + keyword-list status, rendered generically.
+    spec: sherpaProvisionSpec as unknown as ModuleSpec,
+    // Input: the keyword-list text (sherpa format - one
+    // `spaced tokens @display name` per line, from the driver's keywords
+    // param). Validates non-empty and returns the serialized artifact.
+    produce: async (input) => {
+      const { keywords } = input as { keywords?: string }
+      const text = (keywords ?? '').trim()
+      if (!text) {
+        throw new Error('The keyword list is empty - enter at least one wake word.')
+      }
+      return {
+        kind: 'list',
+        backendId: 'sherpa-onnx-kws',
+        payload: { keywords: text },
+      }
+    },
+    // Load-time mapping: the keyword list rides in backendConfig (already the
+    // shape the main-thread backend's configure() reads). The host merges its
+    // live driver values (threshold) over the applied config.
+    apply: (artifact: ProvisionArtifact) => {
+      if (artifact.kind !== 'list') {
+        throw new Error('sherpa-onnx-kws only consumes keyword-list artifacts.')
+      }
+      return { backendConfig: { keywords: artifact.payload.keywords } }
+    },
+  },
   // Engine-card resources (ADR-024). The wasm package bundles the model, so
   // there are no model sources and no URL mapping; only the wasm runtime and
   // the editable wake-word list (a driver param) are shown.

--- a/packages/modules/kws/sherpa/spec/provision.spec.json
+++ b/packages/modules/kws/sherpa/spec/provision.spec.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "../../../../contracts/src/module-spec.schema.json",
+  "meta": {
+    "id": "kws-sherpa-provision",
+    "name": "sherpa-onnx KWS keyword list (provisioning)",
+    "category": "kws",
+    "version": "0.1.0",
+    "maturity": "draft",
+    "owner": "WakeStudio team",
+    "license": "Apache-2.0 (sherpa-onnx) + MIT (integration)",
+    "status": "proposed"
+  },
+  "params": [],
+  "actions": [
+    {
+      "id": "load-with-list",
+      "label": "Load with keyword list",
+      "kind": "load",
+      "progress": "determinate",
+      "requires": ["params.keywords"]
+    }
+  ],
+  "status": [
+    {
+      "id": "keywords",
+      "label": "Wake-word list",
+      "renderer": "badge",
+      "source": "engine:keywords",
+      "refreshMs": 250
+    }
+  ],
+  "runtime": {
+    "web": {
+      "engine": "SherpaOnnxKwsBackend",
+      "worker": true
+    }
+  },
+  "tests": {
+    "l1": "packages/modules/kws/sherpa/tests/provision.test.ts",
+    "required": ["l1"]
+  },
+  "playground": {
+    "route": "/playground/kws/sherpa/provision",
+    "entry": "packages/modules/kws/sherpa/web/playground.tsx"
+  },
+  "interfaces": {
+    "provides": ["ProvisionCapability"],
+    "consumes": ["AFEOutputFrame"]
+  }
+}

--- a/packages/modules/kws/sherpa/tests/provision.test.ts
+++ b/packages/modules/kws/sherpa/tests/provision.test.ts
@@ -1,0 +1,70 @@
+/**
+ * kws-sherpa provisioning capability tests (ADR-033).
+ *
+ * sherpa-onnx-kws provisions the wake-word artifact it loads with: a keyword
+ * list. produce() validates/normalizes the keyword text; apply() maps it into
+ * the engine load backend config (the shape the main-thread backend's
+ * configure() consumes).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getBackendRegistration } from '@wake-studio/module-kws-engine'
+import '@wake-studio/module-kws-sherpa'
+
+type SherpaProvision = NonNullable<
+  NonNullable<ReturnType<typeof getBackendRegistration>>['provision']
+>
+
+describe('sherpa-onnx-kws provisioning capability (ADR-033)', () => {
+  let provision: SherpaProvision
+
+  beforeEach(() => {
+    const reg = getBackendRegistration('sherpa-onnx-kws')
+    expect(reg?.provision).toBeDefined()
+    provision = reg!.provision!
+  })
+
+  it('declares kind list with a provisioning spec', () => {
+    expect(provision.kind).toBe('list')
+    const actionIds = provision.spec?.actions.map((a) => a.id) ?? []
+    expect(actionIds).toContain('load-with-list')
+  })
+
+  it('produce() wraps the keyword text into a list artifact', async () => {
+    const text = 'n \u01d0 h \u01ceo @hello\nx i\u01ceo \u00e0i @xiaoyi'
+    const artifact = await provision.produce({ keywords: text })
+    expect(artifact.kind).toBe('list')
+    expect(artifact.backendId).toBe('sherpa-onnx-kws')
+    if (artifact.kind !== 'list') return
+    expect(artifact.payload.keywords).toBe(text)
+  })
+
+  it('produce() rejects an empty keyword list', async () => {
+    await expect(provision.produce({ keywords: '   ' })).rejects.toThrow(
+      'keyword list is empty',
+    )
+  })
+
+  it('apply() maps the list artifact into backendConfig.keywords', async () => {
+    const artifact = await provision.produce({ keywords: 'n \u01d0 h \u01ceo @hello' })
+    const applied = provision.apply(artifact)
+    expect(applied.urls).toBeUndefined()
+    expect(applied.backendConfig?.keywords).toBe('n \u01d0 h \u01ceo @hello')
+  })
+
+  it('apply() rejects a non-list artifact', () => {
+    expect(() =>
+      provision.apply({
+        kind: 'prototype',
+        backendId: 'sherpa-onnx-kws',
+        payload: {
+          id: 'p',
+          word: 'x',
+          vector: [1],
+          sampleIds: [],
+          createdAtMs: Date.now(),
+        },
+      }),
+    ).toThrow('only consumes keyword-list artifacts')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,9 +406,6 @@ importers:
       '@wake-studio/module-kws-engine':
         specifier: workspace:^
         version: link:../kws/engine
-      '@wake-studio/module-kws-plix':
-        specifier: workspace:^
-        version: link:../kws/plix
       '@wake-studio/platform':
         specifier: workspace:^
         version: link:../../platform
@@ -529,6 +526,9 @@ importers:
       '@wake-studio/dsp':
         specifier: workspace:*
         version: link:../../../dsp
+      '@wake-studio/module-few-shot':
+        specifier: workspace:^
+        version: link:../../few-shot
       '@wake-studio/module-kws-engine':
         specifier: workspace:^
         version: link:../engine


### PR DESCRIPTION
## Summary

Implements **ADR-033 — Provisioning capability**: one abstract wake-word artifact flow for all KWS backends (#76). Producing "the wake-word artifact a backend needs" (enrolled prototype / keyword list / trained classifier) is now one abstract behavior with driver-owned input collection, instead of the host branching on the `isFewShot` category.

**Part 1 — the capability (commit 1, `Closes #76`):**

- **contracts** (`packages/contracts/src/provision.ts`): `ProvisionKind` (`'prototype' | 'list' | 'train'`) + serializable `ProvisionArtifact` payloads (pure data, no engine types); `ActionKind` gains `'enroll'`.
- **kws-engine**: `ProvisionCapability { kind, spec?, produce(input), apply(artifact) }` added to `KWSBackendRegistration`; the worker's plixkws load branch reads the prototype from `backendConfig` (legacy message field still supported).
- **Inversion (#74 §5)**: `WakeWordPrototype` + scoring primitives moved from `kws-plix` → `few-shot`; plix imports them now (arrow flipped, no impl-module re-exports from few-shot).
- **plix `prototype` capability**: `produce` (mean-pool enrolled samples → serialized artifact) + `apply` (prototype vectors into `backendConfig`) + provisioning spec (record/enroll/start/stop actions).
- **Host**: KWSPanel enrollment flow runs through produce → persist → apply; no plix-specific code paths left in the panel; `commandRef` dispatches on `provision` presence (`isFewShot` removed); artifacts persist in the shared **user artifact library** (generalized user model library, IndexedDB) with lazy migration of legacy few-shot prototypes.

**Part 2 — sherpa `list` capability (commit 2):**

- sherpa-onnx-kws gains a `list` capability: `produce` validates keyword text → artifact, `apply` maps it into `backendConfig.keywords` (the shape its `configure()` already reads). Proves a non-few-shot backend (asr-decoding) works through the same capability with a second artifact type.
- Host provisioning section is now **kind-driven**: prototype kind = enrollment UI; list kind = keyword editor + load-with-list flow. Adding a driver of either kind needs zero host edits.

## Acceptance criteria (#76)

- [x] `ProvisionCapability` contract defined in contracts (ADR-033 accepted)
- [x] plix enrollment flow runs through the capability; KWSPanel has no plix-specific enrollment code paths
- [x] `commandRef` load/start/stop dispatch no longer branches on `isFewShot`
- [x] Provisioning panels render from the driver's provisioning spec (labels/actions + kind-driven sections)
- [x] Artifacts (prototypes today) persist in the shared user model library
- [x] Existing few-shot L1 tests green; enrollment UX unchanged

## Validation

- `pnpm typecheck`: 18/18 packages green
- `pnpm -r test:unit`: **376 passed** (incl. 11 new provisioning tests: plix produce/apply + sherpa list produce/apply + user-artifact-library persistence)
- `pnpm build`: green
- `pnpm lint` (touched packages): 0 errors

## Follow-ups (noted in ADR-033)

- `train` capability + train-runner wiring (Phase 5)
- Shrinking `BackendModelUrls` / worker `prototype` fields into `backendConfig` (#74 §5)
- Artifacts-list UI in the Model Library view (artifacts currently surface in the Engine card's resources)
- Full module-kit generator rendering of the provisioning panel (currently spec-driven labels/actions in the live panel)

## Manual verification

Enrollment UX should be unchanged: select `plixkws` → load encoder → record samples → build prototype (optionally negative) → start detection. For `sherpa-onnx-kws`, edit the keyword list and use "Load with keyword list".

Closes #76
