### PR TITLE
feat(web): rename 'Model Library' nav item to 'Model Registry' (#78)

### DIFF
--- a/apps/web/e2e/recent-projects.spec.ts
+++ b/apps/web/e2e/recent-projects.spec.ts
@@ -23,9 +23,9 @@ test('recent projects: create via menu, switch from another view', async ({ page
   // The trigger now shows the current project name.
   await expect(page.getByRole('button', { name: /Recent Word/ })).toBeVisible()
 
-  // Navigate away to the model library — the workspace (and its menu) is
+  // Navigate away to the model registry — the workspace (and its menu) is
   // kept alive but hidden.
-  await page.locator('aside').getByRole('button', { name: 'Model Library' }).click()
+  await page.locator('aside').getByRole('button', { name: 'Model Registry' }).click()
   await expect(page).toHaveURL(/#\/library/)
   await expect(page.getByRole('button', { name: /Recent Word/ })).toBeHidden()
 

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -18,7 +18,7 @@ test('console shell renders: sidebar + workspace default view', async ({ page })
   const sidebar = page.locator('aside')
   await expect(sidebar).toBeVisible()
   await expect(sidebar.getByRole('button', { name: 'Workspace' })).toBeVisible()
-  await expect(sidebar.getByRole('button', { name: 'Model Library' })).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: 'Model Registry' })).toBeVisible()
   await expect(sidebar.getByRole('button', { name: 'Projects' })).toBeVisible()
 
   // Default view is the workspace (h1 in the top bar + main heading). Root
@@ -29,8 +29,8 @@ test('console shell renders: sidebar + workspace default view', async ({ page })
 test('hash routing navigates between views', async ({ page }) => {
   await page.goto('/')
 
-  // Model Library: registry-driven view.
-  await sidebarNav(page, 'Model Library')
+  // Model Registry: registry-driven view.
+  await sidebarNav(page, 'Model Registry')
   await expect(page).toHaveURL(/#\/library/)
   await expect(page.getByRole('heading', { name: /Models \(\d+ of \d+\)/ })).toBeVisible()
 

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -16,7 +16,7 @@ import {
 
 const VIEW_TITLES: Record<ConsoleRoute, string> = {
   workspace: 'Workspace',
-  library: 'Model Library',
+  library: 'Model Registry',
   projects: 'Projects',
   console: 'Session Console',
   'playground-rnnoise': 'RNNoise Playground',

--- a/apps/web/src/components/shell-nav.ts
+++ b/apps/web/src/components/shell-nav.ts
@@ -33,7 +33,7 @@ export interface SettingsNavItem {
 
 export const PRIMARY_NAV: NavItem[] = [
   { route: 'workspace', label: 'Workspace', icon: IconWorkspace },
-  { route: 'library', label: 'Model Library', icon: IconLibrary },
+  { route: 'library', label: 'Model Registry', icon: IconLibrary },
   { route: 'projects', label: 'Projects', icon: IconFolder },
   { route: 'console', label: 'Console', icon: IconConsole },
 ]

--- a/apps/web/src/views/ModelLibraryView.tsx
+++ b/apps/web/src/views/ModelLibraryView.tsx
@@ -1,5 +1,5 @@
 /**
- * Model Library view (Phase 3).
+ * Model Registry view (Phase 3).
  *
  * Renders the model registry (`model-registry.json`) as cards with:
  *  - search + tier/format filter
@@ -158,7 +158,7 @@ export function ModelLibraryView() {
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="text-lg font-semibold text-ink-1">Model Library</h2>
+        <h2 className="text-lg font-semibold text-ink-1">Model Registry</h2>
         <p className="mt-1 max-w-2xl text-sm text-ink-2">
           Models are never bundled with the app (ADR-011) — they are fetched
           lazily from the registry. License + commercial flags drive the export


### PR DESCRIPTION
## Summary

The console's "Model Library" view renders `model-registry.json`, whose entries are all KWS today (AFE ships RNNoise embedded; there is no lazy-fetched AFE weight to show). "Model Library" promised more than the content delivers.

Rename the nav item and view heading to **"Model Registry"** — matching the file and ADR-011's wording, and staying accurate until module-owned model fragments (#77) let AFE modules declare assets too.

## Changes

- `ConsoleShell` `VIEW_TITLES` + sidebar nav label (`shell-nav.ts`) + view heading → "Model Registry"
- e2e specs that assert the nav label update to match (the `#/library` route is unchanged — it's internal)

No behavior change; label only.

Closes #78