### PR TITLE
fix(p0): point CI/deploy at apps/web/dist (P0-3 deploy wasm path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist
+          # The web app's vite root is apps/web, so the build emits
+          # apps/web/dist (not ./dist). Upload that (P0-3).
+          path: apps/web/dist
           retention-days: 7
 
   e2e:
@@ -117,5 +119,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: playwright-report
+          path: apps/web/playwright-report
           retention-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          # The web app's vite root is apps/web -> build emits apps/web/dist.
+          path: apps/web/dist
 
       - name: Deploy to GitHub Pages
         id: deployment
@@ -107,5 +108,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # ADR-014: the project name is wake-studio (was wave-studio).
-          command: pages deploy dist --project-name=wake-studio
+          # ADR-014: the project name is wake-studio (was wave-studio). The
+          # web app's vite root is apps/web -> build emits apps/web/dist.
+          command: pages deploy apps/web/dist --project-name=wake-studio


### PR DESCRIPTION
## Summary

The web app's vite root is `apps/web`, so `pnpm build` emits `apps/web/dist`, not `./dist`. The CI and deploy workflows referenced root `dist/`, which silently no-ops:

- `ci.yml` artifact upload logged **"No files were found with the provided path: dist. No artifacts will be uploaded."** (masked by `if-no-files-found: warn`)
- `deploy.yml` would have published an **empty site** on the first manual deploy → deployed KWS wasm 404s (P0-3)

## Changes

- `ci.yml`: upload `apps/web/dist`; point the playwright-report upload at `apps/web/playwright-report`
- `deploy.yml`: `upload-pages-artifact` and Cloudflare `pages deploy` now use `apps/web/dist`

## Verification

- YAML structure validated visually; edits are minimal path-only changes
- Local build confirmed the output lives in `apps/web/dist` (incl. `dist/ort/` wasm pair + `dist/modules/`)
- CI on this PR should now show a real `dist` artifact upload (no warning)

Closes #29 (P0-3 deploy path fix)