### PR TITLE
test(kws-plix): dual-path encoder verification + release assets (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           node scripts/fetch-artifact.mjs kws-sherpa || echo "sherpa artifact fetch failed; sherpa L2 skips"
           node scripts/fetch-artifact.mjs kws-openwakeword || echo "openwakeword assets fetch failed; openwakeword L2 skips"
+          node scripts/fetch-artifact.mjs kws-plix || echo "plix assets fetch failed; plix L2 skips"
 
       - name: Lint
         run: pnpm lint
@@ -101,6 +102,7 @@ jobs:
         run: |
           node scripts/fetch-artifact.mjs kws-sherpa || echo "sherpa wasm fetch failed; sherpa-kws spec will be skipped"
           node scripts/fetch-artifact.mjs kws-openwakeword || echo "openwakeword assets fetch failed; openwakeword spec will be skipped"
+          node scripts/fetch-artifact.mjs kws-plix || echo "plix assets fetch failed; plix specs will be skipped"
 
       - name: Build PWA (for preview server)
         # `pnpm preview` serves dist/; the e2e job must build it first (the

--- a/apps/web/e2e/plix-encoder.spec.ts
+++ b/apps/web/e2e/plix-encoder.spec.ts
@@ -58,9 +58,9 @@ test('plixkws encoder loads in the browser (worker registration works)', async (
   await expect(loadButton).toBeVisible()
   await loadButton.click()
 
-  // Success: engine reaches 'ready' and the "PLiX encoder loaded — record
-  // samples to enroll" hint renders.
-  const readyHint = page.getByText(/PLiX encoder loaded/i)
+  // Success: engine reaches 'ready' and the "Encoder loaded — record
+  // samples to enroll" hint renders (ADR-033 provisioning panel).
+  const readyHint = page.getByText(/Encoder loaded — record samples to enroll/)
   await expect(readyHint).toBeVisible({ timeout: 150_000 })
 
   // Any load failure surfaces an error instead.
@@ -89,7 +89,7 @@ test('switching backend after a load re-boots with the new backend', async ({ pa
   const loadEncoder = page.getByRole('button', { name: /Load PLiX encoder/i })
   await expect(loadEncoder).toBeVisible()
   await loadEncoder.click()
-  await expect(page.getByText(/PLiX encoder loaded/i)).toBeVisible({ timeout: 150_000 })
+  await expect(page.getByText(/Encoder loaded — record samples to enroll/)).toBeVisible({ timeout: 150_000 })
 
   const errorText = page.getByText(/Failed to load|not found/i)
   await expect(errorText).toBeHidden()

--- a/apps/web/e2e/plix-transformers.spec.ts
+++ b/apps/web/e2e/plix-transformers.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import { existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { enableKws } from './helpers'
+
+// The plix onnx assets are gitignored (ADR-011); skip when absent (like the
+// other kws specs) so CI does not fail on a bare checkout.
+const here = dirname(fileURLToPath(import.meta.url))
+const hfConfig = resolve(
+  here,
+  '..',
+  '..',
+  '..',
+  'packages',
+  'modules',
+  'kws',
+  'plix',
+  'assets',
+  'hf',
+  'plixkws',
+  'config.json',
+)
+const SKIP_REASON = existsSync(hfConfig)
+  ? null
+  : 'plix HF-style assets not present (gitignored); run `node scripts/fetch-artifact.mjs kws-plix`'
+
+/**
+ * PLiX encoder - 'transformers' runtime browser verification (ADR-026, #48).
+ *
+ * The 'transformers' runtime (encoders/plix-transformers.ts) loads
+ * @huggingface/transformers from the jsDelivr CDN and serves the model from
+ * the locally-hosted HF-style dir (assets/hf/plixkws). This spec pins that
+ * the non-ONNX path boots to 'ready' in the browser.
+ *
+ * Requires network access to cdn.jsdelivr.net (the CDN import); on offline
+ * CI runners the load surfaces a visible error and this spec fails — if that
+ * becomes a problem, move it to merge-gate cadence like the sherpa e2e
+ * (issue #33 / Q11).
+ */
+test('plixkws transformers runtime loads the encoder in the browser (#48)', async ({
+  page,
+}) => {
+  test.skip(Boolean(SKIP_REASON), SKIP_REASON ?? '')
+  test.setTimeout(300_000)
+  await page.goto('/')
+  await enableKws(page)
+
+  const backendSelect = page
+    .locator('select')
+    .filter({ has: page.locator('option[value="plixkws"]') })
+  await expect(backendSelect).toBeVisible()
+  await backendSelect.selectOption('plixkws')
+
+  // Switch the driver's runtime param (Radix select) to Transformers.js.
+  const runtimeCombobox = page.locator('[role="combobox"]', {
+    hasText: 'ONNX (onnxruntime-web)',
+  })
+  await expect(runtimeCombobox).toBeVisible()
+  await runtimeCombobox.click()
+  await page.getByText('Transformers.js (browser-native, CDN)').click()
+  await expect(
+    page.locator('[role="combobox"]', { hasText: 'Transformers.js' }),
+  ).toBeVisible({ timeout: 15_000 })
+
+  const loadButton = page.getByRole('button', { name: /Load PLiX encoder/i })
+  await expect(loadButton).toBeVisible()
+  await loadButton.click()
+
+  // Success: engine reaches 'ready' and the enrollment hint renders.
+  await expect(page.getByText(/Encoder loaded — record samples to enroll/)).toBeVisible({
+    timeout: 240_000,
+  })
+  const errorText = page.getByText(/Encoder load failed|Failed to load|not found/i)
+  await expect(errorText).toBeHidden()
+})

--- a/apps/web/e2e/sherpa-kws.spec.ts
+++ b/apps/web/e2e/sherpa-kws.spec.ts
@@ -52,7 +52,10 @@ test('sherpa-onnx-kws backend loads (wasm boots + spotter created)', async ({
   await expect(backendSelect).toBeVisible()
   await backendSelect.selectOption('sherpa-onnx-kws')
 
-  const loadButton = page.getByRole('button', { name: /Load models/i })
+  // The sherpa driver is a list-kind provisioning backend (ADR-033): the
+  // Engine card shows its list-load action ('Load with keyword list') instead
+  // of the generic 'Load models' (KWSPanel, #79 rewrite).
+  const loadButton = page.getByRole('button', { name: /Load with keyword list/i })
   await expect(loadButton).toBeVisible()
 
   await loadButton.click()

--- a/docs/modules/kws.md
+++ b/docs/modules/kws.md
@@ -407,19 +407,31 @@ All parameters are surfaced in the **Studio config panel** with the defaults bel
   threshold + min-duration trigger logic, cooldown, VAD gate. These are extracted
   to a testable module (`kws/engine/core/logic.ts`, with numeric DSP in
   `@wake-studio/dsp` ADR-032) with no ONNX dependency.
-- **WASM runtime test (L2, Node):** load the sherpa-onnx-kws emscripten bundle in
-  a Node process (the glue supports `ENVIRONMENT=node`), instantiate the
-  `KeywordSpotter`, and run one inference pass over a synthetic clip. Fast, runs
-  on every PR; catches wasm/model regressions before the slow browser e2e.
+- **WASM/ONNX runtime test (L2, Node):** one suite per driver, running on
+  every PR (ADR-026; the gitignored artifacts are fetched in CI, ADR-027):
+  - `kws-sherpa` — boots the browser emscripten bundle in a Node vm (the
+    glue's `ENVIRONMENT_IS_NODE` path reads the wasm + .data via fs once the
+    sandbox provides `process`), creates a `KeywordSpotter`, decodes a
+    synthetic clip.
+  - `kws-openwakeword` — loads melspectrogram → speech_embedding → hey-buddy
+    classifier via onnxruntime-web, runs one synthetic pass, asserts finite
+    outputs and a classifier score in [0,1].
+  - `kws-plix` — loads the small ONNX encoder + the shared mel front-end,
+    embeds a clip into a finite 1280-dim vector.
+  Each suite skips when its artifact is absent, so CI stays green on a bare
+  checkout.
 - **Integration (browser):** load a real model in Playwright; feed a test audio
   clip and assert the score rises on the wake word and stays low on silence.
 - **Manual / on-device:** speak the demo wake word -> confirm a trigger fires
   with < 500 ms latency; adjust threshold/min-duration sliders -> confirm
   behavior changes predictably; confirm VAD silences KWS during silence.
-- **e2e (Playwright):** `e2e/sherpa-kws.spec.ts` asserts the sherpa-onnx-kws
-  backend boots in the browser (wasm initializes + KeywordSpotter created,
-  status becomes `ready`, `EP: WASM` label renders). Slow (~55 MB wasm fetch),
-  so it runs at a lower cadence than L1/L2 (see testing ADR).
+- **e2e (Playwright):** per-backend load specs assert each backend boots in
+  the browser to `ready` — `sherpa-kws.spec.ts` (wasm + KeywordSpotter),
+  `openwakeword-kws.spec.ts` (worker registration, EP label),
+  `plix-encoder.spec.ts` (onnx) and `plix-transformers.spec.ts` (transformers
+  runtime via CDN + local HF dir). `smoke.spec.ts` pins the panel branches.
+  The sherpa spec is slow (~55 MB wasm), so it runs at a lower cadence than
+  L1/L2 (see testing ADR).
 
 ## 10. Security & privacy
 

--- a/packages/modules/kws/plix/spec/module.spec.json
+++ b/packages/modules/kws/plix/spec/module.spec.json
@@ -111,7 +111,13 @@
         "default": "18",
         "required": false
       }
-    ]
+    ],
+    "fetch": {
+      "source": "release",
+      "releaseTag": "models-plix-v1",
+      "pattern": "*.tar.gz"
+    },
+    "notes": "The ONNX export (small variant, both flat + HF-style layouts) is hosted as a GitHub Release (ADR-027); fetched via scripts/fetch-artifact.mjs. Regenerate with scripts/build-plix.mjs (needs the .pt weights) if a new export is required."
   },
   "tests": {
     "l1": "packages/modules/kws/plix/tests/params.test.ts",

--- a/packages/modules/kws/plix/tests/hf-assets.test.ts
+++ b/packages/modules/kws/plix/tests/hf-assets.test.ts
@@ -1,0 +1,40 @@
+/**
+ * kws-plix - HF-style local dir completeness for the transformers runtime
+ * (ADR-026 L1, #48).
+ *
+ * The 'transformers' runtime (encoders/plix-transformers.ts) loads the model
+ * from a locally-served HF-style dir (`/modules/kws/plix/assets/hf/plixkws`)
+ * instead of the Hub: it needs `config.json` + `onnx/model.onnx` (+ external
+ * data `model.onnx_data`). This suite guards that the fetched assets contain
+ * everything the runtime requires, so a partial fetch is caught in CI without
+ * a browser. Skips when the (gitignored) assets are absent.
+ */
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const hfDir = resolve(here, '../assets/hf/plixkws')
+const requiredFiles = [
+  'config.json',
+  'onnx/model.onnx',
+  'onnx/model.onnx_data',
+] as const
+
+const ASSETS_PRESENT = existsSync(resolve(hfDir, requiredFiles[0]))
+
+describe.skipIf(!ASSETS_PRESENT)('plix transformers runtime assets (L1, #48)', () => {
+  it('the HF-style local dir has every file the transformers runtime needs', () => {
+    for (const rel of requiredFiles) {
+      expect(
+        existsSync(resolve(hfDir, rel)),
+        `missing ${rel} under assets/hf/plixkws/ (run pnpm fetch:all)`,
+      ).toBe(true)
+    }
+    // The runtime splits the local path into base dir + model id
+    // (<localModelPath>/<id>/...): the id must be the last path segment.
+    const config = resolve(hfDir, 'config.json')
+    expect(existsSync(config)).toBe(true)
+  })
+})

--- a/packages/modules/kws/plix/tests/onnx-runtime.test.ts
+++ b/packages/modules/kws/plix/tests/onnx-runtime.test.ts
@@ -1,0 +1,83 @@
+/**
+ * kws-plix driver module - L2 onnx-runtime test (ADR-026, #48).
+ *
+ * Boots the PLiX small ONNX encoder in Node (onnxruntime-web) and runs the
+ * shared acoustic front-end (melSpectrogram -> fitFrames, raw magnitude as
+ * the graph logs internally) + one forward pass: a synthetic 16 kHz clip ->
+ * 1280-dim embedding. Asserts the output is finite, non-zero, and of the
+ * right dimensionality (PLIX_EMBEDDING_DIM).
+ *
+ * The assets are gitignored per ADR-011 (fetch with `pnpm fetch:all`); the
+ * suite skips when they are absent so CI stays green without them.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as ort from 'onnxruntime-web'
+import {
+  PLIX_SAMPLE_RATE,
+  PLIX_WINDOW_LENGTH,
+  PLIX_HOP_LENGTH,
+  PLIX_N_MELS,
+  PLIX_TARGET_FRAMES,
+  melSpectrogram,
+  fitFrames,
+} from '../encoders/plix-frontend'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const MODEL_PATH = resolve(here, '../assets/plixkws-small.onnx')
+const DATA_PATH = resolve(here, '../assets/plixkws-small.onnx.data')
+
+const ASSETS_PRESENT = existsSync(MODEL_PATH) && existsSync(DATA_PATH)
+
+describe.skipIf(!ASSETS_PRESENT)('plix onnx encoder runtime (L2, Node)', () => {
+  let session: ort.InferenceSession
+  let inputName: string
+
+  beforeAll(async () => {
+    // Mirror the browser encoder's external-data handling
+    // (encoders/plix-onnx.ts): the small export stores its weights in a
+    // co-located plixkws-small.onnx.data; pass them explicitly (Node can
+    // also read them from disk, but the explicit path matches the browser
+    // session option shape).
+    session = await ort.InferenceSession.create(readFileSync(MODEL_PATH), {
+      executionProviders: ['wasm'],
+      externalData: [{ path: 'plixkws-small.onnx.data', data: readFileSync(DATA_PATH) }],
+    })
+    inputName = session.inputNames[0]
+  }, 90_000)
+
+  it('embeds a synthetic 16 kHz clip into a finite 1280-dim vector', async () => {
+    // ~1.05 s of a 440 Hz sine -> 104 mel frames, fit to the 100-frame
+    // target the ONNX graph expects ([1, 1, 64, 100]).
+    const samples = new Float32Array(17_000)
+    for (let i = 0; i < samples.length; i++) {
+      samples[i] = Math.sin((2 * Math.PI * 440 * i) / PLIX_SAMPLE_RATE) * 0.5
+    }
+    let mel = melSpectrogram(samples)
+    const numFrames = Math.floor(
+      (samples.length - PLIX_WINDOW_LENGTH) / PLIX_HOP_LENGTH + 1,
+    )
+    mel = fitFrames(mel, numFrames)
+
+    const tensor = new ort.Tensor('float32', mel, [
+      1,
+      1,
+      PLIX_N_MELS,
+      PLIX_TARGET_FRAMES,
+    ])
+    const outputs = await session.run({ [inputName]: tensor })
+    const outputName = session.outputNames.includes('embeddings')
+      ? 'embeddings'
+      : session.outputNames[0]
+    const embedding = outputs[outputName] as ort.Tensor
+    const data = embedding.data as Float32Array
+    // 1280-dim embedding, finite and non-degenerate (a pure sine is not
+    // speech, but the encoder must still produce a real vector).
+    expect(data.length).toBe(1280)
+    expect(data.every((v) => Number.isFinite(v))).toBe(true)
+    const norm = Math.sqrt(data.reduce((acc, v) => acc + v * v, 0))
+    expect(norm).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What

Closes #48 — both PLiX encoder runtimes verified, and the plix assets now have a durable fetch pipeline.

## Changes

- **Assets → GitHub Release** — the plix ONNX assets (small export, flat + HF-style layouts) are hosted on [models-plix-v1](https://github.com/awareride/wake-studio/releases/tag/models-plix-v1); `kws-plix` spec `build.fetch` points at it, so `pnpm fetch:all` works (the Actions artifact `plixkws-onnx` never existed — fetch was broken). Verified locally.
- **L2 onnx test** (`packages/modules/kws/plix/tests/onnx-runtime.test.ts`) — Node loads `plixkws-small.onnx` (external data) + the shared mel front-end and embeds a synthetic clip into a **finite 1280-dim vector**. 264 ms.
- **L1 HF-dir completeness** (`tests/hf-assets.test.ts`) — guards config.json + onnx/model.onnx + data for the transformers runtime.
- **e2e transformers runtime** (`apps/web/e2e/plix-transformers.spec.ts`) — switches the driver runtime param to 'transformers' and loads the encoder in the browser (CDN transformers.js + local HF dir) to ready. ~11 s for all 3 plix specs.
- **e2e fixes for the #79 panel rewrite** (stale text, previously hidden by skip-gating):
  - `plix-encoder.spec.ts`: 'PLiX encoder loaded' → 'Encoder loaded — record samples to enroll'
  - `sherpa-kws.spec.ts`: 'Load models' → 'Load with keyword list' (list-kind provisioning action)

## Evidence

- `pnpm test:unit` green (all packages); plix module 28 tests incl. the new L2/L1.
- Full `pnpm test:e2e` local run: all specs green after the fixes (smoke/sherpa/plix/streaming).
- `node scripts/fetch-artifact.mjs kws-plix` + `pnpm --filter @wake-studio/module-kws-plix fetch:all` verified.

Closes #48