### PR TITLE
ui(workspace): flat page, full-width live cards, even spacing, clean sticky (#89)

### DIFF
--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -494,8 +494,10 @@ function WorkspaceInner({
 
           <div className="mt-4 space-y-4">
             <PipelineLevelCurve frameData={frameData} running={runState.afeRunning} />
-            {/* Detailed per-stage cards (waveform + level + metric + spectrum). */}
-            <div className="mx-auto grid max-w-5xl gap-4 sm:grid-cols-3 items-stretch">
+            {/* Detailed per-stage cards (waveform + level + metric + spectrum).
+                Full width, like the chart above — no centered max-w cap that
+                would leave side gutters. */}
+            <div className="grid gap-4 sm:grid-cols-3 items-stretch">
               {(['aec', 'bss', 'ns'] as const).map((id) => (
                 <StagePanel
                   key={id}

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -324,7 +324,7 @@ function WorkspaceInner({
         <div>
           {/* Sticky unit: section header + stage cards pin to the workspace top
               while the active module panel scrolls underneath (blurred). */}
-          <div className="sticky top-0 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
+          <div className="sticky top-3 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
               <span className="rounded bg-brand-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-brand-300">
                 Setup
@@ -447,7 +447,7 @@ function WorkspaceInner({
       {/* ============ LIVE dashboard (after Start) ============ */}
       {previewVisible && (
         <div>
-          <div className="sticky top-0 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
+          <div className="sticky top-3 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
               <span className="rounded bg-emerald-500/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-emerald-300">
                 Live

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -324,7 +324,12 @@ function WorkspaceInner({
         <div>
           {/* Sticky unit: section header + stage cards pin to the workspace top
               while the active module panel scrolls underneath (blurred). */}
-          <div className="sticky top-3 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
+          {/* Sticky unit: the wrapper pins flush (top-0) with a solid
+              page-surface strip above the floating card, so scrolled content
+              never shows through the margin (top-3 alone would leave a
+              see-through gap). */}
+          <div className="sticky top-0 z-20 bg-surface pt-3">
+            <div className="rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
               <span className="rounded bg-brand-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-brand-300">
                 Setup
@@ -339,6 +344,7 @@ function WorkspaceInner({
               onSelect={setActiveTab}
               cards={stageCards}
             />
+            </div>
           </div>
           <div className="mt-4">
 
@@ -447,7 +453,8 @@ function WorkspaceInner({
       {/* ============ LIVE dashboard (after Start) ============ */}
       {previewVisible && (
         <div>
-          <div className="sticky top-3 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
+          <div className="sticky top-0 z-20 bg-surface pt-3">
+            <div className="rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
               <span className="rounded bg-emerald-500/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-emerald-300">
                 Live
@@ -489,6 +496,7 @@ function WorkspaceInner({
                 onToggleEnabled={() => toggleKws(!kwsEnabled)}
                 preview={<MiniScoreCurve />}
               />
+            </div>
             </div>
           </div>
 

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -319,10 +319,12 @@ function WorkspaceInner({
           form state survive the switch to Live — unmounting would dispose
           the engine mid load (epic #53 KWS fix). */}
       <div className={previewVisible ? 'hidden' : ''}>
-        <section className="rounded-2xl border border-line bg-surface-1 p-4">
+        {/* No outer box: the workspace page is flat — the sticky header and
+            inner cards carry their own surfaces. */}
+        <div>
           {/* Sticky unit: section header + stage cards pin to the workspace top
               while the active module panel scrolls underneath (blurred). */}
-          <div className="sticky top-0 z-20 -mx-2 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
+          <div className="sticky top-0 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
               <span className="rounded bg-brand-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-brand-300">
                 Setup
@@ -439,13 +441,13 @@ function WorkspaceInner({
             </StageModuleShell>
           </div>
           </div>
-        </section>
+        </div>
       </div>
 
       {/* ============ LIVE dashboard (after Start) ============ */}
       {previewVisible && (
-        <section className="rounded-2xl border border-line bg-surface-1 p-4">
-          <div className="sticky top-0 z-20 -mx-2 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
+        <div>
+          <div className="sticky top-0 z-20 rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
               <span className="rounded bg-emerald-500/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-emerald-300">
                 Live
@@ -493,7 +495,7 @@ function WorkspaceInner({
           <div className="mt-4 space-y-4">
             <PipelineLevelCurve frameData={frameData} running={runState.afeRunning} />
             {/* Detailed per-stage cards (waveform + level + metric + spectrum). */}
-            <div className="mx-auto grid max-w-5xl gap-5 sm:grid-cols-3 items-stretch">
+            <div className="mx-auto grid max-w-5xl gap-4 sm:grid-cols-3 items-stretch">
               {(['aec', 'bss', 'ns'] as const).map((id) => (
                 <StagePanel
                   key={id}
@@ -511,7 +513,7 @@ function WorkspaceInner({
               config={persistence}
             />
           </div>
-        </section>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
Two workspace UI nits (issue #89):

1. **No more section boxes.** The Setup and Live views were wrapped in
   `<section class='rounded-2xl border … p-4'>` cards; on the workspace page
   that extra box is unnecessary (the sticky headers + inner cards already
   carry their own surfaces). Both wrappers removed; the sticky headers drop
   the now-meaningless `-mx-2` negative margin.

2. **Uniform live-dashboard spacing.** The detailed AEC/BSS/NS cards grid used
   `gap-5` (20 px) while the dashboard uses `space-y-4` (16 px) — so when
   the cards wrapped to another row (narrow windows), the row gap didn't match
   the gap between the top Level/VAD chart and the cards. Grid now `gap-4`:
   every vertical gap in the live dashboard is 16 px.

Verified by DOM measurement (temporary playwright probe, since removed):
chart→cards gap = 16 px and wrapped-row gap = 16 px at 620–1440 px
viewports. Typecheck + lint (0 errors) + smoke e2e (8/8) green.

Closes #89

---

**Follow-up:** the AEC/BSS/NS cards row was capped at `max-w-5xl` (1024 px, centered), so on wider screens it sat narrower than the Level/VAD chart above with empty side gutters. The cap is gone — the cards now span the full content width, aligned with the chart and the panels below (verified: identical left/right edges at 1440 px).

---

**Follow-up:** the Setup/Live sticky headers pinned at `top-0` — flush against the shell's top bar when scrolling. Now `sticky top-3`: a 12 px gap (verified by DOM measurement).

---

**Follow-up:** the sticky headers no longer show scrolled content in the margin. The wrapper pins flush (`top-0`) with a solid `bg-surface` strip (`pt-3`), and the floating card sits inside — the visual 12 px margin stays, but content scrolling underneath is hidden behind the solid strip (verified: elementFromPoint at the strip returns the wrapper, not scrolled content).