### PR TITLE
feat(training): Colab spec seam — train.notebookLocal + 'Open in Colab' action (ADR-035)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1044,3 +1044,45 @@ per-backend drivers (ADR-030), and training adapts to upstream scripts/notebooks
 design is ADR-016; the config panel is ADR-017; KWS Phase 2 design is ADR-018
 (resumes against the `KWSBackend` interface). Defaults from Q2/Q3/Q4/Q7 are
 applied per this log and may be overridden._
+
+## ADR-035 — Module-owned Colab notebooks: `train.notebookLocal` + spec-driven "Open in Colab"
+
+- **Status:** Accepted
+- **Origin:** Human product-direction update (Phase 5 Colab-first training,
+  `docs/colab-training.plan.md`, decisions C-5/C-6/C-7, 2026-08-11)
+- **Decision:** A module advertises its **own** Colab training notebook via a
+  new `spec.train.notebookLocal` field (a **repo-relative** path, matching the
+  existing `playground.entry` / `tests.*` path convention). The notebook lives
+  inside the owning module (module-ownership, ADR-025), e.g.
+  `packages/modules/kws/openwakeword/train/colab/train.ipynb`. When the field
+  is present, the **generated panel** (module-kit, ADR-025) renders an "Open in
+  Colab" action — a plain external link built from the repo + path via the
+  GitHub→Colab URL (`https://colab.research.google.com/github/<org>/<repo>/blob/<ref>/<path>`).
+  No WakeStudio server and no provider credentials are involved; the user runs
+  the notebook in their own Colab session under their own Google account
+  (ADR-023).
+- **Rationale:** The training module's `spec.train` already distinguishes
+  **upstream** `notebook` (third-party, we adapt to it, ADR-031) from a local
+  `entry` (uv, ADR-028). A module-owned notebook is a third, distinct case that
+  needs no server: it is versioned in the module, opened directly from GitHub,
+  and executes in the user's Colab. Rendering it from spec (not per-driver
+  registration, ADR-030/033) keeps "panels are generated, never hand-written"
+  true and the module spec the single fact source (ADR-025).
+- **Open questions resolved in this ADR (flagged for human):**
+  1. *Path convention:* repo-relative (matches `playground.entry`/`tests.*`),
+     not module-relative — the GitHub URL builder needs the repo path and cannot
+     derive the module dir from `meta.id` reliably.
+  2. *Spec vs registration:* spec field + generated panel action; no per-driver
+     registration (ADR-030 is for runtime capabilities).
+  3. *Separate fields:* `notebook` (upstream) vs `notebookLocal` (module-owned)
+     stay distinct; no `source` discriminator.
+- **Consequences:**
+  - `module-spec.schema.json` + `ModuleTrain` gain `notebookLocal`; the
+    validator accepts a colab-only train block (no local `entry`/`deps`).
+  - module-kit exports `buildColabUrl` + `SOURCE_REPO`; the generated panel
+    auto-renders "Open in Colab" when `train.notebookLocal` is set.
+  - Optional notebook keys (Google API / TTS token) are user-provided in the
+    Settings panel security section (issue #52), client-side only (ADR-013),
+    passed to the notebook as job params/env — never embedded.
+  - `kws-openwakeword` declares its notebook; the notebook itself lands in
+    `packages/modules/kws/openwakeword/train/colab/train.ipynb` (issue #96).

--- a/docs/colab-training.plan.md
+++ b/docs/colab-training.plan.md
@@ -1,0 +1,244 @@
+# Colab Training Backend Plan (review draft)
+
+> **Status:** Draft for human review — nothing implemented yet.
+> **Scope:** Phase 5 "Custom-model training" — stand up the **first real
+> training backend** on **Google Colab**, producing a real, trainable model
+> artifact that flows back into the PWA for in-browser test + export.
+> **Intent:** start the train loop with **no self-hosted service** and **no
+> cloud-provider credentials**, using only the user's free Google account.
+> **Companion ADRs:** ADR-013 (three backends), ADR-022 (data-source layer),
+> ADR-023 (Colab backend), ADR-028 (uv train scripts), ADR-024 (KWS categories /
+> T-5 train targets). Contract home: `docs/modules/training.md`.
+
+---
+
+## 0. Why this plan exists
+
+The training module is currently **scaffolding only**:
+
+- `packages/modules/training/` has the spec + generated panel + the
+  `manifest.ts` artifact-bundle importer — but **no real train engine**.
+- `apps/studio-backend/` has `train-runner.ts` (the `uv`/self-hosted path) but
+  it is a skeleton and depends on a locally-run server + Python/PyTorch.
+- There is **no module-owned Colab notebook** and **no cloud-provider adapter** yet.
+- No real train script exists in the repo: PLiX and sherpa encoders are frozen
+  (ADR-024 inference-only), so the only trainable line is the **Traditional /
+  MCU path** (openWakeWord-style).
+
+**The human constraint (2026-08):** *no resources to self-host.* So the first
+real backend should be **Colab** — free compute, no WakeStudio server, no
+provider credentials, just the user's Google account. This is exactly the
+design intent of ADR-023. This plan makes training *actually run* by picking
+one backend + one engine and closing the loop end-to-end.
+
+---
+
+## 1. Goals
+
+| # | Goal | Plan section |
+|---|---|---|
+| 1 | A real, runnable training notebook lives in the module's `train/colab/` | §4 |
+| 2 | It trains a wake-word model from a phrase using synthetic data (Piper TTS + augmentation) | §4 |
+| 3 | The trained result normalizes into the **standard artifact bundle** (ADR-013 §6) | §5 |
+| 4 | The PWA's existing `manifest.ts` importer pulls the bundle back in ("Import Colab results") for in-browser test + export | §7 |
+| 5 | No WakeStudio server, no provider credentials involved | whole plan |
+| 6 | The module advertises its Colab notebook via `spec.json` (no hand-written registration) | §5 |
+| 7 | HF as a cloud-provider adapter is **deferred** (noted, not built) | §8 |
+
+**Non-goals for this slice:** the self-hosted service, cloud-provider adapters,
+the async job queue (T-1), and the data-source layer's full endpoint config.
+This is the minimal vertical slice that makes training real.
+
+---
+
+## 2. Backend choice — why Colab first
+
+| Backend | Setup cost | Free? | Fits "no self-host" constraint? |
+|---|---|---|---|
+| **Self-hosted** (`studio-backend`) | local server + Python/PyTorch | runs on your hardware | ❌ rejected (human) |
+| **Cloud Provider** (HF, …) | provider credentials + per-provider adapter | HF has a free tier | ⚠️ more work, later (§8) |
+| **Colab** | open notebook, run, download | ✅ free GPU | ✅ **Chosen** |
+
+Colab is the lowest-friction real backend and is already an accepted design
+(ADR-023). Notebooks are version-controlled inside the owning module's
+`train/colab/` (§4).
+
+---
+
+## 3. Engine decision (Q10, issue #32) — recommended: openWakeWord app-class
+
+The Traditional/MCU path is the only trainable line today. Q10 is still open.
+
+| Engine | Tier / output | Notes |
+|---|---|---|
+| **openWakeWord** | app-class, ONNX | natural first target, most documented, easiest end-to-end win |
+| **micro-wake-word** | MCU, TFLite-Micro | matches `target: mc` default; heavier MCU path |
+| **wakeforge / `ww_trainer`** | (Q10 candidate) | evaluate later behind the same adapter contract |
+
+**Recommended default:** start with **openWakeWord app-class** — shortest path
+to a model that trains and comes back. The adapter contract (§6) is engine-
+agnostic, so micro-wake-word and wakeforge can reuse it later.
+
+---
+
+## 4. Deliverable 1 — module-owned training notebook (openWakeWord)
+
+The WakeStudio-authored wrapper notebook lives **inside the module** (module-ownership, ADR-025):
+
+```
+packages/modules/kws/openwakeword/train/colab/train.ipynb
+```
+
+It is a version-controlled, module-owned notebook that:
+
+1. **Sets up** the pinned upstream `openWakeWord` training environment
+   (ADR-028 `uv`/pip, pinned ref).
+2. **Generates synthetic data** for the wake phrase using Piper TTS +
+   augmentation (the ADR-022 data-source layer) — fully inside Colab.
+3. **Runs the upstream train script** bytes-identical (per the "we adapt to
+   the script, not vice versa" rule, `docs/modules/training.md` §4).
+4. **Writes results** into the standard bundle layout (§6).
+
+The notebook is **not rewritten upstream code** — it is a WakeStudio wrapper
+that invokes the upstream trainer and normalizes the output.
+
+---
+
+## 5. Deliverable 2 — spec-driven Colab invocation (how the panel finds the notebook)
+
+The module advertises its Colab notebook in **`spec.json`** — the single shared
+fact source (ADR-025) — so the generated panel renders an "Open in Colab"
+action with **no hand-written per-driver registration**.
+
+### 5.1 Two distinct notebook kinds (do not conflate)
+
+| Kind | Owner | Where | Spec field |
+|---|---|---|---|
+| **Upstream** notebook (third-party, we adapt to it) | external repo | referenced, not stored | `train.notebook` (existing: `repo`/`path`/`ref`) |
+| **Module-owned** wrapper notebook (ours) | WakeStudio | `train/colab/` | **new** `train.notebookLocal` |
+
+**Decision (human, 2026-08-11): separate fields.** C-6 resolved —
+`notebook` vs `notebookLocal` stay distinct; no `source` discriminator.
+
+`schema.json` already has `train.invocation: ["colab"]` and `train.notebook`;
+this slice adds `train.notebookLocal` — a **repo-relative** path to the
+module-owned wrapper (matches the existing `playground.entry` / `tests.*`
+path convention; the GitHub→Colab URL builder needs the repo path and cannot
+derive the module dir from `meta.id` reliably).
+
+### 5.2 How the panel opens it (no server, no credentials)
+
+The generated panel builds the GitHub→Colab URL from the module's repo + the
+local path in spec:
+
+```
+https://colab.research.google.com/github/<org>/<repo>/blob/<ref>/<train.notebookLocal>
+```
+
+The user runs the notebook in their own Colab session; WakeStudio never hosts
+it. This is the "submit" half of the Colab adapter (ADR-013 §2.1).
+
+### 5.3 Optional keys: user-set in Settings
+
+Colab itself needs **no WakeStudio credential** — the user's Google account is
+the only auth (ADR-023). But a notebook may need an optional key (Google API
+key for Drive import, a public TTS endpoint token from the data-source layer,
+etc.). Policy (human, 2026-08-11):
+
+- The user sets such keys in the app's **Settings panel — security section**
+  (issue #52: data-driven Settings, secrets, localStorage-backed).
+- Keys are **client-side only** (ADR-013 security note): never logged, never
+  embedded in exported bundles, never sent to a WakeStudio server.
+- The key is passed to the notebook as a **job param / env var** (the
+  `{{params.*}}` / `{{env.*}}` template in `spec.train`, `docs/modules/training.md`
+  §4.1), pasted or read from the notebook's runtime env by the user.
+
+### 5.4 Why spec, not registration
+
+- **ADR-025:** spec is the single shared fact source; panels are generated,
+  never hand-written.
+- **ADR-030/033 (registration)** is for runtime driver capabilities — a static
+  notebook path is declarative metadata, not a runtime seam. Mixing it in
+  would force per-driver panel code, which the module platform forbids.
+- The same `notebookLocal` field is readable by CI/studio-backend later
+  (docs/modules/training.md §4.2) without new discovery code.
+
+## 6. Deliverable 3 — artifact-bundle normalization (the loop's contract)
+
+The notebook's output dir is normalized into the **standard bundle manifest**
+(`docs/modules/training.md` §6) via the `standardize-results` adapter:
+
+```
+wake-studio-results/<job-id>/
+  model.onnx            (or model.tflite)
+  metrics.json          (FAR/FRR, loss, epochs)
+  metadata.json         (jobId, moduleId, backend='colab', params, trainedAt)
+  provenance.json       (license: user-owned / commercially clean — Phase 4 gate)
+  config.json           (AFE/KWS/Few-Shot config snapshot)
+```
+
+The single importer is the existing `manifest.ts`; the notebook only needs to
+lay the files down in this shape. `provenance.json` declaring the model
+**user-owned / commercially clean** is what lets the Phase 4 license gate treat
+it as exportable (unlike openWakeWord's CC BY-NC-SA pre-trained models).
+
+---
+
+## 7. Deliverable 4 — "Import Colab results" in the PWA
+
+Reuse the existing `TrainingJob` interface (ADR-013) + `manifest.ts` importer:
+
+1. User picks the downloaded bundle (zip) in the app.
+2. The importer validates against the manifest (`metadata.json` +
+   `provenance.json`).
+3. The model registers for **in-browser test** (existing KWS load path) +
+   **export** (Phase 4 license gate).
+
+No WakeStudio server is involved; the user's Google account is the only
+credential (ADR-023).
+
+---
+
+## 8. Deferred (noted, not built now)
+
+- **Cloud Provider adapter (HF free tier)** — later, behind the same common
+  interface / bundle manifest.
+- **Self-hosted** `studio-backend` training — later / when resources allow.
+- **Async job queue + SSE streaming** (T-1) — Colab is user-driven, no polling.
+- **Data-source layer full endpoint config** — this slice uses only the
+  in-notebook Piper generation.
+
+---
+
+## 9. Sequencing & dependencies
+
+- This slice is **independent of the P0 delivery blockers (#27–30)** and
+  **Phase 4 (SDK/export)** — it does not need them resolved to run.
+- Docs-first: update `docs/modules/training.md` (§4.2/§5/§7) **and** the
+  `module-spec.schema.json` (`train.notebookLocal`) in the same change as the
+  notebook (docs-sync rule).
+- The existing `manifest.ts` importer is reused; no new retrieval contract.
+
+---
+
+## 10. Open questions for review
+
+| # | Question | Recommended default |
+|---|---|---|
+| C-1 | Engine: openWakeWord (app-class) vs micro-wake-word (MCU) vs wakeforge? | ✅ **RESOLVED (human, 2026-08-11): openWakeWord app-class first** (§3) |
+| C-2 | Colab import: zip upload vs Drive picker? | ✅ **RESOLVED (human, 2026-08-11): zip upload first** (T-2 default) |
+| C-3 | Which upstream `openWakeWord` ref to pin for the notebook? | ✅ **RESOLVED (human, 2026-08-11): latest tagged release, pinned in the notebook** |
+| C-4 | Should this slice also scaffold the HF cloud-provider adapter (free tier)? | ✅ **RESOLVED (human, 2026-08-11): No — defer** (§8) |
+| C-5 | Spec field name for the module-owned notebook | ✅ **RESOLVED (human, 2026-08-11): `train.notebookLocal`** (§5) — **repo-relative** path (matches `playground.entry`/`tests.*` convention) |
+| C-6 | Distinguish upstream vs module-owned notebooks by separate fields, or a `source` discriminator? | ✅ **RESOLVED (human, 2026-08-11): separate fields** (`notebook` vs `notebookLocal`) |
+| C-7 | Notebook keys (Google API key / TTS token) — how does the user provide them? | ✅ **RESOLVED (human, 2026-08-11): Settings panel security section** (issue #52), client-side only, passed as job params/env (§5.3) |
+
+---
+
+## 11. Change log
+
+| Date | Change | Author |
+|---|---|---|
+| 2026-08-11 | Initial review draft — Colab-first training backend (openWakeWord, synthetic Piper data, standard bundle import). | agent |
+| 2026-08-11 | Notebook moved into the owning module (`train/colab/`, ADR-025 module-ownership); advertised via new `spec.train.notebookLocal` (spec-driven panel, no hand-written registration) — §4/§5, questions C-5/C-6. | agent |
+| 2026-08-11 | **C-6 resolved:** separate fields (`notebook` vs `notebookLocal`). **C-7 added & resolved:** optional notebook keys (Google API / TTS) are user-set in the Settings panel security section (issue #52), client-side only, passed as job params/env — new §5.3. | agent |

--- a/docs/modules/training.md
+++ b/docs/modules/training.md
@@ -129,6 +129,12 @@ stays byte-identical; WakeStudio wraps it.
     "paramsCell": 3,                     // cell index whose code maps to job params
     "outputsCell": "last"                // where the notebook writes results
   },
+  "notebookLocal": "packages/modules/kws/openwakeword/train/colab/train.ipynb",
+                                          // NEW (ADR-035): a MODULE-OWNED Colab
+                                          // notebook (repo-relative path). Distinct
+                                          // from "notebook" (upstream): this one
+                                          // lives in this repo; the generated panel
+                                          // renders an "Open in Colab" action from it.
   // HOW to normalize the output into the standard bundle (single importer):
   "outputs": {                           // (existing) declared outputs
     "checkpoint": "out/model.onnx",
@@ -193,11 +199,20 @@ license if the training wrapped a restricted model.
 ## 7. Google Colab (ADR-023) - output-retrieval convention
 
 Colab is the fourth backend: the PWA opens a notebook, the user runs it in
-their own Colab session, and **imports the results back**. Per §4, we **do not
-rewrite** an upstream notebook - we adapt to it:
+their own Colab session, and **imports the results back**. There are two
+notebook kinds (ADR-035):
 
-1. Upstream notebooks stay byte-identical; the module's `spec/train.notebook`
-   declares which cell maps job params and which cell writes results.
+- **Upstream** notebooks (third-party) — we **never rewrite**; we adapt to
+  them. The module's `spec/train.notebook` declares which cell maps job params
+  and which cell writes results.
+- **Module-owned** notebooks (ours) — declared via `spec/train.notebookLocal`
+  (repo-relative path). The **generated panel** renders an "Open in Colab"
+  action (module-kit `buildColabUrl`, ADR-035); the user opens it directly
+  from GitHub and runs it under their own account.
+
+Common flow (both kinds):
+
+1. The user opens/runs the notebook in their own Colab session.
 2. A **WakeStudio-provided adapter cell** (prepended by the studio-backend / CI
    path, or the user pastes it into Colab) normalizes the notebook's output
    dir into the standard bundle (§6) via `standardize-results`.
@@ -207,7 +222,9 @@ rewrite** an upstream notebook - we adapt to it:
    and registers the model for in-browser testing + export.
 
 No WakeStudio server is involved; the user's Google account is the only
-credential (ADR-023).
+credential (ADR-023). Optional notebook keys (Google API / TTS token) are
+user-set in the Settings panel security section (issue #52), client-side only
+(ADR-013), passed to the notebook as job params/env — never embedded.
 
 ## 8. Cloud Providers (ADR-013)
 

--- a/packages/contracts/src/module-spec.schema.json
+++ b/packages/contracts/src/module-spec.schema.json
@@ -336,6 +336,10 @@
         "entry": {
           "type": "string"
         },
+        "notebookLocal": {
+          "type": "string",
+          "description": "Repo-relative path to the module-owned Colab notebook (e.g. \"packages/modules/kws/openwakeword/train/colab/train.ipynb\"). Distinct from \"notebook\" (upstream ref): the notebook lives in this repo and the generated panel renders an \"Open in Colab\" action from it (ADR-035). Repo-relative to match playground.entry / tests paths."
+        },
         "python": {
           "type": "string"
         },

--- a/packages/contracts/src/module-spec.ts
+++ b/packages/contracts/src/module-spec.ts
@@ -92,6 +92,14 @@ export interface ModuleRuntime {
 export interface ModuleTrain {
   /** Local uv script (ADR-028), e.g. "train/train.py". */
   entry?: string
+  /**
+   * Repo-relative path to the module-owned Colab notebook (e.g.
+   * "packages/modules/kws/openwakeword/train/colab/train.ipynb"). Distinct
+   * from `notebook` (upstream ref): the notebook lives in this repo; the
+   * generated panel renders an "Open in Colab" action from it (ADR-035).
+   * Repo-relative to match `playground.entry` / `tests.*` path conventions.
+   */
+  notebookLocal?: string
   python?: string
   deps?: string
   /** Who may invoke: "subprocess" (studio-backend), "ci", "colab". */

--- a/packages/module-kit/src/panel-generator.tsx
+++ b/packages/module-kit/src/panel-generator.tsx
@@ -26,6 +26,39 @@ import { UiBar, UiWaveform, UiCurve } from './ui/canvas'
 import { renderParamControl } from './ui/mapper'
 
 // ---------------------------------------------------------------------------
+// Colab notebook seam (ADR-035)
+// ---------------------------------------------------------------------------
+
+/**
+ * The source repo where module-owned Colab notebooks live. The generated
+ * panel opens a notebook via the GitHub→Colab URL builder below; no server
+ * and no credentials are involved (the user runs it in their own Colab
+ * session, ADR-023).
+ */
+export const SOURCE_REPO = {
+  org: 'awareride',
+  repo: 'wake-studio',
+  /** Notebooks are opened from the default branch; feature branches are out of scope. */
+  ref: 'main',
+} as const
+
+/**
+ * Build the GitHub→Colab URL for a module-owned notebook.
+ *
+ * `notebookLocal` is repo-relative (e.g.
+ * "packages/modules/kws/openwakeword/train/colab/train.ipynb"), matching the
+ * `playground.entry` / `tests.*` path convention, so no module-directory
+ * derivation is needed.
+ */
+export function buildColabUrl(
+  notebookLocal: string,
+  source: typeof SOURCE_REPO = SOURCE_REPO,
+): string {
+  const path = notebookLocal.replace(/^\.?\//, '')
+  return `https://colab.research.google.com/github/${source.org}/${source.repo}/blob/${source.ref}/${path}`
+}
+
+// ---------------------------------------------------------------------------
 // Panel controller contract (host-provided)
 // ---------------------------------------------------------------------------
 
@@ -175,6 +208,26 @@ export function ModulePanel({ spec, controller, title }: GeneratedPanelProps) {
                 onClick={() => controller.runAction(action.id)}
               />
             ))}
+          </div>
+        )}
+
+        {/*
+          Module-owned Colab notebook (ADR-035): when the module declares
+          spec.train.notebookLocal, the generated panel renders an "Open in
+          Colab" action. It is a plain external link — no server, no
+          credentials; the user runs the notebook in their own Colab session.
+        */}
+        {spec.train?.notebookLocal && (
+          <div className="flex flex-wrap gap-3 pt-2">
+            <a
+              href={buildColabUrl(spec.train.notebookLocal)}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-surface-3"
+            >
+              <span aria-hidden>☁️</span>
+              Open in Colab
+            </a>
           </div>
         )}
 

--- a/packages/module-kit/src/validator.ts
+++ b/packages/module-kit/src/validator.ts
@@ -66,8 +66,15 @@ export function validateModuleSpec(raw: unknown): SpecValidationResult {
     errors.push('playground.route must start with "/"')
 
   if (spec.train) {
-    if (!spec.train.entry) errors.push('train.entry required')
-    if (!spec.train.deps) errors.push('train.deps required (pyproject.toml or requirements.txt)')
+    const hasSource = Boolean(
+      spec.train.entry || spec.train.script || spec.train.notebook || spec.train.notebookLocal,
+    )
+    if (!hasSource)
+      errors.push('train must declare one of: entry, script, notebook, or notebookLocal')
+    // entry+deps are required only for the local uv path (ADR-028); a
+    // notebook/notebookLocal target has no local script to run (ADR-035).
+    if (spec.train.entry && !spec.train.deps)
+      errors.push('train.deps required when train.entry is set (pyproject.toml or requirements.txt)')
     if (!spec.train.invocation?.length) errors.push('train.invocation must be non-empty')
   }
 

--- a/packages/module-kit/tests/panel-generator.test.tsx
+++ b/packages/module-kit/tests/panel-generator.test.tsx
@@ -10,7 +10,12 @@ import { describe, it, expect } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ModuleSpec } from '@wake-studio/contracts'
 import { validateModuleSpec } from '../src/validator'
-import { defaultsFromSpec, renderPanel, ModulePanel } from '../src/panel-generator'
+import {
+  defaultsFromSpec,
+  renderPanel,
+  ModulePanel,
+  buildColabUrl,
+} from '../src/panel-generator'
 
 // A minimal but complete spec (mirrors rnnoise/module.spec.json shape).
 const MINIMAL_SPEC: ModuleSpec = {
@@ -80,12 +85,43 @@ describe('validateModuleSpec', () => {
     expect(res.ok).toBe(false)
     expect(res.errors.some((e) => e.includes('group'))).toBe(true)
   })
+
+  it('rejects a train block with no invocation source', () => {
+    const bad = structuredClone(MINIMAL_SPEC)
+    bad.train = { invocation: ['colab'], outputs: {} }
+    const res = validateModuleSpec(bad)
+    expect(res.ok).toBe(false)
+    expect(res.errors.some((e) => e.includes('notebookLocal'))).toBe(true)
+  })
+
+  it('accepts a colab-only train block (notebookLocal, no local entry) (ADR-035)', () => {
+    const ok = structuredClone(MINIMAL_SPEC)
+    ok.train = {
+      notebookLocal: 'packages/modules/kws/openwakeword/train/colab/train.ipynb',
+      invocation: ['colab'],
+      outputs: { checkpoint: 'out/model.onnx' },
+    }
+    const res = validateModuleSpec(ok)
+    expect(res.ok).toBe(true)
+    expect(res.errors).toEqual([])
+  })
 })
 
 describe('defaultsFromSpec', () => {
   it('maps every param to its default', () => {
     const d = defaultsFromSpec(MINIMAL_SPEC)
     expect(d).toEqual({ strength: 1, enabled: true })
+  })
+})
+
+describe('buildColabUrl', () => {
+  it('builds the GitHub→Colab URL from a repo-relative notebook path (ADR-035)', () => {
+    const url = buildColabUrl(
+      'packages/modules/kws/openwakeword/train/colab/train.ipynb',
+    )
+    expect(url).toBe(
+      'https://colab.research.google.com/github/awareride/wake-studio/blob/main/packages/modules/kws/openwakeword/train/colab/train.ipynb',
+    )
   })
 })
 
@@ -120,5 +156,37 @@ describe('renderPanel', () => {
   it('ModulePanel is a named component from the spec', () => {
     const Panel = renderPanel(MINIMAL_SPEC)
     expect(Panel.displayName).toBe('ModulePanel(test-module)')
+  })
+
+  it('renders an Open in Colab link when spec.train.notebookLocal is set (ADR-035)', () => {
+    const withNotebook = structuredClone(MINIMAL_SPEC)
+    withNotebook.train = {
+      notebookLocal: 'packages/modules/kws/openwakeword/train/colab/train.ipynb',
+      invocation: ['colab'],
+      outputs: { checkpoint: 'out/model.onnx' },
+    }
+    const html = renderToStaticMarkup(
+      <ModulePanel spec={withNotebook} controller={{
+        values: defaultsFromSpec(withNotebook),
+        setValue: () => {},
+        runAction: () => {},
+      }} />,
+    )
+    expect(html).toContain('Open in Colab')
+    expect(html).toContain(
+      'https://colab.research.google.com/github/awareride/wake-studio/blob/main/packages/modules/kws/openwakeword/train/colab/train.ipynb',
+    )
+    expect(html).toContain('target="_blank"')
+  })
+
+  it('does not render an Open in Colab link without notebookLocal', () => {
+    const html = renderToStaticMarkup(
+      <ModulePanel spec={MINIMAL_SPEC} controller={{
+        values: defaultsFromSpec(MINIMAL_SPEC),
+        setValue: () => {},
+        runAction: () => {},
+      }} />,
+    )
+    expect(html).not.toContain('Open in Colab')
   })
 })

--- a/packages/modules/kws/openwakeword/spec/module.spec.json
+++ b/packages/modules/kws/openwakeword/spec/module.spec.json
@@ -47,6 +47,14 @@
       "worker": true
     }
   },
+  "train": {
+    "notebookLocal": "packages/modules/kws/openwakeword/train/colab/train.ipynb",
+    "invocation": ["colab"],
+    "outputs": {
+      "checkpoint": "out/model.onnx",
+      "metrics": "out/metrics.json"
+    }
+  },
   "build": {
     "recipe": "none",
     "registryEntry": "public/model-registry.json#kws-openwakeword",


### PR DESCRIPTION
## What

Phase 5 Colab-first training foundation (epic #95, tasks #98 + #99). First real step toward trainable wake-word models on Google Colab with no self-hosted service and no credentials.

- **contracts:** `ModuleTrain.notebookLocal` (repo-relative path) + schema field — distinct from the existing upstream `notebook` ref
- **module-kit:** `buildColabUrl()` + `SOURCE_REPO`; the generated panel auto-renders an **Open in Colab** action when `spec.train.notebookLocal` is set (plain external link, no server/credentials)
- **validator:** a colab-only train block (notebookLocal, no local `entry`/`deps`) now validates; every train block must declare exactly one source
- **kws-openwakeword** spec declares its notebook at `packages/modules/kws/openwakeword/train/colab/train.ipynb`
- **docs:** ADR-035 (decisions C-5/C-6/C-7), training.md §4.1/§7, plan decisions C-1..C-7 resolved

## Design notes

- Path convention is **repo-relative** (matches `playground.entry`/`tests.*`) — the URL builder needs the repo path and can't derive the module dir from `meta.id` reliably (flagged in ADR-035).
- Spec field, not driver registration (ADR-030/033 are runtime capabilities; a static notebook path is declarative metadata).

## Test evidence

- `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors, pre-existing warnings only) · `pnpm test:unit` ✅ (all suites)
- New L1 tests: colab-only train block validates; colab-less train block rejected; `buildColabUrl` output; panel renders/omits the Open in Colab link

Closes #98
Closes #99