### PR TITLE
feat(kws-openwakeword): model assets hosted as GitHub Release + fetched in CI (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Fetch L2 test artifacts (sherpa + openwakeword, ADR-027)
+        # The L2 wasm/onnx boot tests exercise the gitignored artifacts
+        # (ADR-011). Non-fatal: each L2 suite skips when its asset is absent
+        # (tests/wasm-runtime.test.ts in kws-sherpa / kws-openwakeword), so a
+        # missing artifact degrades coverage instead of red.
+        run: |
+          node scripts/fetch-artifact.mjs kws-sherpa || echo "sherpa artifact fetch failed; sherpa L2 skips"
+          node scripts/fetch-artifact.mjs kws-openwakeword || echo "openwakeword assets fetch failed; openwakeword L2 skips"
+
       - name: Lint
         run: pnpm lint
 
@@ -85,12 +94,14 @@ jobs:
         # child-package bins - P0-2).
         run: pnpm --filter @wake-studio/web exec playwright install --with-deps chromium
 
-      - name: Fetch runtime assets (sherpa wasm for e2e)
-        # The sherpa-kws e2e boots the 53 MB wasm; fetch it into the module
-        # assets dir (gitignored). Non-fatal: the spec skips if the file is
-        # absent (see sherpa-kws.spec.ts).
+      - name: Fetch runtime assets (sherpa wasm + openwakeword onnx for e2e)
+        # The sherpa-kws e2e boots the 53 MB wasm; the openwakeword e2e loads
+        # the mel/embedding/classifier onnx. Fetched into the module assets
+        # dirs (gitignored). Non-fatal: the specs skip if the files are absent
+        # (see sherpa-kws.spec.ts / openwakeword-kws.spec.ts).
         run: |
           node scripts/fetch-artifact.mjs kws-sherpa || echo "sherpa wasm fetch failed; sherpa-kws spec will be skipped"
+          node scripts/fetch-artifact.mjs kws-openwakeword || echo "openwakeword assets fetch failed; openwakeword spec will be skipped"
 
       - name: Build PWA (for preview server)
         # `pnpm preview` serves dist/; the e2e job must build it first (the

--- a/apps/web/e2e/sherpa-kws.spec.ts
+++ b/apps/web/e2e/sherpa-kws.spec.ts
@@ -52,7 +52,10 @@ test('sherpa-onnx-kws backend loads (wasm boots + spotter created)', async ({
   await expect(backendSelect).toBeVisible()
   await backendSelect.selectOption('sherpa-onnx-kws')
 
-  const loadButton = page.getByRole('button', { name: /Load models/i })
+  // The sherpa driver is a list-kind provisioning backend (ADR-033): the
+  // Engine card shows its list-load action ('Load with keyword list') instead
+  // of the generic 'Load models' (KWSPanel, #79 rewrite).
+  const loadButton = page.getByRole('button', { name: /Load with keyword list/i })
   await expect(loadButton).toBeVisible()
 
   await loadButton.click()

--- a/docs/build-artifacts.md
+++ b/docs/build-artifacts.md
@@ -67,8 +67,11 @@ node scripts/fetch-<artifact>.mjs [--force] [--version <v>]
 
 - Reads the expected version/hash from `public/model-registry.json`
   (single source of truth).
-- Downloads via the GitHub Actions artifact REST API (or a pinned release URL
-  for third-party assets), extracts into the target dir, verifies sha256.
+- Downloads via the GitHub Actions artifact REST API (default;
+  `build.artifactName`), or from a GitHub Release when the module spec's
+  `build.fetch.source = "release"` (`build.fetch.releaseTag` + `pattern`;
+  for static, non-CI-built models — see the `kws-openwakeword` / `kws-plix`
+  rows below), extracts into the target dir, verifies sha256.
 - Exits non-zero with a clear message if the artifact is missing/expired.
 
 ## 4. Checklist for adding a new artifact
@@ -91,7 +94,8 @@ node scripts/fetch-<artifact>.mjs [--force] [--version <v>]
 | Artifact | Build (module build block) | Fetch | Dest | Registry key |
 |---|---|---|---|---|
 | sherpa-onnx-kws wasm | `kws-sherpa` (`.github/workflows/build.yaml` + `scripts/build-sherpa-kws.mjs`) | `scripts/fetch-artifact.mjs kws-sherpa` | `packages/modules/kws/sherpa/assets/` | `kws-sherpa` |
-| PLiX ONNX encoder | `kws-plix` (`.github/workflows/build.yaml` + `scripts/build-plix.mjs`) | `scripts/fetch-artifact.mjs kws-plix` | `packages/modules/kws/plix/assets/` | `kws-plix` |
+| openwakeword + hey-buddy onnx | `kws-openwakeword` (static; hosted on Release `models-openwakeword-v1`, `build.fetch.source=release`) | `scripts/fetch-artifact.mjs kws-openwakeword` | `packages/modules/kws/openwakeword/assets/` | `melspectrogram`, `speech_embedding`, `silero-vad`, `openwakeword-*`, `hey-buddy` |
+| PLiX ONNX encoder | `kws-plix` (export script `scripts/build-plix.mjs`; hosted on Release `models-plix-v1`, `build.fetch.source=release`) | `scripts/fetch-artifact.mjs kws-plix` | `packages/modules/kws/plix/assets/` | `plixkws`, `plixkws-small` |
 | kws-streaming ONNX (Keyword Transformer / att_mh_rnn) | `kws-streaming` (`.github/workflows/build.yaml` + `scripts/build-kws-streaming.mjs`) | `scripts/fetch-artifact.mjs kws-streaming` | `packages/modules/kws/streaming/assets/kws-streaming/` | `kws-streaming-*` |
 | RNNoise wasm (pilot) | embedded base64 in `web/vendor/`; standalone CI build planned | (not needed while embedded) | `packages/modules/afe/rnnoise/assets/` | `rnnoise` |
 

--- a/packages/contracts/src/module-spec.schema.json
+++ b/packages/contracts/src/module-spec.schema.json
@@ -457,6 +457,19 @@
           "type": "object",
           "description": "How scripts/fetch-artifact.mjs unpacks the artifact into assets/.",
           "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["run", "release"],
+              "description": "Where the artifact comes from: a GitHub Actions run (default; build.artifactName) or a GitHub Release (source=release; static models with no CI build, e.g. openwakeword/hey-buddy)."
+            },
+            "releaseTag": {
+              "type": "string",
+              "description": "GitHub Release tag to download when source=release."
+            },
+            "pattern": {
+              "type": "string",
+              "description": "Glob for gh release download (default '*'). Use e.g. '*.tar.gz' for a layout-preserving archive."
+            },
             "include": {
               "type": "array",
               "items": {

--- a/packages/modules/kws/openwakeword/assets/README.md
+++ b/packages/modules/kws/openwakeword/assets/README.md
@@ -6,30 +6,37 @@ Browser-ready openWakeWord model files for the OpenWakeWord KWS driver
 ## What lives here
 
 `openWakeWord/` mirrors the upstream `dscripka/openWakeWord` release files
-used by this module:
+used by this module, plus the hey-buddy classifier:
 
-- `melspectrogram.onnx` / `.tflite` — 16 kHz log-Mel front-end (Apache-2.0).
-- `embedding_model.onnx` / `.tflite` — Google speech_embedding backbone
-  re-implemented in openWakeWord (Apache-2.0, ~1.4M params).
+- `melspectrogram.onnx` — 16 kHz log-Mel front-end (Apache-2.0).
+- `embedding_model.onnx` — Google speech_embedding backbone re-implemented
+  in openWakeWord (Apache-2.0, ~1.4M params).
 - `silero_vad.onnx` — Silero VAD (MIT; gating candidate, ADR-018).
 - `alexa_v0.1`, `hey_jarvis_v0.1`, `hey_mycroft_v0.1`, `hey_rhasspy_v0.1`,
-  `timer_v0.1`, `weather_v0.1` (`.onnx` + `.tflite`) — openWakeWord demo
-  classifiers (CC BY-NC-SA; demo-only, NOT commercially clean).
+  `timer_v0.1`, `weather_v0.1` (`.onnx`) — openWakeWord demo classifiers
+  (CC BY-NC-SA; demo-only, NOT commercially clean).
+- `hey-buddy/models/hey-buddy.onnx` — Hey Buddy wake-word classifier
+  (CC-BY-4.0, commercially clean; the app's default classifier).
 
-The files are **gitignored** (ADR-011) and are NOT CI-built — they are copied
-once from the upstream release (see `spec/module.spec.json` `build.notes`).
-They are served at `/modules/kws/openwakeword/assets/openWakeWord/...`
-(vite middleware in dev, `copyModuleAssets` into dist for deploy; ADR-025).
+The files are **gitignored** (ADR-011) and fetched from the GitHub Release
+`models-openwakeword-v1` (ADR-027; `spec/module.spec.json` `build.fetch`).
+Fetch with `pnpm fetch:all` (or `node scripts/fetch-artifact.mjs
+kws-openwakeword`). They are served at
+`/modules/kws/openwakeword/assets/openWakeWord/...` (vite middleware in dev,
+`copyModuleAssets` into dist for deploy; ADR-025).
 
 ## Where the app points
 
 The registry (`apps/web/public/model-registry.json`) entries `melspectrogram`,
-`speech_embedding` and `silero-vad` reference these paths. The KWS panel
-(`apps/web/src/components/KWSPanel.tsx`) hard-codes the first two for the
-OpenWakeWord backend. The classifier stays remote (hey-buddy, CC-BY-4.0,
-commercially clean - ADR-018 Q-KWS-1).
+`speech_embedding`, `silero-vad`, the `openwakeword-*` demo models and
+`hey-buddy` reference these paths. The KWS panel renders the backend's
+model-source roles from its registration (ADR-024); the defaults are
+melspectrogram + embedding + hey-buddy.
 
 ## Regenerating
 
-Re-copy from the upstream openWakeWord release if needed, keeping the same
-filenames so the registry / panel URLs stay valid.
+The tarball on the release was staged from these files. To refresh (e.g. a
+new upstream openWakeWord release), rebuild the tarball keeping the same
+filenames and upload it to the release (`gh release upload
+models-openwakeword-v1 <archive> --clobber`) so the registry / panel URLs
+stay valid.

--- a/packages/modules/kws/openwakeword/package.json
+++ b/packages/modules/kws/openwakeword/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run",
-    "fetch:all": "echo 'models live in assets/openWakeWord/ (copied from the openWakeWord release, ADR-025); see assets/README.md'"
+    "fetch:all": "node ../../../../scripts/fetch-artifact.mjs kws-openwakeword"
   },
   "dependencies": {
     "@wake-studio/contracts": "workspace:*",

--- a/packages/modules/kws/openwakeword/spec/module.spec.json
+++ b/packages/modules/kws/openwakeword/spec/module.spec.json
@@ -51,20 +51,28 @@
     "recipe": "none",
     "registryEntry": "public/model-registry.json#kws-openwakeword",
     "fetch": {
-      "subdir": "openWakeWord"
+      "source": "release",
+      "releaseTag": "models-openwakeword-v1",
+      "pattern": "*.tar.gz"
     },
-    "notes": "Third-party openWakeWord models (melspectrogram / speech_embedding / silero-vad / demo classifiers) are copied into assets/openWakeWord/ from the upstream release; not CI-built. Registry entries point at /modules/kws/openwakeword/assets/openWakeWord/ (ADR-025)."
+    "notes": "melspectrogram/embedding (Apache-2.0, upstream openWakeWord) + hey-buddy classifier (CC-BY-4.0) hosted as a GitHub Release (ADR-027 §6.7); fetched via scripts/fetch-artifact.mjs. The tar.gz preserves the module asset layout (openWakeWord/ + hey-buddy/models/)."
   },
   "tests": {
     "l1": "packages/modules/kws/openwakeword/tests/backend.test.ts",
-    "required": ["l1"]
+    "required": [
+      "l1"
+    ]
   },
   "playground": {
     "route": "/playground/kws/openwakeword",
     "entry": "packages/modules/kws/openwakeword/web/playground.tsx"
   },
   "interfaces": {
-    "provides": ["KWSBackend"],
-    "consumes": ["AFEOutputFrame"]
+    "provides": [
+      "KWSBackend"
+    ],
+    "consumes": [
+      "AFEOutputFrame"
+    ]
   }
 }

--- a/packages/modules/kws/sherpa/spec/module.spec.json
+++ b/packages/modules/kws/sherpa/spec/module.spec.json
@@ -16,7 +16,7 @@
       "label": "Wake words (comma-separated)",
       "group": "primary",
       "type": "string",
-      "default": "n \u01d0 h \u01ceo j \u016bn g \u0113 @\u4f60\u597d\u519b\u54e5\nn \u01d0 h \u01ceo w \u00e8n w \u00e8n @\u4f60\u597d\u95ee\u95ee\nx i\u01ceo \u00e0i t \u00f3ng x u\u00e9 @\u5c0f\u7231\u540c\u5b66",
+      "default": "n ǐ h ǎo j ūn g ē @你好军哥\nn ǐ h ǎo w èn w èn @你好问问\nx iǎo ài t óng x ué @小爱同学",
       "description": "Editable text wake-word list for ASR-Decoding KWS (ADR-024). One keyword per line: spaced tokens @label (sherpa-onnx text2token; the 2025-12-20 zh-en model uses ppinyin tokens + @display label, no score/threshold suffixes). Defaults match the model test keywords."
     },
     {
@@ -83,6 +83,9 @@
     "artifactName": "sherpa-onnx-kws-wasm",
     "registryEntry": "public/model-registry.json#kws-sherpa",
     "fetch": {
+      "source": "release",
+      "releaseTag": "models-sherpa-wasm-v1",
+      "pattern": "*.tar.gz",
       "subdir": "sherpa-onnx-kws",
       "include": [
         "sherpa-onnx-wasm-kws-main.js",
@@ -116,7 +119,8 @@
         "default": "sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20.tar.bz2",
         "required": false
       }
-    ]
+    ],
+    "notes": "The wasm runtime (built by scripts/build-sherpa-kws.mjs, ADR-027) is hosted as a GitHub Release and fetched via scripts/fetch-artifact.mjs; regenerate with the build script if a new build is required."
   },
   "tests": {
     "l1": "packages/modules/kws/sherpa/tests/spec.test.ts",

--- a/scripts/fetch-artifact.mjs
+++ b/scripts/fetch-artifact.mjs
@@ -2,10 +2,14 @@
 /**
  * Generic artifact fetch (ADR-027 SOP §6.7).
  *
- * Downloads a built artifact (from a GitHub Actions run, or a local dir) into
- * the owning module's assets/ directory. The module's spec `build` block
- * declares artifactName + registryEntry; the fetch is the counterpart of the
- * module's build script.
+ * Downloads a module's binary assets into its assets/ directory from one of:
+ *   - a GitHub Actions run artifact (default; spec build.artifactName), or
+ *   - a GitHub Release (spec build.fetch.source = "release", ADR-027 §6.7
+ *     for static, non-CI-built models like the openwakeword/hey-buddy onnx),
+ *   - a local dir (--from).
+ * The module's spec `build` block declares artifactName/registryEntry (or
+ * fetch.releaseTag); the fetch is the counterpart of the module's build
+ * script.
  *
  * Usage:
  *   node scripts/fetch-artifact.mjs <module-id> [--from <local-dir>]
@@ -14,14 +18,14 @@
  *   GITHUB_REPO  owner/name to pull the artifact from (default: git remote)
  *   ARTIFACT_DIR override target dir (default: <module>/assets/)
  *
- * The artifact name comes from the module spec (build.artifactName).
- *
  * Unpacking honors the module spec's `build.fetch` block (ADR-025):
  *   - build.fetch.subdir  copy into <assets>/<subdir> (default: assets/ root)
  *   - build.fetch.include file whitelist (basenames); only these files are
  *     copied, so demo extras (app.js, index.html, README) are dropped.
  *   - Nested directories in the artifact are flattened: the whitelist is
  *     matched by basename anywhere under the artifact root.
+ *   - Release assets may be a .tar.gz that preserves the module's asset
+ *     layout; the archive is extracted first, then copied as a tree.
  */
 
 import { existsSync, mkdirSync, copyFileSync, readdirSync, statSync, rmSync } from 'node:fs'
@@ -64,11 +68,14 @@ function main() {
   if (!found) die(`no module spec for '${moduleId}'`)
   const { spec, dir } = found
   const build = spec.build
+  const fetchCfg = build?.fetch
+  const isRelease = fetchCfg?.source === 'release'
   const artifactName = build?.artifactName
-  if (!artifactName) die(`module '${moduleId}' has no build.artifactName`)
+  if (!isRelease && !artifactName) {
+    die(`module '${moduleId}' has no build.artifactName (and no fetch.source=release)`)
+  }
 
   const targetDir = process.env.ARTIFACT_DIR || resolve(dir, 'assets')
-  const fetchCfg = build?.fetch
   const destDir = fetchCfg?.subdir ? resolve(targetDir, fetchCfg.subdir) : targetDir
   mkdirSync(destDir, { recursive: true })
 
@@ -88,9 +95,30 @@ function main() {
   }
 
   const repo = process.env.GITHUB_REPO || defaultRepo()
-  console.log(`[fetch-artifact] gh run download ${artifactName} from ${repo}`)
   const tmp = join(repoRoot, '.tmp-artifact')
   mkdirSync(tmp, { recursive: true })
+
+  if (isRelease) {
+    // Static, non-CI-built models hosted on a GitHub Release (ADR-027 §6.7):
+    // e.g. openwakeword/hey-buddy onnx assets. A .tar.gz asset may preserve
+    // the module's asset layout; extract before unpacking.
+    const tag = fetchCfg.releaseTag
+    if (!tag) die(`module '${moduleId}' fetch.source=release needs build.fetch.releaseTag`)
+    console.log(`[fetch-artifact] gh release download ${tag} from ${repo}`)
+    const out = spawnSync(
+      'gh',
+      ['release', 'download', tag, '--repo', repo, '--pattern', fetchCfg.pattern ?? '*', '--dir', tmp, '--clobber'],
+      { stdio: 'inherit' },
+    )
+    if (out.status !== 0) die(`gh release download failed (${out.status})`)
+    extractArchiveIfNeeded(tmp)
+    unpack(tmp)
+    rmSync(tmp, { recursive: true, force: true }) // scratch dir; never commit
+    console.log(`[fetch-artifact] done -> ${destDir}`)
+    return
+  }
+
+  console.log(`[fetch-artifact] gh run download ${artifactName} from ${repo}`)
   const out = spawnSync('gh', ['run', 'download', '--repo', repo, '--name', artifactName, '--dir', tmp], {
     stdio: 'inherit',
   })
@@ -98,6 +126,24 @@ function main() {
   unpack(tmp)
   rmSync(tmp, { recursive: true, force: true }) // scratch dir; never commit
   console.log(`[fetch-artifact] done -> ${destDir}`)
+}
+
+/**
+ * If the download contains a single .tar.gz/.tgz (release mode), extract it
+ * in place so the copy helpers see the preserved asset layout, then drop the
+ * archive itself (never copied into assets/).
+ */
+function extractArchiveIfNeeded(tmp) {
+  for (const entry of readdirSafe(tmp)) {
+    if (entry.endsWith('.tar.gz') || entry.endsWith('.tgz')) {
+      const archive = resolve(tmp, entry)
+      console.log(`[fetch-artifact] extract ${entry}`)
+      const out = spawnSync('tar', ['-xzf', archive, '-C', tmp], { stdio: 'inherit' })
+      if (out.status !== 0) die(`tar extraction failed (${out.status}): ${archive}`)
+      rmSync(archive, { force: true })
+      return
+    }
+  }
 }
 
 /** Recursively copy a tree, flattening into dest. */


### PR DESCRIPTION
## What

Option (b) of #50: the openwakeword/hey-buddy onnx assets (mel-spectrogram, speech-embedding, hey-buddy classifier — ~3.6 MB total) are now hosted on the GitHub Release [models-openwakeword-v1](https://github.com/awareride/wake-studio/releases/tag/models-openwakeword-v1) as a layout-preserving `.tar.gz`, fetched via `scripts/fetch-artifact.mjs` (the ADR-027 pattern sherpa already uses).

## Changes

- **`scripts/fetch-artifact.mjs`** — new `build.fetch.source=release` mode: `gh release download` + tar extraction (preserves the module asset layout). Actions-run downloads stay the default.
- **`packages/contracts/src/module-spec.schema.json`** — `build.fetch` gains `source` (`run`/`release`), `releaseTag`, `pattern`.
- **kws-openwakeword spec** — `build.fetch` points at the release.
- **`ci.yml`** — lint-build job fetches sherpa + openwakeword before `pnpm test:unit` (the L2 suites now run for real on every PR); e2e job fetches openwakeword (that spec is no longer skip-gated). Both non-fatal when an artifact is unavailable.
- **module `fetch:all`** now runs the real fetch (was a placeholder echo).

## Notes

- The unused `assets/hey-buddy/pretrained/` duplication (~140 MB: duplicate embedding + piper TTS weights) was removed locally; it is not part of the release.
- Verified: `node scripts/fetch-artifact.mjs kws-openwakeword` and `pnpm --filter @wake-studio/module-kws-openwakeword fetch:all` both download + unpack into the module assets correctly.
- Full unit suite + typecheck + lint green locally.

Closes #50