### PR TITLE
feat(web): replace hand-drawn icons with Radix UI icons

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-toast": "^1.2.23",
     "@radix-ui/react-tooltip": "^1.2.16",
     "@wake-studio/contracts": "workspace:*",

--- a/apps/web/src/components/RecentProjectsMenu.tsx
+++ b/apps/web/src/components/RecentProjectsMenu.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from './ui'
 import { NewProjectDialog } from './NewProjectDialog'
+import { ChevronDownIcon, ListBulletIcon } from '@radix-ui/react-icons'
 
 /** Relative "updated …" caption for the recent-projects menu. */
 function formatUpdated(ms: number): string {
@@ -49,13 +50,9 @@ export function RecentProjectsMenu() {
             className="flex max-w-48 items-center gap-1.5 rounded-lg border border-line bg-surface-3 px-2.5 py-1.5 text-sm font-medium text-ink-1 hover:bg-surface-4"
             title="Recent projects"
           >
-            <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0 text-ink-3" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M3 7h18M7 12h14M3 17h10" />
-            </svg>
+            <ListBulletIcon className="h-3.5 w-3.5 shrink-0 text-ink-3" />
             <span className="truncate">{label}</span>
-            <svg viewBox="0 0 24 24" className="h-3 w-3 shrink-0 text-ink-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m6 9 6 6 6-6" />
-            </svg>
+            <ChevronDownIcon className="h-3 w-3 shrink-0 text-ink-3" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-60">

--- a/apps/web/src/components/SourceConfigSection.tsx
+++ b/apps/web/src/components/SourceConfigSection.tsx
@@ -9,6 +9,7 @@
 
 import { SourceSelector } from './SourceSelector'
 import { FileSourcePanel } from './FileSourcePanel'
+import { FileIcon } from '@radix-ui/react-icons'
 import type { SourceState, SourceActions } from '../workspace/useSourceConfig'
 import { cn } from './cn'
 
@@ -32,6 +33,7 @@ export function SourceConfigSection({ source, actions, disabled }: Props) {
               : 'text-ink-2 hover:bg-surface-4',
           )}
         >
+          {/* Mic: Radix UI has no mic glyph, so this stays hand-drawn. */}
           <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
             <path d="M19 10v1a7 7 0 0 1-14 0v-1M12 18v4M8 22h8" />
@@ -48,10 +50,7 @@ export function SourceConfigSection({ source, actions, disabled }: Props) {
               : 'text-ink-2 hover:bg-surface-4',
           )}
         >
-          <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2Z" />
-            <path d="M14 2v6h6" />
-          </svg>
+          <FileIcon className="h-4 w-4" />
           Audio files
         </button>
       </div>

--- a/apps/web/src/components/StepSection.tsx
+++ b/apps/web/src/components/StepSection.tsx
@@ -7,6 +7,7 @@
  */
 
 import * as React from 'react'
+import { ChevronRightIcon } from '@radix-ui/react-icons'
 import { cn } from './cn'
 
 interface Props {
@@ -52,20 +53,12 @@ export function StepSection({
             </span>
           )}
         </span>
-        <svg
-          viewBox="0 0 24 24"
+        <ChevronRightIcon
           className={cn(
             'h-3.5 w-3.5 text-ink-3 transition-transform',
             open && 'rotate-90',
           )}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="m9 18 6-6-6-6" />
-        </svg>
+        />
       </button>
       {open && <div className="space-y-4 px-4 pb-5 pt-1">{children}</div>}
     </section>

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -1,161 +1,89 @@
 /**
- * Icon set - hand-drawn inline SVG components (24x24, stroke-based).
+ * Icon set - Radix UI icons (https://www.radix-ui.com/icons).
  *
- * Presentation-layer only: no external icon dependency, styled with current
- * color. Kept intentionally tiny and consistent with the WakeStudio logo
- * language (rounded strokes).
+ * Thin wrappers over `@radix-ui/react-icons` that keep the legacy local API
+ * (`size` prop, `IconX` names) so existing call sites work unchanged. Radix
+ * icons are filled and inherit `currentColor`, so they pick up text color
+ * utilities exactly like the old stroke-based set.
+ *
+ * Note: Radix ships no mic/folder/terminal/flask glyphs; closest matches are
+ * used where needed (see each export below).
  */
 
-import type { SVGProps } from 'react'
+import type { ComponentType, SVGProps } from 'react'
+import type { IconProps as RadixIconProps } from '@radix-ui/react-icons/dist/types'
+import {
+  ArchiveIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CodeIcon,
+  Component2Icon,
+  GearIcon,
+  HamburgerMenuIcon,
+  MagicWandIcon,
+  MixIcon,
+  PlayIcon,
+  ReaderIcon,
+  ReloadIcon,
+  StopIcon,
+  ViewGridIcon,
+} from '@radix-ui/react-icons'
 
 type IconProps = SVGProps<SVGSVGElement> & { size?: number }
 
-function base(props: IconProps) {
-  const { size = 18, ...rest } = props
-  return {
-    width: size,
-    height: size,
-    viewBox: '0 0 24 24',
-    fill: 'none',
-    stroke: 'currentColor',
-    strokeWidth: 1.8,
-    strokeLinecap: 'round' as const,
-    strokeLinejoin: 'round' as const,
-    'aria-hidden': true,
-    ...rest,
+/** Wrap a Radix icon, mapping the legacy `size` prop to width/height. */
+function fromRadix(RadixIcon: ComponentType<RadixIconProps>) {
+  function Icon(props: IconProps) {
+    const { size = 18, children: _children, ...rest } = props
+    return <RadixIcon width={size} height={size} aria-hidden {...rest} />
   }
+  return Icon
 }
 
-export function IconWorkspace(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <rect x="3" y="3" width="7.5" height="7.5" rx="1.5" />
-      <rect x="13.5" y="3" width="7.5" height="7.5" rx="1.5" />
-      <rect x="3" y="13.5" width="7.5" height="7.5" rx="1.5" />
-      <path d="M13.5 17h7.5M17 13.5v7.5" />
-    </svg>
-  )
-}
+/** Workspace (2x2 grid view). */
+export const IconWorkspace = fromRadix(ViewGridIcon)
 
-export function IconLibrary(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M4 4.5h16v15H4z" />
-      <path d="M8 9h8M8 13h5" />
-    </svg>
-  )
-}
+/** Model Registry (book / reader). */
+export const IconLibrary = fromRadix(ReaderIcon)
 
-export function IconFolder(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M3 6.5a1.5 1.5 0 0 1 1.5-1.5h4l2 2h9A1.5 1.5 0 0 1 21 8.5v9a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 17.5z" />
-    </svg>
-  )
-}
+/** Projects (Radix has no folder; archive box is the closest match). */
+export const IconFolder = fromRadix(ArchiveIcon)
 
