### PR TITLE
docs: sync stale KWS docs + retire .agents/plan/, roadmap in docs/roadmap.md (#87)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,22 +37,21 @@ Three layers, each with its own reader and role. Do not blur them:
 
 | Layer | Where | Reader | Role | Nature |
 |---|---|---|---|---|
-| **Agent guidance** | `.agents/plan/*.plan` (gitignored) | agent | vision, constraints, ADR index, working agreements, issue index | static (low churn) |
+| **Agent guidance** | `AGENTS.md`, `CONTRIBUTING.md`, `docs/roadmap.md` (all tracked) | agent | vision, constraints, roadmap/phase history, working agreements, issue index | static (low churn) |
 | **Work state** | GitHub Issues + `WakeStudio Delivery` project (org `awareride`) | human + cross-session | who/what/when/blocked | dynamic (live) |
 | **Durable knowledge** | `docs/`, `DECISIONS.md`, `docs/modules/*.md` | human + agent | ADRs, architecture, module specs | versioned with code |
 
-### Plan files (`.agents/plan/`) — read, don't maintain state
+### Roadmap doc (`docs/roadmap.md`) — read, don't maintain state
 
-Plan files are **agent-only context**: vision, phase history, ADR index, and
-pointers to issues. They are gitignored on purpose — they are not for GitHub
-readers and never enter PR diffs. Rules:
+The roadmap is **static guidance**: vision, requirements, phase history, and
+pointers to issues. It is tracked on purpose (reviewable on GitHub). Rules:
 
-- Read plan files for **static guidance** at session start (alongside the
-  board). They are the fastest way to load the project's shape.
-- Plan files do **not** hold live state. Do not edit P0/phase/question status
-  tables in them — state lives in GitHub.
-- The only plan-file edits allowed are **static-pointer fixes** (e.g. an issue
-  index line whose number went stale).
+- Read `docs/roadmap.md` for **static guidance** at session start (alongside
+  the board). It is the fastest way to load the project's shape.
+- The roadmap does **not** hold live state. Do not edit phase/status tables
+  in it — state lives in GitHub.
+- The only roadmap edits allowed are **static-pointer fixes** (e.g. an issue
+  number that went stale) and new phase entries once a phase ships.
 
 ### GitHub Issues + Projects — the live state source
 
@@ -61,7 +60,7 @@ project** (org `awareride`), driven through the `gh` CLI. See
 `CONTRIBUTING.md` (Issues & Projects section) for the full model.
 
 - **Session start:** load live state with `gh project item-list 2 --owner
-  awareride` (or `gh issue list`). Prefer this over reading plan state.
+  awareride` (or `gh issue list`). Prefer this over reading doc/roadmap state.
 - Before starting any non-trivial task, confirm the corresponding issue exists
   (create it with `gh issue create` using the task/bug template if not) and
   move it to `In progress` in the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,12 +135,13 @@ and `gh issue close` on merge.
 
 ## Documentation-first (docs-first)
 
-WakeStudio follows a **documentation-first** workflow (see plan §11):
+WakeStudio follows a **documentation-first** workflow (see `docs/roadmap.md`):
 
 - **Durable design lives in `docs/`.** The high-level architecture is in
   `docs/architecture.md`; the ADR log is `DECISIONS.md`; the license matrix is
-  `LICENSES.md`. The `.agents/plan/goal.plan` is the *living* planning doc and is
-  gitignored - promote durable design out of it into `docs/`.
+  `LICENSES.md`; the phased roadmap (vision, phases, model selection, target
+  matrix) is `docs/roadmap.md`. Promote durable design there — never into
+  untracked notes.
 - **Module specs are written just-in-time, before code.** At the start of each
   phase (Phase 1+), copy `docs/module-template.md` to `docs/modules/<name>.md`
   and fill in the contract (purpose, scope, public API/types, data flow,

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -642,13 +642,14 @@ Status legend: `Proposed` · `Accepted` · `Superseded` · `Deprecated`
     browser-only semantics (this is exactly the pitfall noted in the
     sherpa-onnx-kws commit).
 - **Status of this ADR:** Accepted. Implemented: rnnoise L2 wasm-runtime test;
-  per-module L1 suites (10 modules, ~158 tests). L2 for sherpa wasm is
-  deferred — the browser-targeted emscripten bundle does not boot in a plain
-  Node process (waits on `fetch`/DOM shims; hangs to the 120 s timeout, see
-  issue #49). The sherpa L2 test ships as a `SHERPA_L2_RUN=1`-gated scaffold;
-  the follow-up is a Node-targeted glue or the sherpa-onnx NPM binding.
-  openwakeword/plix onnx assets are gitignored, so their L2/e2e run only
-  where the assets are present (issue #50).
+  per-module L1 suites (10 modules, ~158 tests). Sherpa, openwakeword and
+  plix L2 boot suites now run on every PR (2026-08-11): sherpa — the browser
+  emscripten bundle boots in a Node vm once the sandbox provides the Node
+  globals the glue branches on (issue #49 fixed; wasm + .data read via fs);
+  openwakeword — mel → embedding → classifier; plix — 1280-dim embed. The
+  wasm/onnx assets stay gitignored but are hosted as GitHub Releases and
+  fetched in CI (ADR-027 §6.7, issues #50/#48), so the L2/e2e suites execute
+  for real instead of skipping.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Phases 0–3 shipped (AFE, KWS, Few-Shot, console/studio productization), and
 the module platform migration (ADR-025) is complete: all functional areas
 (AFE stages, KWS engine + drivers, Few-Shot, Training) are self-contained
 modules with specs + generated panels. Phase 4 (device SDK + export kits) is
-next. See `.agents/plan/goal.plan` for the full phased roadmap and
+next. See [`docs/roadmap.md`](./docs/roadmap.md) for the full phased roadmap and
 [`DECISIONS.md`](./DECISIONS.md) for recorded decisions.
 
 | Phase | Goal | Status |

--- a/apps/web/public/model-registry.json
+++ b/apps/web/public/model-registry.json
@@ -52,7 +52,7 @@
       "class": "redistributable",
       "sha256": "TODO-phase2",
       "sizeBytes": 1186048,
-      "notes": "Browser-first wake-word model. Commercially clean (CC-BY-4.0). Replaces the CC BY-NC-SA openWakeWord alexa demo model. Now vendored locally under the module assets (user-provided 2026-08-07); no remote fetch."
+      "notes": "Browser-first wake-word model. Commercially clean (CC-BY-4.0). Replaces the CC BY-NC-SA openWakeWord alexa demo model. Fetched from the GitHub Release models-openwakeword-v1 (ADR-027; `pnpm fetch:all`)."
     },
     {
       "id": "plixkws",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,8 @@
 > Status: Accepted (durable overview)
 > Scope: High-level architecture of WakeStudio. This document describes *what the
 > system is* and *how the pieces fit*, not phase-by-phase status (see
-> `.agents/plan/goal.plan` for that). It is kept in sync with `DECISIONS.md` (ADR
+> [`docs/roadmap.md`](roadmap.md) for that). It is kept in sync with
+> `DECISIONS.md` (ADR
 > log) and `LICENSES.md` (third-party license matrix).
 >
 > Companion docs: `docs/module-template.md` (convention for per-module specs),
@@ -400,10 +401,10 @@ package and offers to train a clean replacement instead.
   ADR-013 amended (in-browser training removed, Cloud Providers unified, Colab
   added) and ADR-011 amended (asset pre-fetch).
 - **License matrix:** `LICENSES.md`.
-- **Living plan & phased roadmap:** `.agents/plan/goal.plan` (gitignored; the source
-  of truth for phase status and open questions).
+- **Roadmap & phased status:** `docs/roadmap.md` (static phase history; live
+  status lives in the GitHub project).
 - **Per-module specs:** `docs/modules/*.md`, each written just-in-time at its
-  phase's start using `docs/module-template.md` (see plan §11).
+  phase's start using `docs/module-template.md` (see `docs/roadmap.md`).
 - **KWS categories spec:** `docs/kws-categories.md` — the 3-category taxonomy
   (Traditional / ASR-Decoding / Few-Shot), the decoupling rule, the dual-layer
   unified panel spec, and the P0 integration TODO (ADR-024).

--- a/docs/modules/training.md
+++ b/docs/modules/training.md
@@ -2,7 +2,7 @@
 
 - **Status:** Draft (awaiting human review - the train integration contract)
 - **Owner:** WakeStudio team
-- **Plan phase:** module-migration §6.5 (goal.plan Phase 5)
+- **Plan phase:** ADR-013 + docs/roadmap.md Phase 5
 - **Related ADRs:** ADR-005 (self-hosted service), ADR-013 (training backends:
   Self-hosted / Cloud Providers / Colab), ADR-022 (data-source layer),
   ADR-023 (Colab backend), ADR-028 (uv train scripts)
@@ -16,7 +16,7 @@ Define the **training integration contract** before any code: how the PWA
 submits a training job to each backend (Self-hosted Service, Cloud Providers,
 Google Colab), how status is polled, and how the trained artifacts are
 retrieved. This contract is locked **before** the training module's spec +
-panel are built (§6.5 Step B). Backend implementations land in goal.plan
+panel are built (§6.5 Step B). Backend implementations land in docs/roadmap.md
 Phase 5.
 
 > **Design principle (human, 2026-08-05): preserve upstream train scripts /
@@ -186,7 +186,7 @@ wake-studio-results/<job-id>/
 }
 ```
 
-`provenance.json` is the **license-gate input** (goal.plan Phase 4): it declares
+`provenance.json` is the **license-gate input** (docs/roadmap.md Phase 4): it declares
 the model commercially clean (trained = user-owned) or carries the third-party
 license if the training wrapped a restricted model.
 
@@ -229,16 +229,16 @@ for every provider. Capability labels: train-capable vs inference-only.
 
 | ID | Question | Recommended default |
 |---|---|---|
-| T-1 | **studio-backend train: synchronous (current skeleton) vs async job + streaming** | Keep the synchronous skeleton for the module scaffolding (§6.5 Step B); add async queue + SSE streaming in goal.plan Phase 5. The PWA polls `GET /status`; a job id is added when the queue lands. |
+| T-1 | **studio-backend train: synchronous (current skeleton) vs async job + streaming** | Keep the synchronous skeleton for the module scaffolding (§6.5 Step B); add async queue + SSE streaming in docs/roadmap.md Phase 5. The PWA polls `GET /status`; a job id is added when the queue lands. |
 | T-2 | **Colab import: zip upload vs Drive picker** | Start with zip upload (no Drive API dependency); Drive picker as an enhancement. |
 | T-3 | **Artifact serving auth on a deployed self-hosted service** | Deferred to Phase 5 (per-deployment concern); localhost has no auth. |
 | T-4 | **Where the bundle manifest lives in the PWA** | `packages/modules/training/core/manifest.ts` - the single importer used by all backends. |
-| T-5 | **Which modules have a `train/` target in v1** | kws drivers (sherpa: transduce model frozen, so NO train - it's inference-only per ADR-024 ASR-Decoding; openwakeword: traditional train in Phase 5; plix: encoder is frozen). Training targets land with goal.plan Phase 5 backends. |
+| T-5 | **Which modules have a `train/` target in v1** | kws drivers (sherpa: transduce model frozen, so NO train - it's inference-only per ADR-024 ASR-Decoding; openwakeword: traditional train in Phase 5; plix: encoder is frozen). Training targets land with docs/roadmap.md Phase 5 backends. |
 | T-6 | **Upstream-script adapters (§4): preserve scripts/notebooks as-is vs rewrite** | ✅ **RESOLVED (human, 2026-08-05): preserve.** WakeStudio adapts to the upstream artifact (declare invocation + normalize outputs), never rewrites it. Spec `train` gains `script`/`notebook` + `adapter`/`adapterOptions` fields. |
 
 > T-5 note: per ADR-024, ASR-Decoding (sherpa) is **inference-only** - it has no
 > train target. The training module's first real `train/` targets are the
-> Traditional/MCU path (openWakeWord-style training, goal.plan Phase 5).
+> Traditional/MCU path (openWakeWord-style training, docs/roadmap.md Phase 5).
 
 ## 11. Change log
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -2,7 +2,7 @@
 
 - **Status:** Draft (docs-first; migration §6.1)
 - **Owner:** WakeStudio team
-- **Plan phase:** Module migration (module-migration.plan §6.1); consumed by all modules
+- **Plan phase:** Module migration (ADR-025, completed); consumed by all modules
 - **Related ADRs:** ADR-011 (lazy model registry), ADR-012 (base path),
   ADR-016 (AFE), ADR-021 (device SDK), ADR-025 (module platform),
   ADR-027 (build artifacts)
@@ -113,7 +113,7 @@ export interface AudioSource { start(): Promise<void>; stop(): void }
 
 ## 12. References
 
-- ADR-011/012/025/027; module-migration.plan §6.1; `docs/architecture.md` §3.
+- ADR-011/012/025/027; `docs/roadmap.md` §3; `docs/architecture.md` §3.
 - Legacy homes (migrated 2026-08-05): `apps/web/src/config.ts`,
   `apps/web/src/data/registry.ts` → `packages/platform/src/`.
 - **Sibling platform package:** `@wake-studio/dsp` (ADR-032, `packages/dsp/`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,328 @@
+# WakeStudio — Product Roadmap
+
+> Durable, versioned roadmap (replaces the former `.agents/plan/goal.plan`,
+> which was gitignored and is retired). **Live work state lives in GitHub**
+> (Issues + the `WakeStudio Delivery` project, org `awareride`) — this doc
+> keeps the static vision, phase history, and pointers; it never holds live
+> status.
+> Owner: WakeStudio team · Updated: 2026-08-11 (KWS Phase-3 closure shipped)
+> Companions: `docs/architecture.md` (durable architecture), `DECISIONS.md`
+> (ADR log), `LICENSES.md` (license matrix), `docs/modules/*.md` (module
+> specs), `CONTRIBUTING.md` (working agreements + issue/project model).
+
+---
+
+## 1. Vision
+
+Build **WakeStudio**, a Progressive Web App (PWA) console that lets a developer
+or product engineer go from "I have a wake word idea" to "I have a deployable,
+testable KWS bundle for my target chip" — **without installing any toolchain,
+runtime, or Python environment**.
+
+WakeStudio wraps the full voice pipeline:
+
+```
+AEC ──> BSS ──> NS ──> KWS
+```
+
+and makes every stage (1) **trainable/customizable** (in the browser where
+feasible, otherwise via a training backend), (2) **visible** through real-time
+visualization, and (3) **exportable** to mainstream embedded and
+application-processor targets, complete with reference integrations and runnable
+demo apps.
+
+**Core product principle:** _Do not invent new models._ WakeStudio is a
+**productization layer** over excellent open-source models and DSP components.
+We select, integrate, harden, and package — we do not train new foundation
+models.
+
+**Two domains** (see README): low-power (MCU) vs high-performance
+(Linux/Android), served by two KWS tracks with different open-source stacks.
+
+## 2. Requirements
+
+| # | Requirement | How the plan addresses it |
+|---|---|---|
+| R1 | Full-chain AFE: AEC -> BSS -> NS -> KWS | Browser audio graph runs the whole chain; each stage is a pluggable module (ADR-025). AEC is passthrough for v1 (ADR-016). |
+| R2 | Works out-of-the-box, no environment setup | PWA console running the live experience client-side (WebAudio + WASM + onnxruntime-web). Training runs on one of three backends, not in the browser (ADR-013). |
+| R3 | Users upload a few wake-word samples to train a new model | Few-Shot enrollment (3–5 samples, PLiX encoder, prototype-distance) is fully client-side (Phase 3, ADR-002). |
+| R4 | Model export for the full cross-device matrix + integration refs + testable demos | Phase 4 export kits built on the device-side SDK (ADR-021); every bundle ships a runnable demo (ADR-019). |
+| R5 | In-app experience with visual outputs across the pipeline | Phases 1–2 deliver real-time visualizations per stage; the Workspace pipeline canvas orchestrates them. |
+| R6 | Two domains: Low-power (MCU) vs High-performance (Linux/Android) | Two KWS tracks with different open-source stacks, selected per target via pluggable `KWSBackend` (ADR-020). |
+| R7 | High-performance supports user-defined wake words via Few-Shot KWS | Few-Shot track (Phase 3) — shipped. |
+| R8 | Low-power and high-performance use different KWS solutions | MCU = Traditional (classification) KWS (micro-wake-word); App-class = Few-Shot (metric-learning, PLiX) (ADR-020). |
+
+## 3. Architecture & module platform
+
+The durable architecture lives in `docs/architecture.md`; the ADR log in
+`DECISIONS.md` (ADR-001…). Key invariants:
+
+- **Pipeline** is strictly **AEC → BSS → NS → KWS** (ADR-001); AEC/BSS are
+  passthrough for v1 (ADR-016), NS is RNNoise (vendored WASM), KWS is pluggable.
+- **Monorepo** (ADR-025): `apps/web` (PWA), `apps/local-service` (Node API,
+  self-hosted training backend), `packages/contracts` (shared types/schemas),
+  `packages/module-kit` (spec-driven panel generator), `packages/test-kit`
+  (L2 wasm runner), `packages/platform` (base-path, registry, runtime seams),
+  `packages/modules/*` (functional modules), `packages/sdk` (device SDK),
+  top-level `device/` (C/C++ CMake tree). A module owns core + spec +
+  generated panel + tests + playground + multi-target deliverables;
+  `module.spec.json` is the single shared fact source.
+- **Module migration (ADR-025/029/030/031) is complete** — every functional
+  area is a self-contained module (AFE stages + graph, KWS engine + drivers,
+  Few-Shot, Training); panels are generated, never hand-written; assets are
+  module-owned (ADR-025/027).
+- **Training runs on three backends** (ADR-013 amended): Self-hosted Service,
+  Cloud Providers (capability-labeled), Google Colab (ADR-023). In-Browser
+  WASM is inference/Few-Shot enrollment only.
+- **KWS** is organized into three categories (ADR-024): Traditional, ASR
+  Decoding, Few-Shot — with a hard decoupling rule (a new category = a driver
+  module + a panel, no shared-module edits). Newer: provisioning capabilities
+  (ADR-033) and composition roots (ADR-034) — drivers self-register; the host
+  dispatches on capabilities, never per-driver code.
+- **Exports** are client-side `.zip` bundles built on the layered device-side
+  SDK (ADR-021); a license gate blocks non-commercial models (ADR-009/011).
+- **Testing** is three-layer (ADR-026): L1 unit, L2 wasm/onnx boot (Node,
+  every PR), L3 browser e2e (merge gate). All KWS drivers have L2 suites that
+  run for real in CI (sherpa/openwakeword/plix; assets are GitHub Release
+  hosted, ADR-027 §6.7).
+- **Deploy** (ADR-012): `VITE_BASE_PATH` — `/` for Cloudflare, `/<repo>/` for
+  GitHub Pages.
+
+## 4. Model & component selection
+
+> The authoritative matrix is `LICENSES.md`; the KWS taxonomy is
+> `docs/kws-categories.md`. Key fact: **openWakeWord's pre-trained models are
+> CC BY-NC-SA 4.0 (demo-only)** — they must never enter a commercial bundle;
+> the Phase 4 export license gate enforces this.
+
+| Backend | Category (ADR-024) | License | Tier / targets | In repo today |
+|---|---|---|---|---|
+| **openWakeWord** (`dscripka/openWakeWord`) | Traditional | Apache-2.0 code; CC BY-NC-SA pre-trained models (demo-only) | App-class (Pi, desktop, mobile, browser) | ✅ `packages/modules/kws/openwakeword/` |
+| **sherpa-onnx KWS** (`k2-fsa/sherpa-onnx`) | ASR Decoding | Apache-2.0 | App-class + MCU; real KWS transducer, compiled WASM in-browser | ✅ `packages/modules/kws/sherpa/` (wasm from Release `models-sherpa-wasm-v1`) |
+| **PLiX Few-Shot** (`aaqibsaeed/plixkws`) | Few-Shot | Apache-2.0 | App-class, enrollment-based (prototype-distance, ADR-002); onnx + transformers runtimes | ✅ `packages/modules/kws/plix/` |
+| **micro-wake-word** (`OHF-Voice/micro-wake-word`) | Traditional | Apache-2.0 | MCU (Cortex-M, ESP32) via TFLite-Micro | ⏳ Phase 4/5 |
+| **PocketSphinx** (`cmusphinx/pocketsphinx`) | Traditional (lightweight alt) | BSD-style | MCU-class and above, lightweight alternative | ⏳ Pending (ADR-020) |
+
+AFE components (ADR-016): AEC = passthrough for v1 (WebRTC/SpeexDSP in
+exports); BSS = passthrough or 2-mic approximation (vendor BSS in exports);
+NS = **RNNoise** (vendored WASM, AudioWorklet); VAD = RNNoise VAD score
+(Silero deferred to v1.x). Inference = onnxruntime-web (WebGPU + WASM fallback)
+in a Web Worker; TTS/synthetic data = Piper, runs in training backends, not the
+browser (ADR-022). UI = React 18 + Vite 5 + TS 5 + Tailwind 3 + Radix.
+
+## 5. Target platforms & export matrix (ADR-019)
+
+Export is client-side `.zip` generation (JSZip) built on the device-side SDK
+(ADR-021); the license gate blocks non-commercial models.
+
+| Target | Tier | KWS backend(s) | SDK binding | Status |
+|---|---|---|---|---|
+| **Arm Cortex-M** (STM32, Arduino) | MCU (primary) | micro-wake-word; PocketSphinx (alt) | C / TFLite-Micro | ⏳ Phase 4 |
+| **Raspberry Pi** (Zero/3/4/5) | App-class edge | openWakeWord / PLiX / PocketSphinx | Python | ⏳ Phase 4 |
+| **Android** | Mobile | openWakeWord / PLiX (ONNX RT) | Kotlin | ⏳ Phase 4 |
+| **iOS** | Mobile | openWakeWord / PLiX (ONNX RT / Core ML) | Swift | ⏳ Phase 4 |
+| **Browsers** (Chrome/Safari/Firefox/Edge) | Browser | openWakeWord / PLiX (onnxruntime-web) | JS / WASM | ✅ (in-app demo) |
+| **Linux** (x86_64) | Desktop | openWakeWord / PLiX / PocketSphinx | Python | ⏳ Phase 4 |
+| **macOS** / **Windows** | Desktop | openWakeWord / PLiX | Python / Swift | ⏳ Phase 4 |
+| **ESP32-S3** (deferred) | MCU (extended) | micro-wake-word | C / TFLite-Micro | ⏳ Deferred |
+
+## 6. Phased roadmap
+
+Each phase is independently validatable and follows the **docs-first** rule:
+the relevant module doc (`docs/modules/*.md`) is written/reviewed before the
+module is implemented, and updated in the same change as the code (docs-sync
+rule, `CONTRIBUTING.md`).
+
+### Phase 0 — Foundation, decisions & scaffold — ✅ Complete
+
+ADR-001…012 recorded; pnpm workspace + PWA shell (Vite 5 + React 18 + TS 5 +
+Tailwind 3 + `vite-plugin-pwa`); model-registry manifest + lazy loader; CI +
+deploy workflow scaffolds (dormant, ADR-015); docs-first baseline.
+
+### Phase 1 — In-browser AFE + pipeline visualization — ✅ Complete
+
+RNNoise NS (vendored WASM, ADR-016), AudioWorklet pipeline, per-stage bypass,
+latency meter, Record/Replay, config panel from `describeParameters()`
+(ADR-017). AEC/BSS passthrough for v1 (ADR-016).
+
+### Phase 2 — KWS inference in the browser — ✅ Complete
+
+`KWSBackend` interface (ADR-020); **openWakeWord** backend (mel/embed/
+classifier in a Web Worker, ADR-018); **sherpa-onnx-kws** backend (real KWS
+transducer via compiled WASM, ADR-024 ASR-Decoding); score curve,
+threshold/min-duration smoothing, trigger flash, VAD gating (ADR-018).
+
+### Phase 3 — Few-Shot custom wake-word enrollment — ✅ Complete
+
+PLiX encoder (ADR-002) + prototype-distance scoring (client-side), sample
+recording with quality checks, IndexedDB persistence, enrollment UI,
+anti-false-trigger measures, Few-Shot bundle export.
+
+### Phase 3.5 — Console / Studio productization — ✅ Complete
+
+App shell (Radix), hash routing, status bar; Workspace + project model
+(IndexedDB) + pipeline canvas + unified spec-driven config panels; Model
+Library + export license gate; Session console + trigger history; base-path
+awareness (ADR-012); module platform (ADR-025).
+
+### Phase 3.6 — Module platform migration (ADR-025/029/030/031) — ✅ Complete
+
+All functional areas moved from `apps/web/src/{afe,kws,few-shot}` into
+self-contained modules with specs + generated panels: `packages/platform`,
+per-stage AFE modules, KWS engine + per-backend drivers (self-registration,
+ADR-030), Few-Shot, Training (contract + spec panel, ADR-031). Follow-ups:
+KWSPanel registration seams (ADR-034), provisioning capability (ADR-033),
+kws-streaming module.
+
+### Phase 3.7 — KWS Phase-3 closure — ✅ Complete (2026-08-11)
+
+Every KWS backend loads in the browser and is guarded by tests that run for
+real on every PR (PRs #82/#84/#85/#86):
+
+- L2 boot suites for all drivers: **sherpa** (the browser emscripten bundle
+  boots in a Node vm — #49), **openwakeword** (mel → embedding → classifier),
+  **plix** (1280-dim embed, #48).
+- Asset pipeline (ADR-027 §6.7): the wasm/onnx assets are hosted as GitHub
+  Releases (`models-sherpa-wasm-v1`, `models-openwakeword-v1`,
+  `models-plix-v1`) and fetched in CI — the L2/e2e suites execute instead of
+  skipping; `scripts/fetch-artifact.mjs` gained a release-download mode.
+- e2e per backend (sherpa/openwakeword/plix onnx + transformers) + stale
+  assertions from the panel rewrite fixed.
+
+### Phase 4 — Device-side SDK & export kits (ADR-021) — ⏳ Next
+
+> Tracked as epic [#31](https://github.com/awareride/wake-studio/issues/31)
+> with sub-issues #37–#42 in the `WakeStudio Delivery` project.
+> Docs-first: `docs/modules/sdk.md` + `docs/modules/export.md` before code.
+
+1. **SDK core (C/C++, `packages/sdk` + `device/`):** portable core
+   (`KWSBackend` interface ADR-020, portable AFE ADR-003/016, audio I/O +
+   threading + clock abstractions, VAD); CMake tree in `device/` (ADR-025).
+   Validate with one C unit-test harness first.
+2. **Target adapters:** first two golden paths — **Cortex-M** (STM32/Arduino,
+   micro-wake-word + TFLite-Micro) and **Raspberry Pi** (PLiX/openWakeWord +
+   Python); then Android (Kotlin), iOS (Swift), desktop (Python), browsers
+   (JS/WASM).
+3. **Language bindings** per target (ADR-021 §3).
+4. **Bundle generation:** client-side `.zip` per target (model + AFE config +
+   SDK adapter + demo + README + LICENSES + test); each bundle runs a demo.
+5. **License gate:** block CC BY-NC-SA models from commercial exports; offer
+   to train a clean replacement (Phase 5).
+6. **PocketSphinx** backend as the lightweight Traditional alternative
+   (ADR-020): driver module + panel under the ADR-024 decoupling rule.
+
+Validation: Cortex-M bundle builds on real hardware and triggers on the wake
+word; Pi bundle runs and triggers; bundle README lists every included license;
+the gate blocks a non-commercial model from a commercial export.
+
+### Phase 5 — Custom-model training (multi-backend) — ⏳ Pending
+
+> Docs-first: `docs/modules/training.md` + `docs/modules/data-sources.md`
+> (stubs exist; the train integration contract is locked — ADR-013/023/028).
+> Training never runs in the browser (ADR-013 amendment).
+
+1. **Common training-job interface** (ADR-013): one PWA flow — type the wake
+   phrase, choose target, choose backend, monitor status, retrieve artifacts
+   into the app for in-browser test + export.
+2. **Self-hosted Service** (`apps/local-service`, ADR-005): real training
+   runner (`train-runner.ts` invokes module `train/` scripts via `uv`,
+   ADR-028); PyInstaller binary + Docker image; candidate engine
+   `TigreGotico/wakeforge` (`ww_trainer`) — evaluate (Q10).
+3. **Cloud Providers** (capability-labeled): AWS / Google Cloud / Hugging
+   Face / Alibaba / Tencent / Volcengine adapters behind the common interface;
+   credentials client-side only.
+4. **Google Colab** (ADR-023): version-controlled notebooks (`colab/`);
+   standard result bundle convention (shared artifact-bundle manifest).
+5. **Data-source layer** (ADR-022): in-app endpoint config for local
+   services / project APIs / public TTS endpoints.
+6. **Traditional training panels** (ADR-024 §4.2): a trained model is
+   commercially ownable (FAR/FRR report before export).
+
+### Phase 6 — Polish, PWA, packaging, docs — ⏳ Pending
+
+1. **Offline:** vendor the onnxruntime-web wasm pair locally and point
+   `ort.env.wasm.wasmPaths` at it (CDN dependency gone); asset pre-fetch per
+   the ADR-011 amendment with checksum verification.
+2. **CI/CD activation (ADR-015):** fix the `deploy.yml` Cloudflare
+   `--project-name` rename (wave-studio → wake-studio, ADR-014); fetch wasm
+   before build in deploy jobs; configure environments/secrets; run the first
+   manual deploy; enforce CI green on PRs (also resolves the P0 blockers
+   below).
+3. **Accessibility + i18n scaffold** (English first, per repo policy),
+   keyboard shortcuts, empty/loading/error states, onboarding tour.
+4. **PWA quality:** Lighthouse PWA = 100, performance ≥ 90 on the deployed
+   build; security review (mic permissions, CSP, credential handling).
+5. **Docs reconcile:** `docs/modules/*.md` with shipped reality; public docs
+   site.
+
+### Phase 7 — v1.x backlog (documented, unprioritized)
+
+WebRTC AEC3 WASM (ADR-016 deferral); Silero VAD gating (ADR-018 deferral);
+ESP32-S3 golden path; PocketSphinx full MCU demo; openWakeWord
+training-verifier integration; node-per-stage AudioWorklet topology (ADR-016).
+
+## 7. Live work state (GitHub)
+
+Task state lives in **Issues + the `WakeStudio Delivery` project** (org
+`awareride`, project #2); load it with `gh project item-list 2 --owner
+awareride` (see `CONTRIBUTING.md`). This doc only keeps pointers.
+
+**P0 blockers** (delivery chain — gate every later phase): issues
+[#27](https://github.com/awareride/wake-studio/issues/27) (lint red in
+contracts/test-kit), [#28](https://github.com/awareride/wake-studio/issues/28)
+(playwright CI resolution), [#29](https://github.com/awareride/wake-studio/issues/29)
+(deploy wasm fetch + Cloudflare rename), [#30](https://github.com/awareride/wake-studio/issues/30)
+(vendor ONNX wasm / offline).
+
+**Open questions** (close with a decision that lands as an ADR): #32 (Q10:
+self-hosted training engine), #33 (Q11: L3 e2e cadence), #34 (Q12: PocketSphinx
+timing), #35 (Q13: SDK core CI), #36 (Q14: vendor ONNX wasm now vs Phase 6).
+
+**Next actions** (from the board): close the P0 blockers; start Phase 4 SDK
+(epic #31).
+
+## 8. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Device SDK (Phase 4) is a large C/C++ deliverable with no precedent in this repo | High | High | Validate with one C unit-test harness + one golden-path target (Cortex-M) first; keep the JS PWA unchanged; CI runs a native SDK build on every PR |
+| Export bundles can accidentally ship CC BY-NC-SA models commercially | High | High | License gate (already scaffolded); always train our own models (Phase 5); `LICENSES.md` matrix |
+| Few-Shot high false-alarm rate (only 3–5 samples) | High | Medium | Negative prototypes + VAD gating + min-duration smoothing (shipped) |
+| Cloud-provider credential leakage | Medium | High | Credentials client-side only; never logged/exported; Phase 6 security review |
+| onnxruntime-web wasm on CDN breaks offline promise | Medium | Medium | Vendor locally (Phase 6 / P0-4) |
+| Browser WebGPU/WASM SIMD support varies | Medium | Medium | Feature-detect + WASM fallback |
+| CI red (P0-1/P0-2) blocks all PRs | High | High | P0 blockers land first; they are the gate for everything else |
+
+## 9. Out of scope (non-goals for v1)
+
+- Cloud/server-side processing of the **live pipeline** (capture/AFE/KWS stays
+  100% client-first).
+- Continuous large-vocabulary ASR (KWS + optional short command words only).
+- Training new foundation encoders (we freeze PLiX / Google speech_embedding /
+  sherpa transducer models).
+- Multi-user / multi-wake-word simultaneous detection on MCU.
+- A proprietary/commercial KWS engine (optional, clearly-marked upgrade path).
+- Real AEC/BSS DSP in the browser (deferred to v1.x; device-side vendor AFE in
+  exports).
+
+## 10. References
+
+- openWakeWord: https://github.com/dscripka/openWakeWord (Apache-2.0 code;
+  CC BY-NC-SA pre-trained models)
+- micro-wake-word: https://github.com/OHF-Voice/micro-wake-word (Apache-2.0)
+- sherpa-onnx: https://github.com/k2-fsa/sherpa-onnx (Apache-2.0)
+- wakeforge (`ww_trainer`): https://github.com/TigreGotico/wakeforge
+  (Apache-2.0; Q10 candidate)
+- PLiX KWS: https://github.com/aaqibsaeed/plixkws (Apache-2.0)
+- PocketSphinx: https://github.com/cmusphinx/pocketsphinx (BSD-style)
+- RNNoise: https://gitlab.xiph.org/xiph/rnnoise ; wasm ports (jitsi/timephy)
+- Silero VAD: https://github.com/snakers4/silero-vad (MIT)
+- Piper: https://github.com/OHF-Voice/piper1-gpl (GPL-3.0, active) /
+  https://github.com/rhasspy/piper (MIT, archived)
+- onnxruntime-web: https://onnxruntime.ai/docs/get-started/with-javascript.html
+- WavLM (superseded by PLiX, ADR-002):
+  https://huggingface.co/microsoft/wavlm-base-plus (MIT)
+- Pre-research: `docs/Technical Pre-Research & Feasibility Study_ On-Device
+  Wake Word Detection Systems.md`; `docs/Technical Reference_ Resource
+  Requirements and Zero-Python Deployment Strategies for WavLM-base-plus and
+  plixkws.md`

--- a/packages/modules/kws/plix/assets/README.md
+++ b/packages/modules/kws/plix/assets/README.md
@@ -26,10 +26,14 @@ Python step required at deploy time.
 
 ## ONNX route (default)
 
-What goes here:
+Assets are fetched from the GitHub Release `models-plix-v1` (ADR-027;
+`pnpm fetch:all` — the spec's `build.fetch.source=release`). What goes here:
 
 - `plixkws-base.onnx` — the **base** encoder (EfficientNet-v2-M, 1280-dim).
-- `plixkws-small.onnx` — the **small** encoder (TinyNet-E, 1280-dim).
+  **Not vendored** (the base export is not in the release); select it via a
+  custom encoder URL or export with `scripts/build-plix.mjs`.
+- `plixkws-small.onnx` — the **small** encoder (TinyNet-E, 1280-dim) — the
+  vendored/registry default.
 - `plixkws-small.onnx.data` — **external weights** for the `small` export
   (ONNX external-data format). Must sit **next to** `plixkws-small.onnx` so
   onnxruntime-web can resolve it. (The `base` export is a single self-contained

--- a/packages/modules/kws/sherpa/assets/README.md
+++ b/packages/modules/kws/sherpa/assets/README.md
@@ -4,8 +4,12 @@ This directory holds the sherpa-onnx KWS WebAssembly runtime (the ~53 MB
 bundle) **at runtime only** - it is gitignored (ADR-011) and never committed.
 
 The wasm glue + `.wasm` + `.data` are produced by the generic build workflow
-(`.github/workflows/build.yaml` + `scripts/build-module.mjs kws-sherpa`,
-ADR-027 §6.7) and published as the `sherpa-onnx-kws-wasm` artifact.
+(`.github/workflows/build.yaml` + `scripts/build-sherpa-kws.mjs`, ADR-027
+§6.7). The bundle is hosted as the GitHub Release `models-sherpa-wasm-v1`;
+the module spec's `build.fetch.source=release` points there, and
+`scripts/fetch-artifact.mjs kws-sherpa` downloads it (CI does this on every
+PR so the L2 suite + e2e run for real). The build script remains the
+regeneration path when a fresh build is needed.
 
 The build pins sherpa-onnx **master** (default `sherpa_version` input) - NOT
 a release tag - because upstream commit `dcf56735` (#3836, 2026-08-04)
@@ -18,7 +22,8 @@ latest bilingual one, `sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20`
 ## Fetch locally (dev / preview)
 
 ```bash
-# generic path (reads the module spec's build.artifactName):
+# generic path (reads the module spec's build.fetch — Actions artifact or
+# GitHub Release):
 node scripts/fetch-artifact.mjs kws-sherpa
 ```
 


### PR DESCRIPTION
Docs-sync after the KWS Phase-3 closure stack (#82/#84/#85/#86):

- **DECISIONS.md ADR-026 status**: the L2 gap is closed — sherpa boots in Node (issue #49), openwakeword/plix L2 suites run, and the gitignored assets are release-hosted + CI-fetched (ADR-027 §6.7) so the suites execute instead of skipping.
- **model-registry.json**: hey-buddy note now points at the models-openwakeword-v1 release (was 'user-provided, no remote fetch').
- **kws-sherpa assets README**: bundle hosted on models-sherpa-wasm-v1; fetch comment covers release mode.
- **kws-plix assets README**: notes the models-plix-v1 fetch and that plixkws-base.onnx is not vendored (small is the default).

Closes #87 

---

## Also in this PR: retire the plan files

The gitignored `.agents/plan/` docs are retired; durable content is now tracked:

- **NEW `docs/roadmap.md`** — vision, requirements (R1–R8), architecture/module-platform summary, model + target matrices, phased roadmap (Phases 0–7, incl. the KWS Phase-3 closure as Phase 3.7), live-state pointers (P0 blockers / open questions / next actions → GitHub issues), risks, out-of-scope, references. Live status tables were **not** carried over (GitHub owns state); stale validation claims dropped.
- **AGENTS.md / CONTRIBUTING.md** — the agent-guidance layer is now tracked docs (`docs/roadmap.md`); plan-file rules removed; session start still loads the board.
- **README / architecture / platform / training docs** — references re-pointed from plan files to `docs/roadmap.md` (or the ADRs, for the completed migration).
- `.agents/` deleted locally (gitignored — nothing to commit). The migration content was already in ADR-025…031 + `docs/architecture.md`; the gh-management content was already in AGENTS/CONTRIBUTING.