-export function IconSettings(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.03 1.56V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1.11-1.56 1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.7 1.7 0 0 0 .34-1.87 1.7 1.7 0 0 0-1.56-1.03H3a2 2 0 1 1 0-4h.09a1.7 1.7 0 0 0 1.56-1.11 1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34h.08a1.7 1.7 0 0 0 1.03-1.56V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87v.08a1.7 1.7 0 0 0 1.56 1.03H21a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.56 1.03z" />
-    </svg>
-  )
-}
+export const IconSettings = fromRadix(GearIcon)
 
-export function IconChip(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <rect x="6" y="6" width="12" height="12" rx="2" />
-      <path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3" />
-    </svg>
-  )
-}
+/** Device SDK (chip: rounded rect with edge pins). */
+export const IconChip = fromRadix(Component2Icon)
 
-export function IconMic(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <rect x="9" y="3" width="6" height="11" rx="3" />
-      <path d="M5 11a7 7 0 0 0 14 0M12 18v3" />
-    </svg>
-  )
-}
+export const IconStop = fromRadix(StopIcon)
 
-export function IconStop(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor" stroke="none" />
-    </svg>
-  )
-}
+export const IconPlay = fromRadix(PlayIcon)
 
-export function IconPlay(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M7 5.5v13l11-6.5z" fill="currentColor" stroke="none" />
-    </svg>
-  )
-}
-
+/** Spinner (Radix reload arrows spun via CSS animation). */
 export function IconSpinner(props: IconProps) {
+  const { size = 18, className, children: _children, ...rest } = props
   return (
-    <svg {...base(props)} className={`animate-spin ${props.className ?? ''}`}>
-      <path d="M12 3a9 9 0 1 0 9 9" />
-    </svg>
+    <ReloadIcon
+      width={size}
+      height={size}
+      className={`animate-spin ${className ?? ''}`}
+      aria-hidden
+      {...rest}
+    />
   )
 }
 
-export function IconChevronRight(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M9 6l6 6-6 6" />
-    </svg>
-  )
-}
+export const IconChevronRight = fromRadix(ChevronRightIcon)
 
 /** Left chevron (Back navigation, issue #105). */
-export function IconChevronLeft(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M15 6l-6 6 6 6" />
-    </svg>
-  )
-}
+export const IconChevronLeft = fromRadix(ChevronLeftIcon)
 
-export function IconMenu(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M4 7h16M4 12h16M4 17h16" />
-    </svg>
-  )
-}
+export const IconMenu = fromRadix(HamburgerMenuIcon)
 
-export function IconTrain(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M9 3h6M10 3v6l-5 9a2 2 0 0 0 1.8 3h10.4a2 2 0 0 0 1.8-3l-5-9V3" />
-      <path d="M7.5 15h9" />
-    </svg>
-  )
-}
+/** Training (Radix has no flask; the beaker-with-liquid half of MixIcon). */
+export const IconTrain = fromRadix(MixIcon)
 
-export function IconConsole(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M4 5h16v14H4z" />
-      <path d="M7 9l3 3-3 3M12 15h5" />
-    </svg>
-  )
-}
+/** Console (Radix has no terminal; code brackets are the closest match). */
+export const IconConsole = fromRadix(CodeIcon)
 
 /** A wizard wand with sparkles (the "New train" trigger, issue #105). */
-export function IconWand(props: IconProps) {
-  return (
-    <svg {...base(props)}>
-      <path d="M15 4l5 5L7 22l-5-5L15 4z" />
-      <path d="M13.5 6.5l4 4" />
-      <path d="M18 2v3M19.5 3.5h-3" />
-      <path d="M4 12.5l1.5 1.5M6.5 15l1.5 1.5" />
-    </svg>
-  )
-}
+export const IconWand = fromRadix(MagicWandIcon)

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -21,6 +21,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from './ui'
+import {
+  ChevronRightIcon,
+  Cross2Icon,
+  HamburgerMenuIcon,
+  StopIcon,
+} from '@radix-ui/react-icons'
 import { PRIMARY_NAV, SECONDARY_NAV, isSettingsRoute, type NavItem } from './shell-nav'
 import { useLiveAfe, useLiveKws } from '../workspace/live'
 import { cn } from './cn'
@@ -126,18 +132,12 @@ function SettingsNav({
       >
         <Icon className="h-[18px] w-[18px] shrink-0" />
         <span className="flex-1 truncate text-left">{item.label}</span>
-        <svg
-          viewBox="0 0 16 16"
+        <ChevronRightIcon
           className={cn(
             'h-3.5 w-3.5 shrink-0 text-ink-3 transition-transform group-hover:text-ink-1',
             open && 'rotate-90',
           )}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-        >
-          <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
+        />
       </button>
 
       {open && (
@@ -247,15 +247,7 @@ export function Sidebar({
             aria-label="Close navigation"
             className="rounded-md p-1.5 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
           >
-            <svg
-              viewBox="0 0 16 16"
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            >
-              <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
-            </svg>
+            <Cross2Icon className="h-4 w-4" />
           </button>
         )}
       </div>
@@ -325,9 +317,7 @@ export function TopBar({
         className="rounded-md p-1.5 text-ink-3 hover:bg-surface-3 hover:text-ink-1 lg:hidden"
         aria-label="Toggle navigation"
       >
-        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
-          <path d="M4 7h16M4 12h16M4 17h16" />
-        </svg>
+        <HamburgerMenuIcon className="h-5 w-5" />
       </button>
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <h1 className="truncate text-sm font-semibold text-ink-1">{title}</h1>
@@ -438,18 +428,14 @@ function MiniPipelineBar({ open, onToggle }: { open: boolean; onToggle: () => vo
           aria-label="Stop pipeline"
           className="shrink-0 rounded p-1 text-danger hover:bg-danger/10"
         >
-          <svg viewBox="0 0 24 24" className="h-3 w-3" fill="currentColor">
-            <rect x="6" y="6" width="12" height="12" rx="1.5" />
-          </svg>
+          <StopIcon className="h-3 w-3" />
         </button>
         <button
           onClick={onToggle}
           aria-label="Minimize pipeline status"
           className="shrink-0 rounded p-1 text-ink-3 hover:bg-surface-3 hover:text-ink-1"
         >
-          <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="m9 18 6-6-6-6" />
-          </svg>
+          <ChevronRightIcon className="h-3 w-3" />
         </button>
       </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.24
         version: 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-icons':
+        specifier: ^1.3.2
+        version: 1.3.2(react@18.3.1)
       '@radix-ui/react-toast':
         specifier: ^1.2.23
         version: 1.2.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1971,6 +1974,11 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@radix-ui/react-icons@1.3.2':
+    resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
+    peerDependencies:
+      react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
 
   '@radix-ui/react-id@1.1.4':
     resolution: {integrity: sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==}
@@ -5576,6 +5584,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-icons@1.3.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@radix-ui/react-id@1.1.4(@types/react@18.3.31)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Summary

Standardize the web app's iconography on the **Radix UI icon set** (`@radix-ui/react-icons`, https://www.radix-ui.com/icons) instead of hand-drawn inline SVGs.

### Changes
- **`src/components/icons.tsx`** — rewritten as thin wrappers over Radix icons. The legacy `IconX` names and `size` prop are preserved, so **no call site changed**.
  - `IconWorkspace → ViewGridIcon`, `IconLibrary → ReaderIcon`, `IconFolder → ArchiveIcon`, `IconSettings → GearIcon`, `IconChip → Component2Icon`, `IconTrain → MixIcon`, `IconConsole → CodeIcon`, `IconWand → MagicWandIcon`, `IconPlay/IconStop → PlayIcon/StopIcon`, `IconSpinner → ReloadIcon` (keeps `animate-spin`), chevrons/menu → `ChevronLeft/RightIcon`, `HamburgerMenuIcon`
- **Inline SVGs replaced** in `shell.tsx` (5), `StepSection.tsx`, `SourceConfigSection.tsx`, `RecentProjectsMenu.tsx` with Radix equivalents.
- **Kept hand-drawn (intentional, commented):** the WakeStudio brand logos and the **microphone** glyph — Radix ships no mic icon.

### Verification
- `pnpm typecheck` ✅ · `pnpm build` ✅ · lint clean on changed files ✅ · 177 unit tests pass ✅

Closes #111
