### PR TITLE
feat(web): adopt the Radix UI stack - themes, colors, primitives, source UX

### DIFF
--- a/apps/web/e2e/config-steps.spec.ts
+++ b/apps/web/e2e/config-steps.spec.ts
@@ -13,7 +13,7 @@ test('stage cards render; KWS toggle gates the KWS stage', async ({ page }) => {
 
   // Phase 1 configure flow with all five stage cards.
   await expect(page.getByText('Setup')).toBeVisible()
-  for (const name of ['Source & AFE', 'AEC', 'BSS', 'NS', 'KWS']) {
+  for (const name of ['Source', 'AEC', 'BSS', 'NS', 'KWS']) {
     await expect(page.getByRole('button', { name: `${name} config` })).toBeVisible()
   }
 

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -80,7 +80,7 @@ test('live workspace panels still render (AFE/KWS)', async ({ page }) => {
 
   // Phase 1 configure flow with the pipeline-shaped module tabs.
   await expect(page.getByText('Setup')).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Source & AFE config' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Source config' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'NS config' })).toBeVisible()
 
   // KWS detection.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-toast": "^1.2.23",
     "@radix-ui/react-tooltip": "^1.2.16",
+    "@radix-ui/themes": "^3.3.0",
     "@wake-studio/contracts": "workspace:*",
     "@wake-studio/module-afe-graph": "workspace:^",
     "@wake-studio/module-few-shot": "workspace:^",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "build:e2e": "E2E_HARNESS=1 vite build"
   },
   "dependencies": {
+    "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-icons": "^1.3.2",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,8 @@ import { AppToastProvider } from "./components/toast";
 import { ProjectProvider } from "./projects";
 import { LogProvider } from "./log";
 import { SettingsProvider } from "./settings";
+import { useAppSettings } from "./settings/context";
+import { Theme } from "@radix-ui/themes";
 import { WorkspaceView } from "./views/WorkspaceView";
 import { ModelLibraryView } from "./views/ModelLibraryView";
 import { TrainingView } from "./views/TrainingView";
@@ -33,12 +35,28 @@ export default function App() {
         <ProjectProvider>
           <SettingsProvider>
             <LogProvider>
-              <AppShell />
+              <ThemedShell />
             </LogProvider>
           </SettingsProvider>
         </ProjectProvider>
       </AppToastProvider>
     </ConsoleStatusProvider>
+  );
+}
+
+/**
+ * Radix Themes wrapper - accent comes from the saved platform setting
+ * (Settings -> General -> Accent color; default gray). Gray is the default;
+ * Sky is the classic WakeStudio look. Dark mode (appearance) lands with the
+ * dark token set - today the app is light-only.
+ */
+function ThemedShell() {
+  const { platform } = useAppSettings();
+  const accent = platform['theme.accent'] ?? 'gray';
+  return (
+    <Theme appearance="light" accentColor={accent} grayColor="slate">
+      <AppShell />
+    </Theme>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import { ProjectProvider } from "./projects";
 import { LogProvider } from "./log";
 import { SettingsProvider } from "./settings";
 import { useAppSettings } from "./settings/context";
+import { setBrandAccentVars } from "./settings/accent-colors";
 import { Theme } from "@radix-ui/themes";
 import { WorkspaceView } from "./views/WorkspaceView";
 import { ModelLibraryView } from "./views/ModelLibraryView";
@@ -53,6 +54,11 @@ export default function App() {
 function ThemedShell() {
   const { platform } = useAppSettings();
   const accent = platform['theme.accent'] ?? 'gray';
+  // Sync the brand CSS vars (module-kit rendered panels read them) to the
+  // selected accent scale, alongside the Themes accentColor.
+  React.useEffect(() => {
+    setBrandAccentVars(accent);
+  }, [accent]);
   return (
     <Theme appearance="light" accentColor={accent} grayColor="slate">
       <AppShell />

--- a/apps/web/src/components/ClipsPanel.tsx
+++ b/apps/web/src/components/ClipsPanel.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@radix-ui/themes'
 import type { AFEPipeline } from '@wake-studio/module-afe-graph'
 import { useProjects } from '../projects'
 import type { WorkspaceConfig } from '../workspace/types'
@@ -147,17 +148,15 @@ export function ClipsPanel({ pipeline, running, config }: Props) {
     <div className="rounded-xl border border-line bg-surface-2 p-5">
       <div className="flex flex-wrap items-center gap-3">
         <h3 className="text-sm font-semibold text-ink-1">Per-stage clips</h3>
-        <button
+        <Button
           onClick={() => void handleCapture()}
           disabled={!running || enabledCount === 0}
-          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
-            capturing
-              ? 'bg-danger/90 text-ink-1 hover:bg-red-500'
-              : 'bg-surface-3 text-ink-2 hover:bg-surface-4'
-          }`}
+          variant={capturing ? 'solid' : 'surface'}
+          color={capturing ? 'red' : 'gray'}
+          size="2"
         >
           {capturing ? 'Stop & save clips' : 'Capture'}
-        </button>
+        </Button>
         {running && enabledCount === 0 && (
           <span className="text-xs text-warning">
             Enable persistence in a module config (Source/NS/KWS) first.
@@ -185,36 +184,46 @@ export function ClipsPanel({ pipeline, running, config }: Props) {
                 </span>
                 <div className="ml-auto flex items-center gap-2">
                   {playingId === clip.id ? (
-                    <button
+                    <Button
                       onClick={stop}
-                      className="rounded bg-surface-3 px-2 py-0.5 text-xs text-ink-2 hover:bg-surface-4"
+                      variant="soft"
+                      size="1"
+                      className="text-xs"
                     >
                       Stop
-                    </button>
+                    </Button>
                   ) : (
-                    <button
+                    <Button
                       onClick={() => void handlePlay(clip)}
-                      className="rounded bg-emerald-600/20 px-2 py-0.5 text-xs text-emerald-300 hover:bg-emerald-600/30"
+                      variant="soft"
+                      color="green"
+                      size="1"
+                      className="text-xs"
                     >
                       Play
-                    </button>
+                    </Button>
                   )}
-                  <button
+                  <Button
                     onClick={() => {
                       void clip.blob.arrayBuffer().then((buf) => {
                         downloadWav(new Uint8Array(buf), `${clip.name}.wav`)
                       })
                     }}
-                    className="rounded bg-surface-3 px-2 py-0.5 text-xs text-ink-2 hover:bg-surface-4"
+                    variant="soft"
+                    size="1"
+                    className="text-xs"
                   >
                     Export
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={() => handleDelete(clip.id)}
-                    className="rounded px-2 py-0.5 text-xs text-danger hover:bg-danger/10"
+                    variant="ghost"
+                    color="red"
+                    size="1"
+                    className="text-xs"
                   >
                     Delete
-                  </button>
+                  </Button>
                 </div>
               </div>
               {playingId === clip.id && (

--- a/apps/web/src/components/FileSourcePanel.tsx
+++ b/apps/web/src/components/FileSourcePanel.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useCallback, useRef } from 'react'
+import { Button, Checkbox, Slider } from '@radix-ui/themes'
 import type { FileChannelConfig, FileSourceItem } from '../workspace/types'
 import { decodeAudioFile } from '../workspace/sources/fileSource'
 
@@ -98,13 +99,14 @@ export function FileSourcePanel({ files, onChange, disabled }: Props) {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
-        <button
+        <Button
           onClick={() => inputRef.current?.click()}
           disabled={disabled}
-          className="rounded-lg bg-surface-3 px-3 py-1.5 text-sm font-medium text-ink-2 hover:bg-surface-4 disabled:opacity-50"
+          variant="surface"
+          size="2"
         >
           + Add audio files…
-        </button>
+        </Button>
         <input
           ref={inputRef}
           type="file"
@@ -140,13 +142,16 @@ export function FileSourcePanel({ files, onChange, disabled }: Props) {
                     {f.channels.length} ch
                   </span>
                 </div>
-                <button
+                <Button
                   onClick={() => handleRemove(fi)}
                   disabled={disabled}
-                  className="shrink-0 rounded px-1.5 py-0.5 text-xs text-danger hover:bg-danger/10"
+                  variant="ghost"
+                  color="red"
+                  size="1"
+                  className="shrink-0 text-xs"
                 >
                   Remove
-                </button>
+                </Button>
               </div>
 
               {/* Per-channel rows: loop + offset */}
@@ -160,30 +165,28 @@ export function FileSourcePanel({ files, onChange, disabled }: Props) {
                       Ch {ch.index + 1}
                     </span>
                     <label className="flex items-center gap-1.5">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={ch.loop}
                         disabled={disabled}
-                        onChange={(e) =>
-                          updateChannel(fi, ci, { loop: e.target.checked })
+                        onCheckedChange={(v) =>
+                          updateChannel(fi, ci, { loop: v === true })
                         }
-                        className="h-3.5 w-3.5 rounded accent-brand-9"
+                        size="1"
                       />
                       <span className="text-ink-2">Loop</span>
                     </label>
                     <label className="flex items-center gap-1.5">
                       <span className="text-ink-3">Offset</span>
-                      <input
-                        type="range"
+                      <Slider
                         min={0}
                         max={Math.max(1, Math.round(f.durationMs))}
                         step={100}
-                        value={Math.min(ch.offsetMs, Math.max(1, Math.round(f.durationMs)))}
+                        value={[Math.min(ch.offsetMs, Math.max(1, Math.round(f.durationMs)))]}
                         disabled={disabled}
-                        onChange={(e) =>
-                          updateChannel(fi, ci, { offsetMs: Number(e.target.value) })
+                        onValueChange={(v) =>
+                          updateChannel(fi, ci, { offsetMs: v[0] })
                         }
-                        className="w-32 accent-brand-9"
+                        className="w-32"
                       />
                       <span className="w-14 text-right font-mono text-ink-2">
                         {(ch.offsetMs / 1000).toFixed(1)}s

--- a/apps/web/src/components/FileSourcePanel.tsx
+++ b/apps/web/src/components/FileSourcePanel.tsx
@@ -167,7 +167,7 @@ export function FileSourcePanel({ files, onChange, disabled }: Props) {
                         onChange={(e) =>
                           updateChannel(fi, ci, { loop: e.target.checked })
                         }
-                        className="h-3.5 w-3.5 rounded accent-brand-500"
+                        className="h-3.5 w-3.5 rounded accent-brand-9"
                       />
                       <span className="text-ink-2">Loop</span>
                     </label>
@@ -183,7 +183,7 @@ export function FileSourcePanel({ files, onChange, disabled }: Props) {
                         onChange={(e) =>
                           updateChannel(fi, ci, { offsetMs: Number(e.target.value) })
                         }
-                        className="w-32 accent-brand-500"
+                        className="w-32 accent-brand-9"
                       />
                       <span className="w-14 text-right font-mono text-ink-2">
                         {(ch.offsetMs / 1000).toFixed(1)}s

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -13,6 +13,7 @@
  */
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@radix-ui/themes'
 import type { MutableRefObject } from 'react'
 import type { AFEPipeline } from '@wake-studio/module-afe-graph'
 import type { PanelCommands } from '../workspace/usePipelineRunner'
@@ -970,66 +971,45 @@ export const KWSPanel = memo(function KWSPanel({
           </div>
           <div className="flex items-center gap-2">
             {provisionKind !== 'prototype' && status === 'idle' && (
-              <button
-                onClick={provisionKind === 'list' ? handleListLoad : handleLoad}
-                className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-10"
-              >
+              <Button variant="solid" size="2" onClick={provisionKind === 'list' ? handleListLoad : handleLoad}>
                 {provisionKind === 'list'
                   ? (provisionActionLabel(config.backend, 'load-with-list') ?? 'Load')
                   : 'Load models'}
-              </button>
+              </Button>
             )}
             {provisionKind !== 'prototype' && (status === 'ready' || status === 'error') && (
-              <button
-                onClick={provisionKind === 'list' ? handleListLoad : handleLoad}
-                className="rounded-lg bg-surface-3 px-4 py-2 text-sm font-medium text-ink-2 transition-colors hover:bg-surface-4"
-              >
+              <Button variant="surface" size="2" onClick={provisionKind === 'list' ? handleListLoad : handleLoad}>
                 {provisionKind === 'list'
                   ? (provisionActionLabel(config.backend, 'load-with-list') ?? 'Reload')
                   : 'Reload models'}
-              </button>
+              </Button>
             )}
             {provisionKind === 'prototype' && status !== 'ready' && status !== 'running' && !detecting && (
-              <button
-                onClick={handleProvisionLoad}
-                disabled={status === 'loading'}
-                className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-50"
-              >
+              <Button variant="solid" size="2" onClick={handleProvisionLoad}
+                disabled={status === 'loading'}>
                 {status === 'loading' ? 'Loading…' : loadActionLabel(selectedBackend)}
-              </button>
+              </Button>
             )}
             {provisionKind !== 'prototype' && canStart && (
-              <button
-                onClick={handleStart}
-                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-emerald-500"
-              >
+              <Button variant="solid" color="green" size="2" onClick={handleStart}>
                 Start detection
-              </button>
+              </Button>
             )}
             {provisionKind !== 'prototype' && running && (
-              <button
-                onClick={handleStop}
-                className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-red-500"
-              >
+              <Button variant="solid" color="red" size="2" onClick={handleStop}>
                 Stop detection
-              </button>
+              </Button>
             )}
             {provisionKind === 'prototype' && artifact && !detecting && (
-              <button
-                onClick={handleProvisionStart}
-                disabled={!afeRunning}
-                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500 disabled:opacity-50"
-              >
+              <Button variant="solid" color="green" size="2" onClick={handleProvisionStart}
+                disabled={!afeRunning}>
                 {provisionActionLabel(config.backend, 'start') ?? 'Start detection'}
-              </button>
+              </Button>
             )}
             {provisionKind === 'prototype' && detecting && (
-              <button
-                onClick={handleProvisionStop}
-                className="rounded-lg bg-danger/90 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-red-500"
-              >
+              <Button variant="solid" color="red" size="2" onClick={handleProvisionStop}>
                 {provisionActionLabel(config.backend, 'stop') ?? 'Stop detection'}
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -1214,32 +1194,39 @@ export const KWSPanel = memo(function KWSPanel({
                           Saved: {selectedModel.name} · {Math.round(selectedModel.sizeBytes / 1024)} KB ·{' '}
                           {new Date(selectedModel.createdAtMs).toLocaleDateString()}
                         </span>
-                        <button
+                        <Button
                           onClick={() => void exportUserModel(selectedModel)}
+                          variant="ghost"
+                          size="1"
                           className="text-brand-11 underline hover:text-brand-10"
                         >
                           Export
-                        </button>
-                        <button
+                        </Button>
+                        <Button
                           onClick={() => {
                             void deleteUserModel(selectedModel.id)
                             setUserModels((prev) => prev.filter((m) => m.id !== selectedModel.id))
                             setModelSources((prev) => ({ ...prev, [role]: fallbackId }))
                           }}
+                          variant="ghost"
+                          color="red"
+                          size="1"
                           className="text-danger underline hover:text-red-400"
                         >
                           Delete
-                        </button>
+                        </Button>
                       </div>
                     )}
                     <div className="flex items-center gap-2">
-                      <button
+                      <Button
                         onClick={() => fileInputRef.current?.click()}
                         disabled={status === 'loading' || running}
-                        className="rounded bg-surface-3 px-2 py-0.5 text-[10px] text-ink-2 hover:bg-surface-4"
+                        variant="soft"
+                        size="1"
+                        className="text-[10px]"
                       >
                         Import local file…
-                      </button>
+                      </Button>
                       <input
                         ref={fileInputRef}
                         type="file"
@@ -1334,25 +1321,24 @@ export const KWSPanel = memo(function KWSPanel({
           {provisionKind === 'prototype' && status === 'ready' && !detecting && (
             <div className="space-y-4">
               <div className="flex flex-wrap items-center gap-3">
-                <button
+                <Button
                   onClick={() => void handleRecord('pos')}
                   disabled={recording}
-                  className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-emerald-500 disabled:opacity-50"
+                  variant="solid"
+                  color="green"
+                  size="2"
                 >
                   {recording
                     ? `Recording… (${RECORD_MS}ms)`
                     : (provisionActionLabel(config.backend, 'record') ?? 'Record sample')}
-                </button>
+                </Button>
                 {samples.length >= MIN_SAMPLES && (
-                  <button
-                    onClick={handleBuildPrototype}
-                    disabled={building}
-                    className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-50"
-                  >
+                  <Button variant="solid" size="2" onClick={handleBuildPrototype}
+                    disabled={building}>
                     {building
                       ? 'Building…'
                       : `${provisionActionLabel(config.backend, 'enroll') ?? 'Build prototype'} (${samples.length} samples)`}
-                  </button>
+                  </Button>
                 )}
                 {samples.length > 0 && (
                   <span className="text-xs text-ink-3">
@@ -1411,25 +1397,23 @@ export const KWSPanel = memo(function KWSPanel({
                   )}
                 </div>
                 <div className="flex flex-wrap items-center gap-3">
-                  <button
+                  <Button
                     onClick={() => void handleRecord('neg')}
                     disabled={recordingNeg}
-                    className="rounded-lg bg-surface-3 px-4 py-2 text-sm font-medium text-ink-2 hover:bg-surface-4 disabled:opacity-50"
+                    variant="surface"
+                    size="2"
                   >
                     {recordingNeg ? `Recording… (${RECORD_MS}ms)` : 'Record non-target sample'}
-                  </button>
+                  </Button>
                   {negSamples.length >= MIN_SAMPLES && artifactProto && (
-                    <button
-                      onClick={handleBuildNegative}
-                      disabled={buildingNeg}
-                      className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-50"
-                    >
+                    <Button variant="solid" size="2" onClick={handleBuildNegative}
+                      disabled={buildingNeg}>
                       {buildingNeg
                         ? 'Building…'
                         : artifactProto.negativeVector
                           ? 'Re-enroll negative prototype'
                           : `${provisionActionLabel(config.backend, 'enroll-negative') ?? 'Build negative prototype'} (${negSamples.length} samples)`}
-                    </button>
+                    </Button>
                   )}
                   {negSamples.length > 0 && (
                     <span className="text-xs text-ink-3">

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -972,7 +972,7 @@ export const KWSPanel = memo(function KWSPanel({
             {provisionKind !== 'prototype' && status === 'idle' && (
               <button
                 onClick={provisionKind === 'list' ? handleListLoad : handleLoad}
-                className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-400"
+                className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-10"
               >
                 {provisionKind === 'list'
                   ? (provisionActionLabel(config.backend, 'load-with-list') ?? 'Load')
@@ -993,7 +993,7 @@ export const KWSPanel = memo(function KWSPanel({
               <button
                 onClick={handleProvisionLoad}
                 disabled={status === 'loading'}
-                className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+                className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-50"
               >
                 {status === 'loading' ? 'Loading…' : loadActionLabel(selectedBackend)}
               </button>
@@ -1216,7 +1216,7 @@ export const KWSPanel = memo(function KWSPanel({
                         </span>
                         <button
                           onClick={() => void exportUserModel(selectedModel)}
-                          className="text-brand-400 underline hover:text-brand-300"
+                          className="text-brand-11 underline hover:text-brand-10"
                         >
                           Export
                         </button>
@@ -1347,7 +1347,7 @@ export const KWSPanel = memo(function KWSPanel({
                   <button
                     onClick={handleBuildPrototype}
                     disabled={building}
-                    className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+                    className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-50"
                   >
                     {building
                       ? 'Building…'
@@ -1422,7 +1422,7 @@ export const KWSPanel = memo(function KWSPanel({
                     <button
                       onClick={handleBuildNegative}
                       disabled={buildingNeg}
-                      className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+                      className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-50"
                     >
                       {buildingNeg
                         ? 'Building…'

--- a/apps/web/src/components/ModulePanels.tsx
+++ b/apps/web/src/components/ModulePanels.tsx
@@ -16,6 +16,7 @@
 
 import * as React from 'react'
 import type { MutableRefObject } from 'react'
+import { Button } from '@radix-ui/themes'
 import type { AFEPipeline } from '@wake-studio/module-afe-graph'
 import { describeParameters } from '@wake-studio/module-afe-graph'
 import { ParamRows } from './UnifiedConfigPanel'
@@ -24,7 +25,6 @@ import { PersistenceStageToggle } from './PersistenceStageToggle'
 import type { SourceState, SourceActions } from '../workspace/useSourceConfig'
 import type { WorkspaceConfig } from '../workspace/types'
 import type { ParamValue } from './UnifiedConfigPanel'
-import { cn } from './cn'
 
 // ---------------------------------------------------------------------------
 // Shared flat shell
@@ -68,19 +68,18 @@ export function StageModuleShell({
           </div>
         </div>
         {onToggle && (
-          <button
+          <Button
             onClick={onToggle}
             aria-label={`${title} toggle`}
             aria-pressed={enabled}
-            className={cn(
-              'rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-widest transition-colors',
-              enabled
-                ? 'bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25'
-                : 'bg-surface-4 text-ink-3 hover:bg-surface-3',
-            )}
+            variant={enabled ? 'soft' : 'ghost'}
+            color={enabled ? 'green' : 'gray'}
+            size="1"
+            radius="full"
+            className="px-3 text-[10px] font-bold uppercase tracking-widest"
           >
             {enabled ? 'On' : 'Off'}
-          </button>
+          </Button>
         )}
       </div>
       {children && (

--- a/apps/web/src/components/ModulePanels.tsx
+++ b/apps/web/src/components/ModulePanels.tsx
@@ -119,7 +119,7 @@ export function SourcePanel({
   persistence,
   setPersistence,
 }: {
-  source: SourceState
+  source: SourceState & { dirty: boolean; kindChanged: boolean }
   actions: SourceActions
   afeRef: MutableRefObject<AFEPipeline | null>
   running: boolean

--- a/apps/web/src/components/ModulePanels.tsx
+++ b/apps/web/src/components/ModulePanels.tsx
@@ -157,7 +157,7 @@ export function SourcePanel({
     <StageModuleShell
       color="#64748b"
       number="1"
-      title="Source & AFE"
+      title="Source"
       note="input feed, raw persistence and AFE-wide settings"
       enabled
     >

--- a/apps/web/src/components/NewProjectDialog.tsx
+++ b/apps/web/src/components/NewProjectDialog.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react'
+import { Button, TextField } from '@radix-ui/themes'
 import { useProjects, PROJECT_DOMAINS } from '../projects'
 import type { ProjectDomain } from '../projects'
 import {
@@ -17,7 +18,6 @@ import {
   DialogTitle,
 } from './ui'
 import { useToast } from './toast'
-import { cn } from './cn'
 
 interface Props {
   open: boolean
@@ -59,20 +59,20 @@ export function NewProjectDialog({ open, onOpenChange }: Props) {
         <div className="mt-4 space-y-3">
           <label className="block text-sm">
             <span className="text-ink-2">Project name</span>
-            <input
+            <TextField.Root
+              className="mt-1"
               value={draft.name}
               onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
               placeholder="e.g. Hey Studio"
-              className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
             />
           </label>
           <label className="block text-sm">
             <span className="text-ink-2">Wake word</span>
-            <input
+            <TextField.Root
+              className="mt-1"
               value={draft.targetWord}
               onChange={(e) => setDraft((d) => ({ ...d, targetWord: e.target.value }))}
               placeholder="e.g. hey studio"
-              className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
             />
           </label>
           <label className="block text-sm">
@@ -80,7 +80,7 @@ export function NewProjectDialog({ open, onOpenChange }: Props) {
             <select
               value={draft.domain}
               onChange={(e) => setDraft((d) => ({ ...d, domain: e.target.value as ProjectDomain }))}
-              className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              className="mt-1 w-full rounded-md border border-line bg-surface-3 px-2.5 py-1.5 text-sm text-ink-1 outline-none focus-visible:ring-2 focus-visible:ring-brand-8"
             >
               {PROJECT_DOMAINS.map((d) => (
                 <option key={d.value} value={d.value}>
@@ -91,28 +91,29 @@ export function NewProjectDialog({ open, onOpenChange }: Props) {
           </label>
           <label className="block text-sm">
             <span className="text-ink-2">Target chip (optional)</span>
-            <input
+            <TextField.Root
+              className="mt-1"
               value={draft.targetChip}
               onChange={(e) => setDraft((d) => ({ ...d, targetChip: e.target.value }))}
               placeholder="e.g. rpi4, esp32-s3, linux-x64"
-              className="mt-1 w-full rounded-lg border border-line bg-surface-3 px-3 py-2 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
             />
           </label>
         </div>
         <div className="mt-5 flex justify-end gap-2">
-          <button
+          <Button
             onClick={() => onOpenChange(false)}
-            className={cn('rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3')}
+            variant="outline"
+            size="2"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={submitCreate}
             disabled={busy}
-            className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+            size="2"
           >
             {busy ? 'Creating…' : 'Create'}
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/PersistenceStageToggle.tsx
+++ b/apps/web/src/components/PersistenceStageToggle.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { PersistStageId, WorkspaceConfig } from '../workspace/types'
+import { Checkbox, TextField } from '@radix-ui/themes'
 
 interface Props {
   stageId: PersistStageId
@@ -41,23 +42,22 @@ export function PersistenceStageToggle({ stageId, label, config, onChange }: Pro
 
   return (
     <label className="flex flex-wrap items-center gap-2 text-sm">
-      <input
-        type="checkbox"
+      <Checkbox
         checked={enabled}
-        onChange={(e) => setEnabled(e.target.checked)}
-        className="h-3.5 w-3.5 rounded accent-brand-500"
+        onCheckedChange={(v) => setEnabled(v === true)}
+        size="1"
       />
       <span className="text-ink-2">{label}</span>
       {enabled && (
         <span className="flex items-center gap-1 text-xs text-ink-3">
           max
-          <input
+          <TextField.Root
             type="number"
             min={0}
             placeholder="∞"
             value={maxSeconds ?? ''}
             onChange={(e) => setMax(e.target.value)}
-            className="h-6 w-14 rounded border border-line bg-surface-3 px-1.5 font-mono text-xs text-ink-1"
+            className="h-6 w-14 font-mono text-xs"
           />
           s
         </span>

--- a/apps/web/src/components/PipelineOverview.tsx
+++ b/apps/web/src/components/PipelineOverview.tsx
@@ -189,7 +189,7 @@ function FlowArrow({ active }: { active: boolean }) {
     <div
       className={`h-0.5 w-8 rounded ${
         active
-          ? 'animate-pulse bg-gradient-to-r from-transparent via-brand-400 to-transparent'
+          ? 'animate-pulse bg-gradient-to-r from-transparent via-brand-8 to-transparent'
           : 'bg-slate-700'
       }`}
     />

--- a/apps/web/src/components/PipelineTabs.tsx
+++ b/apps/web/src/components/PipelineTabs.tsx
@@ -14,6 +14,7 @@
  */
 
 import * as React from 'react'
+import { Button } from '@radix-ui/themes'
 import { cn } from './cn'
 
 export type PipelineTabId = 'source' | 'aec' | 'bss' | 'ns' | 'kws'
@@ -73,7 +74,7 @@ export function StageCard({
       className={cn(
         'flex min-w-0 flex-1 cursor-pointer flex-col overflow-hidden rounded-xl border transition-all',
         active
-          ? 'border-brand-400/60 bg-surface-2 shadow-lg shadow-brand-500/5'
+          ? 'border-brand-8/60 bg-surface-2 shadow-lg shadow-brand-9/5'
           : 'border-line bg-surface-2 hover:border-line-2 hover:bg-surface-3',
         !enabled && 'opacity-60',
         !onSelect && 'cursor-default',
@@ -107,22 +108,21 @@ export function StageCard({
             )}
           </div>
           {onToggleEnabled && (
-            <button
+            <Button
               onClick={(e) => {
                 e.stopPropagation()
                 onToggleEnabled?.()
               }}
               aria-label={`${label} toggle`}
               aria-pressed={enabled}
-              className={cn(
-                'shrink-0 rounded-full px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest transition-colors',
-                enabled
-                  ? 'bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25'
-                  : 'bg-surface-4 text-ink-3 hover:bg-surface-3',
-              )}
+              variant={enabled ? 'soft' : 'ghost'}
+              color={enabled ? 'green' : 'gray'}
+              size="1"
+              radius="full"
+              className="shrink-0 px-2 text-[9px] font-bold uppercase tracking-widest"
             >
               {enabled ? 'On' : 'Off'}
-            </button>
+            </Button>
           )}
         </div>
 

--- a/apps/web/src/components/RecentProjectsMenu.tsx
+++ b/apps/web/src/components/RecentProjectsMenu.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from './ui'
 import { NewProjectDialog } from './NewProjectDialog'
+import { Button } from '@radix-ui/themes'
 import { ChevronDownIcon, ListBulletIcon } from '@radix-ui/react-icons'
 
 /** Relative "updated …" caption for the recent-projects menu. */
@@ -46,14 +47,16 @@ export function RecentProjectsMenu() {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button
-            className="flex max-w-48 items-center gap-1.5 rounded-lg border border-line bg-surface-3 px-2.5 py-1.5 text-sm font-medium text-ink-1 hover:bg-surface-4"
+          <Button
+            variant="outline"
+            size="2"
+            className="max-w-48 gap-1.5 font-medium"
             title="Recent projects"
           >
             <ListBulletIcon className="h-3.5 w-3.5 shrink-0 text-ink-3" />
             <span className="truncate">{label}</span>
             <ChevronDownIcon className="h-3 w-3 shrink-0 text-ink-3" />
-          </button>
+          </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-60">
           {recent.length === 0 && (
@@ -68,13 +71,13 @@ export function RecentProjectsMenu() {
                 </span>
               </span>
               {current?.id === p.id && (
-                <span className="text-brand-600">✓</span>
+                <span className="text-brand-11">✓</span>
               )}
             </DropdownMenuItem>
           ))}
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setCreateOpen(true)}>
-            <span className="text-brand-600">+ New project…</span>
+            <span className="text-brand-11">+ New project…</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/components/RunControl.tsx
+++ b/apps/web/src/components/RunControl.tsx
@@ -6,6 +6,7 @@
  */
 
 import { IconPlay, IconStop, IconSpinner } from './icons'
+import { IconButton } from '@radix-ui/themes'
 import { cn } from './cn'
 
 export interface PipelineRunState {
@@ -32,33 +33,37 @@ export function RunControl({ runState, onStart, onStop }: Props) {
   return (
     <div className="flex items-center gap-2">
       {!running ? (
-        <button
+        <IconButton
           onClick={onStart}
           disabled={busy}
           aria-label="Start pipeline"
           title="Start pipeline"
+          size="4"
+          radius="full"
           className={cn(
-            'flex h-11 w-11 items-center justify-center rounded-full bg-brand-500 text-ink-1 shadow-lg shadow-brand-500/30 transition hover:bg-brand-400 disabled:opacity-50',
+            'bg-brand-9 text-ink-1 shadow-lg shadow-brand-9/30 hover:bg-brand-10',
             busy && 'cursor-not-allowed',
           )}
         >
           <IconPlay className="h-5 w-5" />
-        </button>
+        </IconButton>
       ) : (
-        <button
+        <IconButton
           onClick={onStop}
           disabled={busy}
           aria-label="Stop pipeline"
           title="Stop pipeline"
+          size="4"
+          radius="full"
           className={cn(
-            'flex h-11 w-11 items-center justify-center rounded-full bg-danger/90 text-ink-1 shadow-lg shadow-danger/25 transition hover:bg-red-500 disabled:opacity-50',
+            'bg-danger/90 text-ink-1 shadow-lg shadow-danger/25',
             busy && 'cursor-not-allowed',
           )}
         >
           <IconStop className="h-5 w-5" />
-        </button>
+        </IconButton>
       )}
-      {busy && <IconSpinner className="h-5 w-5 text-brand-600" />}
+      {busy && <IconSpinner className="h-5 w-5 text-brand-11" />}
       {runState.kwsLoading && (
         <span className="text-xs text-amber-400">loading models…</span>
       )}

--- a/apps/web/src/components/RunControl.tsx
+++ b/apps/web/src/components/RunControl.tsx
@@ -40,10 +40,7 @@ export function RunControl({ runState, onStart, onStop }: Props) {
           title="Start pipeline"
           size="4"
           radius="full"
-          className={cn(
-            'bg-brand-9 text-ink-1 shadow-lg shadow-brand-9/30 hover:bg-brand-10',
-            busy && 'cursor-not-allowed',
-          )}
+          className={cn('shadow-lg', busy && 'cursor-not-allowed')}
         >
           <IconPlay className="h-5 w-5" />
         </IconButton>
@@ -55,10 +52,9 @@ export function RunControl({ runState, onStart, onStop }: Props) {
           title="Stop pipeline"
           size="4"
           radius="full"
-          className={cn(
-            'bg-danger/90 text-ink-1 shadow-lg shadow-danger/25',
-            busy && 'cursor-not-allowed',
-          )}
+          variant="solid"
+          color="red"
+          className={cn('shadow-lg', busy && 'cursor-not-allowed')}
         >
           <IconStop className="h-5 w-5" />
         </IconButton>

--- a/apps/web/src/components/SourceConfigSection.tsx
+++ b/apps/web/src/components/SourceConfigSection.tsx
@@ -9,12 +9,13 @@
 
 import { SourceSelector } from './SourceSelector'
 import { FileSourcePanel } from './FileSourcePanel'
-import { SegmentedControl } from '@radix-ui/themes'
+import { Button, SegmentedControl } from '@radix-ui/themes'
 import { FileIcon } from '@radix-ui/react-icons'
 import type { SourceState, SourceActions } from '../workspace/useSourceConfig'
 
 interface Props {
-  source: SourceState
+  /** Working source draft; `dirty`/`kindChanged` tell how it differs from the saved one. */
+  source: SourceState & { dirty: boolean; kindChanged: boolean }
   actions: SourceActions
   disabled?: boolean
 }
@@ -42,6 +43,20 @@ export function SourceConfigSection({ source, actions, disabled }: Props) {
           Audio files
         </SegmentedControl.Item>
       </SegmentedControl.Root>
+      {source.dirty && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button size="1" onClick={actions.apply}>
+            {source.kindChanged
+              ? `Use ${source.kind === 'file' ? 'audio files' : 'microphone'} as source`
+              : 'Apply source changes'}
+          </Button>
+          <span className="text-[11px] text-ink-3">
+            {disabled
+              ? 'Applies on the next Start'
+              : 'Not saved yet — press Apply to make it the project source.'}
+          </span>
+        </div>
+      )}
       {source.kind === 'mic' ? (
         <SourceSelector
           value={source.mic}

--- a/apps/web/src/components/SourceConfigSection.tsx
+++ b/apps/web/src/components/SourceConfigSection.tsx
@@ -28,15 +28,17 @@ export function SourceConfigSection({ source, actions, disabled }: Props) {
         onValueChange={(v) => actions.updateKind(v as 'mic' | 'file')}
       >
         <SegmentedControl.Item value="mic">
-          {/* Mic: Radix UI has no mic glyph, so this stays hand-drawn. */}
-          <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          {/* Mic: Radix UI has no mic glyph, so this stays hand-drawn.
+              inline-block: Tailwind preflight makes svg display:block, which
+              would put the icon on its own line and clip the label. */}
+          <svg viewBox="0 0 24 24" className="inline-block h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
             <path d="M19 10v1a7 7 0 0 1-14 0v-1M12 18v4M8 22h8" />
           </svg>
           Microphone
         </SegmentedControl.Item>
         <SegmentedControl.Item value="file">
-          <FileIcon className="h-4 w-4" />
+          <FileIcon className="inline-block h-4 w-4" />
           Audio files
         </SegmentedControl.Item>
       </SegmentedControl.Root>

--- a/apps/web/src/components/SourceConfigSection.tsx
+++ b/apps/web/src/components/SourceConfigSection.tsx
@@ -9,9 +9,9 @@
 
 import { SourceSelector } from './SourceSelector'
 import { FileSourcePanel } from './FileSourcePanel'
+import { Button } from '@radix-ui/themes'
 import { FileIcon } from '@radix-ui/react-icons'
 import type { SourceState, SourceActions } from '../workspace/useSourceConfig'
-import { cn } from './cn'
 
 interface Props {
   source: SourceState
@@ -23,15 +23,12 @@ export function SourceConfigSection({ source, actions, disabled }: Props) {
   return (
     <div className="space-y-3">
       <div className="inline-flex items-center gap-1 rounded-xl border border-line bg-surface-3 p-1">
-        <button
+        <Button
           onClick={() => actions.updateKind('mic')}
           disabled={disabled}
-          className={cn(
-            'flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-medium transition-colors disabled:opacity-50',
-            source.kind === 'mic'
-              ? 'bg-brand-500 text-ink-1 shadow-sm'
-              : 'text-ink-2 hover:bg-surface-4',
-          )}
+          variant={source.kind === 'mic' ? 'solid' : 'ghost'}
+          size="2"
+          className="gap-1.5"
         >
           {/* Mic: Radix UI has no mic glyph, so this stays hand-drawn. */}
           <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -39,20 +36,17 @@ export function SourceConfigSection({ source, actions, disabled }: Props) {
             <path d="M19 10v1a7 7 0 0 1-14 0v-1M12 18v4M8 22h8" />
           </svg>
           Microphone
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => actions.updateKind('file')}
           disabled={disabled}
-          className={cn(
-            'flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-medium transition-colors disabled:opacity-50',
-            source.kind === 'file'
-              ? 'bg-brand-500 text-ink-1 shadow-sm'
-              : 'text-ink-2 hover:bg-surface-4',
-          )}
+          variant={source.kind === 'file' ? 'solid' : 'ghost'}
+          size="2"
+          className="gap-1.5"
         >
           <FileIcon className="h-4 w-4" />
           Audio files
-        </button>
+        </Button>
       </div>
       {source.kind === 'mic' ? (
         <SourceSelector

--- a/apps/web/src/components/SourceConfigSection.tsx
+++ b/apps/web/src/components/SourceConfigSection.tsx
@@ -9,7 +9,7 @@
 
 import { SourceSelector } from './SourceSelector'
 import { FileSourcePanel } from './FileSourcePanel'
-import { Button } from '@radix-ui/themes'
+import { SegmentedControl } from '@radix-ui/themes'
 import { FileIcon } from '@radix-ui/react-icons'
 import type { SourceState, SourceActions } from '../workspace/useSourceConfig'
 
@@ -22,32 +22,24 @@ interface Props {
 export function SourceConfigSection({ source, actions, disabled }: Props) {
   return (
     <div className="space-y-3">
-      <div className="inline-flex items-center gap-1 rounded-xl border border-line bg-surface-3 p-1">
-        <Button
-          onClick={() => actions.updateKind('mic')}
-          disabled={disabled}
-          variant={source.kind === 'mic' ? 'solid' : 'ghost'}
-          size="2"
-          className="gap-1.5"
-        >
+      <SegmentedControl.Root
+        value={source.kind}
+        disabled={disabled}
+        onValueChange={(v) => actions.updateKind(v as 'mic' | 'file')}
+      >
+        <SegmentedControl.Item value="mic">
           {/* Mic: Radix UI has no mic glyph, so this stays hand-drawn. */}
           <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
             <path d="M19 10v1a7 7 0 0 1-14 0v-1M12 18v4M8 22h8" />
           </svg>
           Microphone
-        </Button>
-        <Button
-          onClick={() => actions.updateKind('file')}
-          disabled={disabled}
-          variant={source.kind === 'file' ? 'solid' : 'ghost'}
-          size="2"
-          className="gap-1.5"
-        >
+        </SegmentedControl.Item>
+        <SegmentedControl.Item value="file">
           <FileIcon className="h-4 w-4" />
           Audio files
-        </Button>
-      </div>
+        </SegmentedControl.Item>
+      </SegmentedControl.Root>
       {source.kind === 'mic' ? (
         <SourceSelector
           value={source.mic}

--- a/apps/web/src/components/SourceSelector.tsx
+++ b/apps/web/src/components/SourceSelector.tsx
@@ -12,6 +12,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import type { MicSourceConfig } from '@wake-studio/module-afe-graph'
+import { Button, Card, Checkbox } from '@radix-ui/themes'
 import {
   enumerateMicDevices,
   hasDeviceLabels,
@@ -42,12 +43,11 @@ function ToggleRow({
 }) {
   return (
     <label className="flex items-center gap-2 text-xs">
-      <input
-        type="checkbox"
+      <Checkbox
         checked={checked}
         disabled={disabled}
-        onChange={(e) => onChecked(e.target.checked)}
-        className="h-3.5 w-3.5 rounded accent-brand-500"
+        onCheckedChange={(v) => onChecked(v === true)}
+        size="1"
       />
       <span className="text-ink-2">{label}</span>
       <span className="text-[10px] text-ink-3">{hint}</span>
@@ -90,7 +90,7 @@ export function SourceSelector({ value, onChange, disabled }: Props) {
   }, [devices])
 
   return (
-    <div className="flex flex-wrap items-center gap-x-5 gap-y-3 rounded-xl border border-line bg-surface-2 p-4">
+    <Card className="flex flex-wrap items-center gap-x-5 gap-y-3 !p-4">
       <label className="flex items-center gap-2 text-sm">
         <span className="text-ink-2">Input device</span>
         <select
@@ -109,13 +109,13 @@ export function SourceSelector({ value, onChange, disabled }: Props) {
       </label>
 
       {devices.length > 0 && !permissionGranted && (
-        <button
+        <Button
           onClick={handleRequestPermission}
           disabled={disabled}
-          className="rounded bg-brand-500 px-2 py-1 text-xs font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-50"
+          size="1"
         >
           Allow mic to see device names
-        </button>
+        </Button>
       )}
 
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
@@ -160,6 +160,6 @@ export function SourceSelector({ value, onChange, disabled }: Props) {
         Browser DSP is off by default — our RNNoise is the only noise
         suppressor. Toggle browser AEC/NS/AGC to let the device do it instead.
       </p>
-    </div>
+    </Card>
   )
 }

--- a/apps/web/src/components/SourceSelector.tsx
+++ b/apps/web/src/components/SourceSelector.tsx
@@ -97,7 +97,7 @@ export function SourceSelector({ value, onChange, disabled }: Props) {
           value={value.deviceId ?? ''}
           disabled={disabled || devices.length === 0}
           onChange={(e) => onChange({ ...value, deviceId: e.target.value || undefined })}
-          className="max-w-56 truncate rounded bg-surface-3 px-2 py-1 text-sm text-ink-1"
+          className="max-w-72 truncate rounded bg-surface-3 px-2.5 py-1 text-sm text-ink-1"
         >
           {devices.length === 0 && <option value="">Default device</option>}
           {devices.map((d) => (

--- a/apps/web/src/components/StepSection.tsx
+++ b/apps/web/src/components/StepSection.tsx
@@ -8,6 +8,7 @@
 
 import * as React from 'react'
 import { ChevronRightIcon } from '@radix-ui/react-icons'
+import { Button } from '@radix-ui/themes'
 import { cn } from './cn'
 
 interface Props {
@@ -31,16 +32,18 @@ export function StepSection({
 }: Props) {
   return (
     <section className="overflow-hidden rounded-xl border border-line bg-surface-2">
-      <button
+      <Button
         type="button"
         onClick={onToggle}
         aria-expanded={open}
-        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-3"
+        variant="ghost"
+        size="2"
+        className="w-full justify-start gap-3 px-4 text-left"
       >
         <span
           className={cn(
             'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold',
-            open ? 'bg-brand-500 text-ink-1' : 'bg-surface-4 text-ink-3',
+            open ? 'bg-brand-9 text-ink-1' : 'bg-surface-4 text-ink-3',
           )}
         >
           {step}
@@ -59,7 +62,7 @@ export function StepSection({
             open && 'rotate-90',
           )}
         />
-      </button>
+      </Button>
       {open && <div className="space-y-4 px-4 pb-5 pt-1">{children}</div>}
     </section>
   )

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -66,7 +66,7 @@ function NavButton({
           aria-current={active ? 'page' : undefined}
           variant={active ? 'soft' : 'ghost'}
           size="2"
-          className={cn('w-full justify-start gap-2.5 px-2.5', !active && 'text-ink-2')}
+          className={cn('nav-row w-full justify-start', !active && 'text-ink-2')}
         >
           <Icon className="h-[18px] w-[18px] shrink-0" />
           <span className="flex-1 truncate text-left">{item.label}</span>
@@ -125,7 +125,7 @@ function SettingsNav({
         aria-label={`Settings menu ${open ? 'collapsed' : 'expanded'}`}
         variant="ghost"
         size="2"
-        className="w-full justify-start gap-2.5 px-2.5 text-ink-2"
+        className="nav-row w-full justify-start text-ink-2"
       >
         <Icon className="h-[18px] w-[18px] shrink-0" />
         <span className="flex-1 truncate text-left">{item.label}</span>
@@ -147,7 +147,7 @@ function SettingsNav({
                 aria-current={childActive ? 'page' : undefined}
                 variant={childActive ? 'soft' : 'ghost'}
                 size="1"
-                className={cn('w-full justify-start px-2', !childActive && 'text-ink-3')}
+                className={cn('nav-row w-full justify-start', !childActive && 'text-ink-3')}
               >
                 <span className="flex-1 truncate text-left">{child.label}</span>
               </Button>
@@ -166,7 +166,7 @@ function SettingsNav({
                 aria-current={active ? 'page' : undefined}
                 variant={active ? 'soft' : 'ghost'}
                 size="1"
-                className={cn('w-full justify-start px-2', !active && 'text-ink-3')}
+                className={cn('nav-row w-full justify-start', !active && 'text-ink-3')}
               >
                 <span className="flex-1 truncate text-left">{d.label}</span>
               </Button>

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -21,6 +21,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from './ui'
+import { Button, IconButton } from '@radix-ui/themes'
 import {
   ChevronRightIcon,
   Cross2Icon,
@@ -60,15 +61,12 @@ function NavButton({
   return (
     <Tooltip delayDuration={400}>
       <TooltipTrigger asChild>
-        <button
+        <Button
           onClick={onClick}
           aria-current={active ? 'page' : undefined}
-          className={cn(
-            'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors',
-            active
-              ? 'bg-brand-500/10 text-brand-700'
-              : 'text-ink-2 hover:bg-surface-3 hover:text-ink-1',
-          )}
+          variant={active ? 'soft' : 'ghost'}
+          size="2"
+          className={cn('w-full justify-start gap-2.5 px-2.5', !active && 'text-ink-2')}
         >
           <Icon className="h-[18px] w-[18px] shrink-0" />
           <span className="flex-1 truncate text-left">{item.label}</span>
@@ -77,7 +75,7 @@ function NavButton({
               {item.badge}
             </span>
           )}
-        </button>
+        </Button>
       </TooltipTrigger>
       <TooltipContent side="right">{item.label}</TooltipContent>
     </Tooltip>
@@ -121,42 +119,38 @@ function SettingsNav({
   return (
     <div>
       {/* Parent: toggles open/closed only, no navigation. */}
-      <button
+      <Button
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-label={`Settings menu ${open ? 'collapsed' : 'expanded'}`}
-        className={cn(
-          'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium transition-colors',
-          'text-ink-2 hover:bg-surface-3 hover:text-ink-1',
-        )}
+        variant="ghost"
+        size="2"
+        className="w-full justify-start gap-2.5 px-2.5 text-ink-2"
       >
         <Icon className="h-[18px] w-[18px] shrink-0" />
         <span className="flex-1 truncate text-left">{item.label}</span>
         <ChevronRightIcon
           className={cn(
-            'h-3.5 w-3.5 shrink-0 text-ink-3 transition-transform group-hover:text-ink-1',
+            'h-3.5 w-3.5 shrink-0 text-ink-3 transition-transform',
             open && 'rotate-90',
           )}
         />
-      </button>
+      </Button>
 
       {open && (
         <div className="ml-3 mt-0.5 space-y-0.5 border-l border-line pl-2">          {sections.map((child) => {
             const childActive = activeSection === settingsSectionOf(child.route)
             return (
-              <button
+              <Button
                 key={child.route}
                 onClick={() => onNavigate(child.route)}
                 aria-current={childActive ? 'page' : undefined}
-                className={cn(
-                  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors',
-                  childActive
-                    ? 'bg-brand-500/10 text-brand-700'
-                    : 'text-ink-3 hover:bg-surface-3 hover:text-ink-1',
-                )}
+                variant={childActive ? 'soft' : 'ghost'}
+                size="1"
+                className={cn('w-full justify-start px-2', !childActive && 'text-ink-3')}
               >
                 <span className="flex-1 truncate text-left">{child.label}</span>
-              </button>
+              </Button>
             )
           })}
 
@@ -164,21 +158,18 @@ function SettingsNav({
           {drivers.map((d) => {
             const active = driversActive && d.backendId === settingsBackend
             return (
-              <button
+              <Button
                 key={d.backendId}
                 onClick={() => {
                   window.location.hash = settingsHash('modules', d.backendId)
                 }}
                 aria-current={active ? 'page' : undefined}
-                className={cn(
-                  'flex w-full items-center gap-2 truncate rounded-md px-2 py-1.5 text-[13px] transition-colors',
-                  active
-                    ? 'bg-brand-500/10 text-brand-700'
-                    : 'text-ink-3 hover:bg-surface-3 hover:text-ink-1',
-                )}
+                variant={active ? 'soft' : 'ghost'}
+                size="1"
+                className={cn('w-full justify-start px-2', !active && 'text-ink-3')}
               >
                 <span className="flex-1 truncate text-left">{d.label}</span>
-              </button>
+              </Button>
             )
           })}
         </div>
@@ -242,13 +233,15 @@ export function Sidebar({
           <span className="text-[11px] text-ink-3">on-device KWS studio</span>
         </div>
         {onClose && (
-          <button
+          <IconButton
             onClick={onClose}
             aria-label="Close navigation"
-            className="rounded-md p-1.5 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+            variant="ghost"
+            size="1"
+            className="text-ink-3"
           >
             <Cross2Icon className="h-4 w-4" />
-          </button>
+          </IconButton>
         )}
       </div>
 
@@ -312,13 +305,15 @@ export function TopBar({
 
   return (
     <header className="flex h-14 shrink-0 items-center gap-3 border-b border-line bg-surface-2/90 px-4 backdrop-blur">
-      <button
+      <IconButton
         onClick={onToggleSidebar}
-        className="rounded-md p-1.5 text-ink-3 hover:bg-surface-3 hover:text-ink-1 lg:hidden"
+        variant="ghost"
+        size="2"
+        className="text-ink-3 lg:hidden"
         aria-label="Toggle navigation"
       >
         <HamburgerMenuIcon className="h-5 w-5" />
-      </button>
+      </IconButton>
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <h1 className="truncate text-sm font-semibold text-ink-1">{title}</h1>
       </div>
@@ -423,20 +418,25 @@ function MiniPipelineBar({ open, onToggle }: { open: boolean; onToggle: () => vo
           </React.Fragment>
         ))}
         <span className="mx-1 h-4 w-px shrink-0 bg-line-2" />
-        <button
+        <IconButton
           onClick={stopPipeline}
           aria-label="Stop pipeline"
-          className="shrink-0 rounded p-1 text-danger hover:bg-danger/10"
+          variant="ghost"
+          color="red"
+          size="1"
+          className="shrink-0"
         >
           <StopIcon className="h-3 w-3" />
-        </button>
-        <button
+        </IconButton>
+        <IconButton
           onClick={onToggle}
           aria-label="Minimize pipeline status"
-          className="shrink-0 rounded p-1 text-ink-3 hover:bg-surface-3 hover:text-ink-1"
+          variant="ghost"
+          size="1"
+          className="shrink-0 text-ink-3"
         >
           <ChevronRightIcon className="h-3 w-3" />
-        </button>
+        </IconButton>
       </div>
 
       {/* Minimized: the circle itself is colored by the wake indicator.

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react'
+import { IconButton } from '@radix-ui/themes'
 import {
   Toast,
   ToastDescription,
@@ -77,13 +78,15 @@ export function AppToastProvider({ children }: { children: React.ReactNode }) {
                     <ToastDescription>{t.description}</ToastDescription>
                   )}
                 </div>
-                <button
+                <IconButton
                   onClick={() => setItems((prev) => prev.filter((x) => x.id !== t.id))}
-                  className="rounded p-0.5 text-ink-3 hover:text-ink-1"
+                  variant="ghost"
+                  size="1"
+                  className="text-ink-3"
                   aria-label="Dismiss notification"
                 >
                   ✕
-                </button>
+                </IconButton>
               </div>
             </Toast>
           ))}

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -1,11 +1,20 @@
 /**
  * Radix shell components (App shell layer).
  *
- * Thin, styled adapters over Radix Primitives for the console shell ONLY -
- * navigation, modals, menus, hints, notifications. These are NOT part of the
- * spec-driven layer (ADR-025 keeps that pure in `module-kit`); they are the
- * shell's own building blocks. Styling uses the WakeStudio semantic tokens
- * (`--ws-*`, light theme; dark theme is a token swap).
+ * Thin, styled adapters over Radix Primitives / Radix Themes for the console
+ * shell - navigation, modals, menus, hints, notifications. These are NOT part
+ * of the spec-driven layer (ADR-025 keeps that pure in `module-kit`); they are
+ * the shell's own building blocks.
+ *
+ * - Dialog, buttons, cards, inputs... use Radix Themes components (styling
+ *   comes from the Theme provider + Radix Colors tokens).
+ * - DropdownMenu, Tooltip, Toast stay on Radix Primitives (already themed via
+ *   the `--ws-*` tokens; behavior-critical for e2e).
+ *
+ * Note: Radix Themes' CSS is unlayered, so it beats Tailwind utilities in the
+ * cascade. Where we need to override Themes defaults (dialog width/padding,
+ * drawer positioning) we use Tailwind's `!` (important) modifier - see
+ * DialogContent.
  */
 
 import * as React from 'react'
@@ -13,88 +22,57 @@ import * as DialogPrimitive from '@radix-ui/react-dialog'
 import * as DropdownPrimitive from '@radix-ui/react-dropdown-menu'
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import * as ToastPrimitive from '@radix-ui/react-toast'
+import * as Themes from '@radix-ui/themes'
 import { cn } from './cn'
 import { IconMenu } from './icons'
 
 // ---------------------------------------------------------------------------
-// Dialog
+// Dialog (Radix Themes - bundled overlay + content, themes motion/styling)
 // ---------------------------------------------------------------------------
 export const Dialog = DialogPrimitive.Root
 export const DialogTrigger = DialogPrimitive.Trigger
 export const DialogClose = DialogPrimitive.Close
-export const DialogPortal = DialogPrimitive.Portal
-export const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof Themes.Dialog.Content>,
+  React.ComponentPropsWithoutRef<typeof Themes.Dialog.Content> & {
+    /** Center on screen (default). When false, the content is a left-edge
+     *  side drawer (mobile nav / train list). */
+    centered?: boolean
+  }
+>(({ className, centered = true, ...props }, ref) => (
+  <Themes.Dialog.Content
     ref={ref}
     className={cn(
-      // Position + animation only; the scrim color is applied by the caller
-      // (DialogContent) so a focused modal can fully replace it (issue #105).
-      'fixed inset-0 z-50',
-      'data-[state=open]:animate-in data-[state=closed]:animate-out',
+      // Themes CSS is unlayered -> width/padding overrides need `!`.
+      centered
+        ? '!w-[min(92vw,26rem)]'
+        : '!fixed left-0 top-0 h-screen !w-[min(80vw,17rem)] !p-0',
       className,
     )}
     {...props}
   />
 ))
-DialogOverlay.displayName = 'DialogOverlay'
-export const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
-    /** Center on screen (default). When false, no positioning classes are
-     *  applied so the caller can position it (e.g. a side drawer). */
-    centered?: boolean
-    /** Extra classes for the scrim overlay (e.g. a stronger dim + blur for
-     *  focused modal flows — training wizard / notebook review, #105). */
-    overlayClassName?: string
-  }
->(({ className, children, centered = true, overlayClassName, ...props }, ref) => (
-  <DialogPrimitive.Portal>
-    <DialogOverlay className={overlayClassName ?? 'bg-slate-900/20'} />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'z-50 border border-line bg-surface-2 shadow-2xl',
-        'outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
-        centered
-          ? 'fixed left-1/2 top-1/2 w-[min(92vw,26rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl p-6'
-          : 'fixed',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPrimitive.Portal>
-))
 DialogContent.displayName = 'DialogContent'
+
 export const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+  React.ElementRef<typeof Themes.Dialog.Title>,
+  React.ComponentPropsWithoutRef<typeof Themes.Dialog.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-base font-semibold text-ink-1', className)}
-    {...props}
-  />
+  <Themes.Dialog.Title ref={ref} className={className} {...props} />
 ))
 DialogTitle.displayName = 'DialogTitle'
+
 export const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+  React.ElementRef<typeof Themes.Dialog.Description>,
+  React.ComponentPropsWithoutRef<typeof Themes.Dialog.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('mt-1 text-sm text-ink-2', className)}
-    {...props}
-  />
+  <Themes.Dialog.Description ref={ref} className={className} {...props} />
 ))
 DialogDescription.displayName = 'DialogDescription'
 
 // ---------------------------------------------------------------------------
-// Dropdown menu
+// Dropdown menu (Radix primitive, token-styled)
 // ---------------------------------------------------------------------------
 export const DropdownMenu = DropdownPrimitive.Root
 export const DropdownMenuTrigger = DropdownPrimitive.Trigger
@@ -145,7 +123,7 @@ export const DropdownMenuSeparator = React.forwardRef<
 DropdownMenuSeparator.displayName = 'DropdownMenuSeparator'
 
 // ---------------------------------------------------------------------------
-// Tooltip
+// Tooltip (Radix primitive, token-styled)
 // ---------------------------------------------------------------------------
 export const TooltipProvider = TooltipPrimitive.Provider
 export const Tooltip = TooltipPrimitive.Root
@@ -170,7 +148,7 @@ export const TooltipContent = React.forwardRef<
 TooltipContent.displayName = 'TooltipContent'
 
 // ---------------------------------------------------------------------------
-// Toast
+// Toast (Radix primitive, token-styled)
 // ---------------------------------------------------------------------------
 export const ToastProvider = ToastPrimitive.Provider
 export const ToastViewport = React.forwardRef<

--- a/apps/web/src/components/viz/StageCard.tsx
+++ b/apps/web/src/components/viz/StageCard.tsx
@@ -8,6 +8,7 @@
  */
 
 import { memo, useEffect, useRef } from 'react'
+import { Button } from '@radix-ui/themes'
 import type { StageFrameData } from '@wake-studio/module-afe-graph'
 import { WebGLSpectrogram } from '../spectrogram/WebGLSpectrogram'
 
@@ -44,16 +45,15 @@ export const StagePanel = memo(function StagePanel({
         >
           {id}
         </span>
-        <button
+        <Button
           onClick={() => onToggleBypass(id)}
-          className={`rounded px-2 py-0.5 text-[10px] font-medium uppercase ${
-            isBypassed
-              ? 'bg-surface-4 text-ink-2'
-              : 'bg-emerald-500/20 text-emerald-300'
-          }`}
+          variant={isBypassed ? 'soft' : 'outline'}
+          color={isBypassed ? 'gray' : 'green'}
+          size="1"
+          className="px-2 text-[10px] font-medium uppercase"
         >
           {isBypassed ? 'Bypassed' : 'Active'}
-        </button>
+        </Button>
       </div>
 
       {/* Waveform - flex-1 absorbs the height difference between stages so

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -16,51 +16,48 @@
 }
 
 /*
- * WakeStudio semantic design tokens (light theme, v1).
+ * WakeStudio semantic design tokens - backed by Radix Colors
+ * (https://www.radix-ui.com/colors, the same scales @radix-ui/themes uses).
  *
  * Components use semantic utilities (bg-surface, text-ink-2, border-line...)
  * instead of raw slate-xxx/white classes, so a dark theme is a token swap, not
  * a component sweep. Defined here as CSS variables + mapped in
- * tailwind.config.ts.
+ * tailwind.config.ts. Values are rgb() TRIPLES so Tailwind's <alpha-value>
+ * can compose opacity modifiers (e.g. bg-surface-2/90).
  *
- * Palette rationale:
- *   - ink-1  : primary text (near-black, high contrast)
- *   - ink-2  : secondary text (60% ink)
- *   - ink-3  : tertiary / captions (45% ink)
- *   - surface: page background (very light cool gray)
- *   - surface-2: card background (white)
- *   - surface-3: inset / input background (slightly gray)
- *   - line   : hairline borders
- *   - line-2 : stronger borders (focus rings, active)
- *   - brand  : the sky-blue accent (unchanged from dark theme)
+ * Scale mapping (light theme):
+ *   - surface-*   : Radix slate 1-4 (page, subtle, card/inset, hover)
+ *   - ink-*       : Radix slate 10-12 (tertiary, secondary, primary text)
+ *   - line*       : Radix slate 6-7 (hairlines, stronger borders)
+ *   - brand-*     : Radix sky 1-12 (brand scale; 9=accent, 11-12=text)
+ *   - status      : Radix green/amber/red step 11 (text on light)
  */
 
 /* CSS variables live OUTSIDE @layer so they always exist at :root (Tailwind
-   drops unlayered custom props inside @layer base in some purge paths).
-   Colors are rgb() TRIPLES so Tailwind's <alpha-value> can compose
-   opacity modifiers (e.g. bg-surface-2/90). */
+   drops unlayered custom props inside @layer base in some purge paths). */
 :root {
   color-scheme: light;
 
-  /* Surfaces. */
-  --ws-surface: 248 250 252;    /* slate-50  - page bg */
-  --ws-surface-2: 255 255 255;  /* white     - card bg */
-  --ws-surface-3: 241 245 249;  /* slate-100 - inset/input bg */
-  --ws-surface-4: 226 232 240;  /* slate-200 - hover/active bg */
+  /* Surfaces (Radix slate). */
+  --ws-surface: 252 252 253;    /* slate-1 - page bg */
+  --ws-surface-1: 249 249 251;  /* slate-2 - subtle bg (floating panels) */
+  --ws-surface-2: 255 255 255;  /* white    - card bg */
+  --ws-surface-3: 240 240 243;  /* slate-3 - inset/input bg */
+  --ws-surface-4: 232 232 236;  /* slate-4 - hover/active bg */
 
-  /* Ink (text). */
-  --ws-ink-1: 15 23 42;         /* slate-900 - primary text */
-  --ws-ink-2: 71 85 105;        /* slate-600 - secondary text */
-  --ws-ink-3: 100 116 139;      /* slate-500 - tertiary/captions */
+  /* Ink (Radix slate). */
+  --ws-ink-1: 28 32 36;         /* slate-12 - primary text */
+  --ws-ink-2: 96 100 108;       /* slate-11 - secondary text */
+  --ws-ink-3: 128 131 141;      /* slate-10 - tertiary/captions */
 
-  /* Lines. */
-  --ws-line: 226 232 240;       /* slate-200 - hairlines */
-  --ws-line-2: 203 213 225;     /* slate-300 - stronger borders */
+  /* Lines (Radix slate). */
+  --ws-line: 217 217 224;       /* slate-6 - hairlines */
+  --ws-line-2: 205 206 214;     /* slate-7 - stronger borders */
 
-  /* Semantic (status). */
-  --ws-success: 5 150 105;      /* emerald-600 */
-  --ws-warning: 217 119 6;      /* amber-600 */
-  --ws-danger: 220 38 38;       /* red-600 */
+  /* Semantic (Radix status scales, step 11 = text on light). */
+  --ws-success: 33 131 88;      /* green-11 */
+  --ws-warning: 171 100 0;      /* amber-11 */
+  --ws-danger: 206 44 49;       /* red-11 */
 }
 
 /* Always show the scrollbar: prevents a feedback loop where content height

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -73,3 +73,20 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+/*
+ * Nav row buttons: Radix Themes' ghost variant uses content-box + negative
+ * margins (padding compensation), so inactive nav items render narrower,
+ * offset and shorter than the active soft item - clicking a nav item made
+ * the whole row visually jump. Normalize the box so every nav row item is
+ * identical regardless of variant (this file loads after themes' styles, and
+ * the two-class selector beats the themes one-class rule).
+ */
+.rt-Button.nav-row {
+  box-sizing: border-box;
+  margin: 0;
+  height: var(--base-button-height);
+  padding-left: 10px;
+  padding-right: 10px;
+  gap: 10px;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -58,6 +58,23 @@
   --ws-success: 33 131 88;      /* green-11 */
   --ws-warning: 171 100 0;      /* amber-11 */
   --ws-danger: 206 44 49;       /* red-11 */
+
+  /* Brand = the user's accent theme (Settings -> Accent color; default
+     gray). Sync'd at runtime to the chosen Radix scale via
+     settings/accent-colors.ts; these :root values are the gray fallback
+     before the app boots. */
+  --ws-brand-1: 252 252 252;    /* gray-1 */
+  --ws-brand-2: 249 249 249;    /* gray-2 */
+  --ws-brand-3: 240 240 240;    /* gray-3 */
+  --ws-brand-4: 232 232 232;    /* gray-4 */
+  --ws-brand-5: 224 224 224;    /* gray-5 */
+  --ws-brand-6: 217 217 217;    /* gray-6 */
+  --ws-brand-7: 206 206 206;    /* gray-7 */
+  --ws-brand-8: 187 187 187;    /* gray-8 */
+  --ws-brand-9: 141 141 141;    /* gray-9 - accent solid */
+  --ws-brand-10: 131 131 131;   /* gray-10 */
+  --ws-brand-11: 100 100 100;   /* gray-11 - text on light */
+  --ws-brand-12: 32 32 32;      /* gray-12 */
 }
 
 /* Always show the scrollbar: prevents a feedback loop where content height

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+// Radix Themes - component + theming layer (colors from Radix Colors).
+// Imported before index.css so the app's token overrides (scrollbar, body)
+// win the cascade.
+import '@radix-ui/themes/styles.css'
+import { Theme } from '@radix-ui/themes'
 // Host composition root (ADR-034): the ONLY file in apps/ that imports
 // driver (impl) modules. Each driver registers its backend into the KWS
 // engine registry on import. Adding a driver regenerates module-wire.ts
@@ -15,6 +20,8 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <Theme appearance="light" accentColor="sky" grayColor="slate">
+      <App />
+    </Theme>
   </StrictMode>,
 )

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,9 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 // Radix Themes - component + theming layer (colors from Radix Colors).
 // Imported before index.css so the app's token overrides (scrollbar, body)
-// win the cascade.
+// win the cascade. The <Theme> wrapper itself lives in App.tsx (ThemedShell)
+// so the accent color can come from the saved settings.
 import '@radix-ui/themes/styles.css'
-import { Theme } from '@radix-ui/themes'
 // Host composition root (ADR-034): the ONLY file in apps/ that imports
 // driver (impl) modules. Each driver registers its backend into the KWS
 // engine registry on import. Adding a driver regenerates module-wire.ts
@@ -20,8 +20,6 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <Theme appearance="light" accentColor="sky" grayColor="slate">
-      <App />
-    </Theme>
+    <App />
   </StrictMode>,
 )

--- a/apps/web/src/settings/ModuleSettings.tsx
+++ b/apps/web/src/settings/ModuleSettings.tsx
@@ -87,14 +87,14 @@ export function ModuleSettingsSection({
             className={cn(
               'rounded-xl border bg-surface-2 p-5 transition-opacity',
               focused
-                ? 'border-brand-400 ring-1 ring-brand-400/30'
+                ? 'border-brand-8 ring-1 ring-brand-8/30'
                 : 'border-line',
             )}
           >
             <h3 className="mb-1 text-sm font-semibold text-ink-1">
               {driver.label}
               {focused && (
-                <span className="ml-2 rounded bg-brand-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-700">
+                <span className="ml-2 rounded bg-brand-9/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-brand-11">
                   active
                 </span>
               )}

--- a/apps/web/src/settings/accent-colors.ts
+++ b/apps/web/src/settings/accent-colors.ts
@@ -1,0 +1,51 @@
+/**
+ * Accent theme scales - Radix Colors (https://www.radix-ui.com/colors).
+ *
+ * The `brand-*` Tailwind scale is backed by `--ws-brand-1..12` CSS vars so
+ * module-kit rendered panels (spec-driven controls, ADR-025) and the shell
+ * follow the user's accent theme from Settings -> General -> Accent color,
+ * not a hard-coded sky. This module syncs those vars to the chosen Radix
+ * scale (values stored as rgb() TRIPLES so Tailwind opacity modifiers like
+ * bg-brand-9/10 keep working).
+ */
+
+import { jade, gray, indigo, orange, mint, sky } from '@radix-ui/colors'
+import type { AccentTheme } from './types'
+
+/** #rrggbb -> "r g b" (Tailwind <alpha-value> triple format). */
+function toTriple(hex: string): string {
+  const n = parseInt(hex.slice(1), 16)
+  return `${(n >> 16) & 255} ${(n >> 8) & 255} ${n & 255}`
+}
+
+function toScale(name: string, colors: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (let i = 1; i <= 12; i++) {
+    out[String(i)] = toTriple(colors[`${name}${i}`])
+  }
+  return out
+}
+
+/** rgb-triple values for each accent scale (steps 1-12). */
+export const ACCENT_SCALE_TRIPLES: Record<AccentTheme, Record<string, string>> = {
+  jade: toScale('jade', jade),
+  gray: toScale('gray', gray),
+  indigo: toScale('indigo', indigo),
+  orange: toScale('orange', orange),
+  mint: toScale('mint', mint),
+  sky: toScale('sky', sky),
+}
+
+/**
+ * Sync the `--ws-brand-N` CSS vars to the given accent scale (no-op outside
+ * the browser). Called on accent change; the tailwind `brand-*` classes read
+ * these vars, so the whole app - including module-kit rendered panels -
+ * follows the selected theme.
+ */
+export function setBrandAccentVars(accent: AccentTheme): void {
+  if (typeof document === 'undefined') return
+  const scale = ACCENT_SCALE_TRIPLES[accent]
+  for (let i = 1; i <= 12; i++) {
+    document.documentElement.style.setProperty(`--ws-brand-${i}`, scale[String(i)])
+  }
+}

--- a/apps/web/src/settings/context.tsx
+++ b/apps/web/src/settings/context.tsx
@@ -22,7 +22,7 @@ import {
   resetSettings,
 } from './storage'
 import type { KwsSourcesSettings } from './storage'
-import type { ModuleSettings, PlatformSettings, PlatformSettingId, ThemeMode } from './types'
+import type { ModuleSettings, PlatformSettings, PlatformSettingId, ThemeMode, AccentTheme } from './types'
 
 interface SettingsContextValue {
   /** Resolved platform settings (theme already applied to the document). */
@@ -51,15 +51,32 @@ export function resolveSystemTheme(): Exclude<ThemeMode, 'system'> {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 }
 
+/** Radix Colors step-9 hex per accent theme (for the PWA meta theme-color). */
+export const ACCENT_META_COLORS: Record<AccentTheme, string> = {
+  jade: '#29a383',
+  gray: '#8d8d8d',
+  indigo: '#3e63dd',
+  orange: '#f76b15',
+  mint: '#86ead4',
+  sky: '#7ce2fe',
+}
+
 /** Apply the theme to the document (data-theme + meta theme-color). */
-export function applyTheme(mode: ThemeMode): void {
+export function applyTheme(mode: ThemeMode, accent?: AccentTheme): void {
   const resolved = mode === 'system' ? resolveSystemTheme() : mode
   if (typeof document === 'undefined') return
   document.documentElement.dataset.theme = resolved
   document.documentElement.style.colorScheme = resolved
-  // Update the PWA theme-color meta (light/dark accent).
+  // Update the PWA theme-color meta (accent-aware).
   const meta = document.querySelector('meta[name="theme-color"]')
-  if (meta) meta.setAttribute('content', resolved === 'dark' ? '#0b1020' : '#0ea5e9')
+  if (meta) {
+    meta.setAttribute(
+      'content',
+      resolved === 'dark'
+        ? '#0b1020'
+        : ACCENT_META_COLORS[accent ?? 'gray'],
+    )
+  }
 }
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
@@ -88,9 +105,10 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
 
   // Apply the theme whenever the setting or OS preference changes.
   const theme: ThemeMode = platform.theme ?? PLATFORM_DEFAULTS.theme
+  const accent: AccentTheme = platform['theme.accent'] ?? PLATFORM_DEFAULTS['theme.accent']
   React.useEffect(() => {
-    applyTheme(theme)
-  }, [theme, osTheme])
+    applyTheme(theme, accent)
+  }, [theme, accent, osTheme])
 
   const resolvedTheme: Exclude<ThemeMode, 'system'> =
     theme === 'system' ? osTheme : theme

--- a/apps/web/src/settings/schema.ts
+++ b/apps/web/src/settings/schema.ts
@@ -11,12 +11,13 @@
 import type { PlatformSettings, PlatformSettingId, SettingDescriptor } from './types'
 
 /** Current schema version. Bump when a field is added/removed. */
-export const SETTINGS_SCHEMA_VERSION = 1
+export const SETTINGS_SCHEMA_VERSION = 2
 
 /** Default platform settings (schemaVersion is explicit so merge works). */
 export const PLATFORM_DEFAULTS: PlatformSettings = {
   schemaVersion: SETTINGS_SCHEMA_VERSION,
   theme: 'light',
+  'theme.accent': 'gray',
   locale: 'en',
   'kws.executionProvider': 'wasm',
   'backend.endpoint': 'http://127.0.0.1:4824',
@@ -41,6 +42,23 @@ export const PLATFORM_SETTING_DESCRIPTORS: ReadonlyArray<SettingDescriptor> = [
       { value: 'light', label: 'Light' },
       { value: 'dark', label: 'Dark' },
       { value: 'system', label: 'System' },
+    ],
+    group: 'general',
+  },
+  {
+    id: 'theme.accent',
+    label: 'Accent color',
+    description:
+      'Accent theme (Radix Colors scales). Gray is the default; Sky is the classic WakeStudio look.',
+    type: 'select',
+    default: 'gray',
+    options: [
+      { value: 'jade', label: 'Jade' },
+      { value: 'gray', label: 'Gray' },
+      { value: 'indigo', label: 'Indigo' },
+      { value: 'orange', label: 'Orange' },
+      { value: 'mint', label: 'Mint' },
+      { value: 'sky', label: 'Sky' },
     ],
     group: 'general',
   },

--- a/apps/web/src/settings/types.ts
+++ b/apps/web/src/settings/types.ts
@@ -23,6 +23,9 @@
 /** Platform theme modes. `system` follows `prefers-color-scheme`. */
 export type ThemeMode = 'light' | 'dark' | 'system'
 
+/** Accent color themes - Radix Colors scales (https://www.radix-ui.com/colors). */
+export type AccentTheme = 'jade' | 'gray' | 'indigo' | 'orange' | 'mint' | 'sky'
+
 /** Locale anchor (store-only for now; i18n lands in Phase 6). */
 export type AppLocale = 'en' | 'zh-CN'
 
@@ -37,6 +40,8 @@ export interface PlatformSettings {
   /** Version gate for mergeWithDefaults on read. */
   schemaVersion: number
   theme: ThemeMode
+  /** Accent color theme (Radix Colors scale). */
+  'theme.accent': AccentTheme
   locale: AppLocale
   'kws.executionProvider': ExecutionProvider
   'backend.endpoint': string

--- a/apps/web/src/training/ImportColabResults.tsx
+++ b/apps/web/src/training/ImportColabResults.tsx
@@ -189,11 +189,11 @@ export function ImportColabResults({ onImported }: ImportColabResultsProps) {
         <button
           onClick={() => inputRef.current?.click()}
           disabled={importing}
-          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-400 disabled:opacity-50"
+          className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-10 disabled:opacity-50"
         >
           {importing ? 'Importing…' : 'Import Colab results…'}
         </button>
-        {importing && <IconSpinner className="h-4 w-4 text-brand-600" />}
+        {importing && <IconSpinner className="h-4 w-4 text-brand-11" />}
       </div>
 
       {error && (

--- a/apps/web/src/training/ImportColabResults.tsx
+++ b/apps/web/src/training/ImportColabResults.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react'
+import { Button } from '@radix-ui/themes'
 import {
   BundleImportError,
   BUNDLE_IMPORT_ERROR_MESSAGES,
@@ -186,13 +187,13 @@ export function ImportColabResults({ onImported }: ImportColabResultsProps) {
             e.target.value = ''
           }}
         />
-        <button
+        <Button
           onClick={() => inputRef.current?.click()}
           disabled={importing}
-          className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-10 disabled:opacity-50"
+          size="2"
         >
           {importing ? 'Importing…' : 'Import Colab results…'}
-        </button>
+        </Button>
         {importing && <IconSpinner className="h-4 w-4 text-brand-11" />}
       </div>
 

--- a/apps/web/src/training/console/ConfirmDialog.tsx
+++ b/apps/web/src/training/console/ConfirmDialog.tsx
@@ -5,6 +5,7 @@
  * leave mid-wizard via another menu, etc.
  */
 
+import { Button } from '@radix-ui/themes'
 import {
   Dialog,
   DialogContent,
@@ -35,20 +36,25 @@ export function ConfirmDialog({
         <DialogTitle className="text-sm">{title}</DialogTitle>
         <DialogDescription className="text-xs leading-relaxed">{message}</DialogDescription>
         <div className="mt-4 flex justify-end gap-2">
-          <button
+          <Button
             type="button"
             onClick={onCancel}
-            className="rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-xs text-ink-2 transition-colors hover:bg-surface-3"
+            variant="outline"
+            size="2"
+            className="text-xs"
           >
             Keep
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onConfirm}
-            className="rounded-lg bg-danger px-3 py-1.5 text-xs font-medium text-surface-2 transition-colors hover:opacity-90"
+            variant="solid"
+            color="red"
+            size="2"
+            className="text-xs"
           >
             {confirmLabel}
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/training/console/FileReviewCard.tsx
+++ b/apps/web/src/training/console/FileReviewCard.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import { Button } from '@radix-ui/themes'
 import {
   personalizeNotebook,
   personalizedParamIds,
@@ -147,26 +148,29 @@ export function FileReviewCard({
 
       <div className="mt-3 flex flex-wrap gap-2">
         {isNotebook && onReview && (
-          <button
+          <Button
             type="button"
             onClick={onReview}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-9 px-3 py-1.5 text-xs font-semibold text-ink-1 transition-colors hover:bg-brand-10"
+            size="2"
+            className="gap-1.5 text-xs font-semibold"
           >
             Review
-          </button>
+          </Button>
         )}
         {rawUrl && (
-          <button
+          <Button
             type="button"
             onClick={() =>
               isNotebook && params && paramMeta
                 ? downloadPersonalized(rawUrl, fileName, params, paramMeta)
                 : downloadRaw(rawUrl, fileName)
             }
-            className="rounded-lg border border-line bg-surface-3 px-3 py-1.5 text-xs font-medium text-ink-1 transition-colors hover:bg-surface-4"
+            variant="surface"
+            size="2"
+            className="text-xs font-medium"
           >
             Download {fileName}
-          </button>
+          </Button>
         )}
         {openUrl && (
           <a

--- a/apps/web/src/training/console/FileReviewCard.tsx
+++ b/apps/web/src/training/console/FileReviewCard.tsx
@@ -150,7 +150,7 @@ export function FileReviewCard({
           <button
             type="button"
             onClick={onReview}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-1.5 text-xs font-semibold text-ink-1 transition-colors hover:bg-brand-400"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-9 px-3 py-1.5 text-xs font-semibold text-ink-1 transition-colors hover:bg-brand-10"
           >
             Review
           </button>

--- a/apps/web/src/training/console/InlineGuide.tsx
+++ b/apps/web/src/training/console/InlineGuide.tsx
@@ -23,7 +23,7 @@ export function InlineGuide({
   const [open, setOpen] = useState(false)
   if (lines.length === 0) return null
   return (
-    <div className={cn('rounded-lg border border-brand-500/20 bg-brand-500/5', className)}>
+    <div className={cn('rounded-lg border border-brand-9/20 bg-brand-9/5', className)}>
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -31,9 +31,9 @@ export function InlineGuide({
         className="flex w-full items-center gap-2 px-3 py-2 text-left"
       >
         <IconChevronRight
-          className={cn('h-3.5 w-3.5 text-brand-700 transition-transform', open && 'rotate-90')}
+          className={cn('h-3.5 w-3.5 text-brand-11 transition-transform', open && 'rotate-90')}
         />
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-brand-700">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-brand-11">
           {title}
         </span>
         {!open && <span className="text-[10px] text-ink-3">click to expand</span>}
@@ -42,7 +42,7 @@ export function InlineGuide({
         <ul className="space-y-1 px-3 pb-2.5 pt-1">
           {lines.map((line, i) => (
             <li key={i} className="flex gap-1.5 text-xs leading-relaxed text-ink-2">
-              <span aria-hidden className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-brand-500/60" />
+              <span aria-hidden className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-brand-9/60" />
               {line}
             </li>
           ))}

--- a/apps/web/src/training/console/MethodStep.tsx
+++ b/apps/web/src/training/console/MethodStep.tsx
@@ -33,8 +33,8 @@ export function MethodStep({ module, selected, onSelect }: MethodStepProps) {
             className={cn(
               'flex w-full items-start justify-between gap-3 rounded-xl border p-4 text-left transition-colors',
               active
-                ? 'border-brand-500/60 bg-brand-500/5'
-                : 'border-line bg-surface-2 hover:border-brand-500/30 hover:bg-surface-3',
+                ? 'border-brand-9/60 bg-brand-9/5'
+                : 'border-line bg-surface-2 hover:border-brand-9/30 hover:bg-surface-3',
             )}
           >
             <div className="min-w-0">
@@ -44,7 +44,7 @@ export function MethodStep({ module, selected, onSelect }: MethodStepProps) {
             <span
               className={cn(
                 'mt-0.5 h-4 w-4 shrink-0 rounded-full border-2',
-                active ? 'border-brand-500 bg-brand-500/20' : 'border-ink-3/50',
+                active ? 'border-brand-9 bg-brand-9/20' : 'border-ink-3/50',
               )}
               aria-hidden
             />

--- a/apps/web/src/training/console/ModelTypeStep.tsx
+++ b/apps/web/src/training/console/ModelTypeStep.tsx
@@ -43,8 +43,8 @@ export function ModelTypeStep({ modules, selectedId, onSelect }: ModelTypeStepPr
             className={cn(
               'w-full rounded-xl border p-4 text-left transition-colors',
               selected
-                ? 'border-brand-500/60 bg-brand-500/5'
-                : 'border-line bg-surface-2 hover:border-brand-500/30 hover:bg-surface-3',
+                ? 'border-brand-9/60 bg-brand-9/5'
+                : 'border-line bg-surface-2 hover:border-brand-9/30 hover:bg-surface-3',
             )}
           >
             <div className="flex items-center justify-between gap-2">

--- a/apps/web/src/training/console/NewTrainWizard.tsx
+++ b/apps/web/src/training/console/NewTrainWizard.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button } from '@radix-ui/themes'
 import {
   STEP_DEFS,
   STEP_ORDER,
@@ -132,13 +133,15 @@ export function NewTrainWizard({
           <h3 className="text-base font-semibold text-ink-1">New train</h3>
           <p className="mt-0.5 text-xs text-ink-3">{def.summary}</p>
         </div>
-        <button
+        <Button
           type="button"
           onClick={requestCancel}
-          className="rounded-lg border border-line bg-surface-2 px-2.5 py-1 text-xs text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+          variant="outline"
+          size="1"
+          className="text-xs"
         >
           Cancel
-        </button>
+        </Button>
       </div>
 
       <nav aria-label="New train steps" className="flex shrink-0 flex-wrap items-center gap-1.5">
@@ -212,32 +215,34 @@ export function NewTrainWizard({
           Save/Start in the same position (issue #105). */}
       <div className="shrink-0 space-y-2 border-t border-line pt-4">
         <div className="flex items-center justify-between">
-          <button
+          <Button
             type="button"
             onClick={() => setStep(STEP_ORDER[STEP_ORDER.indexOf(step) - 1])}
             disabled={!canGoBack(step)}
-            className="rounded-lg border border-line bg-surface-2 px-4 py-1.5 text-sm text-ink-2 transition-colors hover:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-50"
+            variant="outline"
+            size="2"
           >
             Back
-          </button>
+          </Button>
           {next ? (
-            <button
+            <Button
               type="button"
               onClick={() => setStep(advanceStep(step) ?? step)}
               disabled={!canNext}
-              className="rounded-lg bg-brand-9 px-5 py-1.5 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-10 disabled:cursor-not-allowed disabled:opacity-50"
+              size="2"
             >
               Next
-            </button>
+            </Button>
           ) : (
-            <button
+            <Button
               type="button"
               onClick={handleStart}
               disabled={starting}
-              className="rounded-lg bg-brand-9 px-5 py-1.5 text-sm font-semibold text-ink-1 transition-colors hover:bg-brand-10 disabled:cursor-not-allowed disabled:opacity-50"
+              size="2"
+              className="font-semibold"
             >
               {starting ? 'Saving…' : method === 'colab' ? 'Save' : 'Start train'}
-            </button>
+            </Button>
           )}
         </div>
         {step === 'ready' && method === 'colab' && (

--- a/apps/web/src/training/console/NewTrainWizard.tsx
+++ b/apps/web/src/training/console/NewTrainWizard.tsx
@@ -153,7 +153,7 @@ export function NewTrainWizard({
                 className={cn(
                   'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium',
                   active
-                    ? 'border-brand-500/60 bg-brand-500/10 text-brand-400'
+                    ? 'border-brand-9/60 bg-brand-9/10 text-brand-11'
                     : done
                       ? 'border-line bg-surface-2 text-ink-2'
                       : 'border-line bg-surface-1 text-ink-3',
@@ -163,7 +163,7 @@ export function NewTrainWizard({
                   className={cn(
                     'flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold',
                     active
-                      ? 'bg-brand-500 text-ink-1'
+                      ? 'bg-brand-9 text-ink-1'
                       : done
                         ? 'bg-success/20 text-success'
                         : 'bg-surface-3 text-ink-3',
@@ -225,7 +225,7 @@ export function NewTrainWizard({
               type="button"
               onClick={() => setStep(advanceStep(step) ?? step)}
               disabled={!canNext}
-              className="rounded-lg bg-brand-500 px-5 py-1.5 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-400 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-brand-9 px-5 py-1.5 text-sm font-medium text-ink-1 transition-colors hover:bg-brand-10 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Next
             </button>
@@ -234,7 +234,7 @@ export function NewTrainWizard({
               type="button"
               onClick={handleStart}
               disabled={starting}
-              className="rounded-lg bg-brand-500 px-5 py-1.5 text-sm font-semibold text-ink-1 transition-colors hover:bg-brand-400 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-brand-9 px-5 py-1.5 text-sm font-semibold text-ink-1 transition-colors hover:bg-brand-10 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {starting ? 'Saving…' : method === 'colab' ? 'Save' : 'Start train'}
             </button>

--- a/apps/web/src/training/console/NotebookReviewView.tsx
+++ b/apps/web/src/training/console/NotebookReviewView.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@radix-ui/themes'
 import { personalizeNotebook, type EnvParam } from '@wake-studio/module-training'
 import { cn } from '../../components/cn'
 import { IconChevronLeft } from '../../components/icons'
@@ -171,13 +172,15 @@ export function NotebookReviewView({
       {/* Panel header. */}
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-3">
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-xs font-medium text-ink-2 transition-colors hover:bg-surface-3"
+            variant="outline"
+            size="1"
+            className="shrink-0 gap-1 text-xs font-medium"
           >
             <IconChevronLeft className="h-3.5 w-3.5" /> Back
-          </button>
+          </Button>
           <div className="min-w-0">
             <h3 className="truncate text-sm font-semibold text-ink-1">Notebook review — {fileName}</h3>
             {bakedIn.length > 0 && (

--- a/apps/web/src/training/console/StatusChip.tsx
+++ b/apps/web/src/training/console/StatusChip.tsx
@@ -7,7 +7,7 @@ import { cn } from '../../components/cn'
 
 export const STATUS_STYLE: Record<HistoryJob['status'], string> = {
   queued: 'bg-amber-500/15 text-amber-700',
-  running: 'bg-brand-500/15 text-brand-600',
+  running: 'bg-brand-9/15 text-brand-11',
   succeeded: 'bg-emerald-500/15 text-emerald-700',
   failed: 'bg-danger/15 text-danger',
   canceled: 'bg-surface-3 text-ink-3',

--- a/apps/web/src/training/console/TrainDetails.tsx
+++ b/apps/web/src/training/console/TrainDetails.tsx
@@ -179,7 +179,7 @@ export function TrainDetails({ job, modules, onImported, onTunnelUrlChange, onDe
                   m.kind === 'failed' || m.kind === 'canceled'
                     ? 'bg-danger'
                     : m.kind === 'started'
-                      ? 'bg-brand-500'
+                      ? 'bg-brand-9'
                       : 'bg-emerald-500',
                 )}
                 aria-hidden
@@ -241,7 +241,7 @@ export function TrainDetails({ job, modules, onImported, onTunnelUrlChange, onDe
               placeholder="https://xxxx.trycloudflare.com"
               value={job.tunnelUrl ?? ''}
               onChange={(e) => onTunnelUrlChange(e.target.value)}
-              className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 font-mono text-xs text-ink-1 outline-none placeholder:text-ink-3 focus:border-brand-400"
+              className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 font-mono text-xs text-ink-1 outline-none placeholder:text-ink-3 focus:border-brand-8"
             />
             <p className="text-[11px] leading-relaxed text-ink-3">
               The notebook prints this URL while running (cloudflared, ADR-023 amendment). With

--- a/apps/web/src/training/console/TrainDetails.tsx
+++ b/apps/web/src/training/console/TrainDetails.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useMemo, useState } from 'react'
+import { Button } from '@radix-ui/themes'
 import {
   backendToMethod,
   deriveMessages,
@@ -292,13 +293,16 @@ export function TrainDetails({ job, modules, onImported, onTunnelUrlChange, onDe
           <p className="text-xs text-ink-3">
             Remove this train from the list. The imported model stays in your model library.
           </p>
-          <button
+          <Button
             type="button"
             onClick={() => setConfirmDelete(true)}
-            className="rounded-lg border border-danger/40 bg-surface-3 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/10"
+            variant="outline"
+            color="red"
+            size="1"
+            className="text-xs"
           >
             Delete
-          </button>
+          </Button>
         </div>
       </section>
 

--- a/apps/web/src/training/console/TrainList.tsx
+++ b/apps/web/src/training/console/TrainList.tsx
@@ -72,7 +72,7 @@ export function TrainList({ jobs, selectedId, onSelect, onToggle }: TrainListPro
                   className={cn(
                     'w-full rounded-lg border px-3 py-2 text-left transition-colors',
                     selected
-                      ? 'border-brand-500/50 bg-brand-500/5'
+                      ? 'border-brand-9/50 bg-brand-9/5'
                       : 'border-transparent hover:border-line hover:bg-surface-2',
                   )}
                 >

--- a/apps/web/src/training/console/TrainList.tsx
+++ b/apps/web/src/training/console/TrainList.tsx
@@ -11,6 +11,7 @@
  */
 
 import { latestMessage, sortJobsNewestFirst, type HistoryJob } from '@wake-studio/module-training'
+import { IconButton } from '@radix-ui/themes'
 import { cn } from '../../components/cn'
 import { IconMenu } from '../../components/icons'
 import { StatusChip } from './StatusChip'
@@ -37,14 +38,16 @@ export function TrainList({ jobs, selectedId, onSelect, onToggle }: TrainListPro
   return (
     <div className="flex min-h-0 flex-col">
       <div className="flex items-center gap-1.5 px-4 pb-2 pt-3">
-        <button
+        <IconButton
           type="button"
           onClick={onToggle}
           aria-label="Toggle train list"
-          className="rounded-md p-1 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+          variant="ghost"
+          size="1"
+          className="text-ink-3"
         >
           <IconMenu className="h-4 w-4" />
-        </button>
+        </IconButton>
         <h3 className="text-xs font-semibold uppercase tracking-wide text-ink-3">Trains</h3>
         {jobs.length > 0 && (
           <span className="ml-auto rounded-full bg-surface-3 px-1.5 py-0.5 text-[10px] text-ink-3">

--- a/apps/web/src/training/console/TrainingConsole.tsx
+++ b/apps/web/src/training/console/TrainingConsole.tsx
@@ -190,7 +190,7 @@ export function TrainingConsole() {
           <button
             type="button"
             onClick={() => setView({ kind: 'wizard', from: view })}
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-brand-500 px-4 py-2 text-sm font-semibold text-ink-1 transition-colors hover:bg-brand-400"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-brand-9 px-4 py-2 text-sm font-semibold text-ink-1 transition-colors hover:bg-brand-10"
           >
             <IconWand className="h-4 w-4" />
             New

--- a/apps/web/src/training/console/TrainingConsole.tsx
+++ b/apps/web/src/training/console/TrainingConsole.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button, IconButton } from '@radix-ui/themes'
 import {
   backendForMethod,
   importedJob,
@@ -187,14 +188,15 @@ export function TrainingConsole() {
               Training never runs in the browser (ADR-013).
             </p>
           </div>
-          <button
+          <Button
             type="button"
             onClick={() => setView({ kind: 'wizard', from: view })}
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-brand-9 px-4 py-2 text-sm font-semibold text-ink-1 transition-colors hover:bg-brand-10"
+            size="2"
+            className="shrink-0 gap-1.5 font-semibold"
           >
             <IconWand className="h-4 w-4" />
             New
-          </button>
+          </Button>
         </div>
       )}
 
@@ -230,14 +232,16 @@ export function TrainingConsole() {
                 toggle lives in the TRAINS header (issue #105). */}
             {(!isDesktop || railCollapsed) && (
               <div className="mb-2 flex shrink-0 items-center gap-2">
-                <button
+                <IconButton
                   type="button"
                   onClick={handleRailToggle}
                   aria-label={isDesktop ? 'Show train list' : 'Open train list'}
-                  className="rounded-md p-1 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+                  variant="ghost"
+                  size="1"
+                  className="text-ink-3"
                 >
                   <IconMenu className="h-4 w-4" />
-                </button>
+                </IconButton>
                 <span className="text-[11px] text-ink-3">Train list</span>
               </div>
             )}
@@ -294,14 +298,16 @@ export function TrainingConsole() {
             <span className="text-xs font-semibold uppercase tracking-wide text-ink-3">
               Train list
             </span>
-            <button
+            <IconButton
               type="button"
               onClick={() => setDrawerOpen(false)}
               aria-label="Close train list"
-              className="rounded-md p-1.5 text-ink-3 transition-colors hover:bg-surface-3 hover:text-ink-1"
+              variant="ghost"
+              size="1"
+              className="text-ink-3"
             >
               ✕
-            </button>
+            </IconButton>
           </div>
           <div className="flex-1 overflow-y-auto">
             <TrainList

--- a/apps/web/src/views/ExportGateDialog.tsx
+++ b/apps/web/src/views/ExportGateDialog.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
   DialogClose,
 } from '../components/ui'
+import { Button } from '@radix-ui/themes'
 import { useToast } from '../components/toast'
 import { cn } from '../components/cn'
 
@@ -109,23 +110,18 @@ export function ExportGateDialog({ model, open, onOpenChange }: ExportGateDialog
 
         <div className="mt-5 flex justify-end gap-2">
           <DialogClose asChild>
-            <button className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3">
+            <Button variant="outline" size="2">
               Cancel
-            </button>
+            </Button>
           </DialogClose>
-          <button
+          <Button
             onClick={handleExport}
             disabled={!usable}
-            className={cn(
-              'rounded-lg px-3 py-1.5 text-sm font-medium',
-              usable
-                ? 'bg-brand-9 text-ink-1 hover:bg-brand-10'
-                : 'cursor-not-allowed bg-surface-4 text-ink-3',
-            )}
+            size="2"
             title={usable ? undefined : 'Blocked by the license gate'}
           >
             Export
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/views/ExportGateDialog.tsx
+++ b/apps/web/src/views/ExportGateDialog.tsx
@@ -89,17 +89,17 @@ export function ExportGateDialog({ model, open, onOpenChange }: ExportGateDialog
                 className={cn(
                   'flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm',
                   target === t.value
-                    ? 'border-brand-500 bg-brand-500/10 text-ink-1'
+                    ? 'border-brand-9 bg-brand-9/10 text-ink-1'
                     : 'border-line bg-surface-3 text-ink-2 hover:bg-surface-4',
                 )}
               >
                 <span
                   className={cn(
                     'flex h-4 w-4 items-center justify-center rounded-full border',
-                    target === t.value ? 'border-brand-500' : 'border-line-2',
+                    target === t.value ? 'border-brand-9' : 'border-line-2',
                   )}
                 >
-                  {target === t.value && <span className="h-2 w-2 rounded-full bg-brand-500" />}
+                  {target === t.value && <span className="h-2 w-2 rounded-full bg-brand-9" />}
                 </span>
                 {t.label}
               </button>
@@ -119,7 +119,7 @@ export function ExportGateDialog({ model, open, onOpenChange }: ExportGateDialog
             className={cn(
               'rounded-lg px-3 py-1.5 text-sm font-medium',
               usable
-                ? 'bg-brand-500 text-ink-1 hover:bg-brand-400'
+                ? 'bg-brand-9 text-ink-1 hover:bg-brand-10'
                 : 'cursor-not-allowed bg-surface-4 text-ink-3',
             )}
             title={usable ? undefined : 'Blocked by the license gate'}

--- a/apps/web/src/views/ModelLibraryView.tsx
+++ b/apps/web/src/views/ModelLibraryView.tsx
@@ -149,7 +149,7 @@ export function ModelLibraryView() {
   if (!registry) {
     return (
       <div className="flex items-center gap-3 py-16 text-sm text-ink-2">
-        <IconSpinner className="h-4 w-4 text-brand-600" />
+        <IconSpinner className="h-4 w-4 text-brand-11" />
         Loading model registry…
       </div>
     )
@@ -173,7 +173,7 @@ export function ModelLibraryView() {
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search models…"
           aria-label="Search models"
-          className="w-64 rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-sm text-ink-1 placeholder:text-ink-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+          className="w-64 rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-sm text-ink-1 placeholder:text-ink-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8"
         />
         <div className="flex gap-1 rounded-lg border border-line bg-surface-2 p-1">
           {(['all', 'low-power', 'high-performance'] as const).map((t) => (
@@ -182,7 +182,7 @@ export function ModelLibraryView() {
               onClick={() => setTier(t)}
               className={cn(
                 'rounded-md px-2.5 py-1 text-xs font-medium',
-                tier === t ? 'bg-brand-500/10 text-brand-700' : 'text-ink-3 hover:text-ink-1',
+                tier === t ? 'bg-brand-9/10 text-brand-11' : 'text-ink-3 hover:text-ink-1',
               )}
             >
               {t === 'all' ? 'All' : t === 'low-power' ? 'MCU' : 'High-perf'}

--- a/apps/web/src/views/ModelLibraryView.tsx
+++ b/apps/web/src/views/ModelLibraryView.tsx
@@ -15,6 +15,7 @@ import { loadRegistry, isCommerciallyUsable } from '@wake-studio/platform'
 import { probeModelUrl, type ProbeResult } from '@wake-studio/platform'
 import { getBackendRegistry } from '@wake-studio/module-kws-engine'
 import { IconSpinner } from '../components/icons'
+import { Button, TextField } from '@radix-ui/themes'
 import { useToast } from '../components/toast'
 import { cn } from '../components/cn'
 import { ExportGateDialog } from './ExportGateDialog'
@@ -71,13 +72,15 @@ function ProbeButton({ model }: { model: RegistryModel }) {
   }
   if (probe.state === 'error') {
     return (
-      <button
+      <Button
         onClick={run}
-        className="text-[11px] text-danger hover:underline"
+        variant="ghost"
+        size="1"
+        className="h-auto text-[11px] text-danger hover:underline"
         title={probe.error}
       >
         unreachable · retry
-      </button>
+      </Button>
     )
   }
   if (probe.state === 'probing') {
@@ -88,12 +91,14 @@ function ProbeButton({ model }: { model: RegistryModel }) {
     )
   }
   return (
-    <button
+    <Button
       onClick={run}
-      className="text-[11px] text-ink-3 hover:text-ink-1 hover:underline"
+      variant="ghost"
+      size="1"
+      className="h-auto text-[11px] text-ink-3 hover:underline hover:text-ink-1"
     >
       verify reachable
-    </button>
+    </Button>
   )
 }
 
@@ -168,25 +173,24 @@ export function ModelLibraryView() {
 
       {/* Toolbar: search + tier filter */}
       <div className="flex flex-wrap items-center gap-3">
-        <input
+        <TextField.Root
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search models…"
           aria-label="Search models"
-          className="w-64 rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-sm text-ink-1 placeholder:text-ink-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8"
+          className="w-64"
         />
         <div className="flex gap-1 rounded-lg border border-line bg-surface-2 p-1">
           {(['all', 'low-power', 'high-performance'] as const).map((t) => (
-            <button
+            <Button
               key={t}
               onClick={() => setTier(t)}
-              className={cn(
-                'rounded-md px-2.5 py-1 text-xs font-medium',
-                tier === t ? 'bg-brand-9/10 text-brand-11' : 'text-ink-3 hover:text-ink-1',
-              )}
+              variant={tier === t ? 'soft' : 'ghost'}
+              size="1"
+              className="text-xs"
             >
               {t === 'all' ? 'All' : t === 'low-power' ? 'MCU' : 'High-perf'}
-            </button>
+            </Button>
           ))}
         </div>
       </div>
@@ -269,12 +273,14 @@ export function ModelLibraryView() {
 
                 <div className="mt-auto flex items-center justify-between pt-2">
                   <ProbeButton model={m} />
-                  <button
+                  <Button
                     onClick={() => setExportModel(m)}
-                    className="rounded-lg border border-line px-2.5 py-1 text-xs font-medium text-ink-2 hover:bg-surface-3"
+                    variant="outline"
+                    size="1"
+                    className="text-xs"
                   >
                     Export…
-                  </button>
+                  </Button>
                 </div>
               </article>
             ))}

--- a/apps/web/src/views/ModelLibraryView.tsx
+++ b/apps/web/src/views/ModelLibraryView.tsx
@@ -15,7 +15,7 @@ import { loadRegistry, isCommerciallyUsable } from '@wake-studio/platform'
 import { probeModelUrl, type ProbeResult } from '@wake-studio/platform'
 import { getBackendRegistry } from '@wake-studio/module-kws-engine'
 import { IconSpinner } from '../components/icons'
-import { Button, TextField } from '@radix-ui/themes'
+import { Button, SegmentedControl, TextField } from '@radix-ui/themes'
 import { useToast } from '../components/toast'
 import { cn } from '../components/cn'
 import { ExportGateDialog } from './ExportGateDialog'
@@ -180,19 +180,17 @@ export function ModelLibraryView() {
           aria-label="Search models"
           className="w-64"
         />
-        <div className="flex gap-1 rounded-lg border border-line bg-surface-2 p-1">
+        <SegmentedControl.Root
+          size="1"
+          value={tier}
+          onValueChange={(v) => setTier(v as 'all' | ModelTier)}
+        >
           {(['all', 'low-power', 'high-performance'] as const).map((t) => (
-            <Button
-              key={t}
-              onClick={() => setTier(t)}
-              variant={tier === t ? 'soft' : 'ghost'}
-              size="1"
-              className="text-xs"
-            >
+            <SegmentedControl.Item key={t} value={t}>
               {t === 'all' ? 'All' : t === 'low-power' ? 'MCU' : 'High-perf'}
-            </Button>
+            </SegmentedControl.Item>
           ))}
-        </div>
+        </SegmentedControl.Root>
       </div>
 
       {/* Backend availability */}

--- a/apps/web/src/views/SessionConsoleView.tsx
+++ b/apps/web/src/views/SessionConsoleView.tsx
@@ -82,7 +82,7 @@ export function SessionConsoleView() {
           <button
             onClick={handleExportCsv}
             disabled={triggers.length === 0}
-            className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-400 disabled:opacity-40"
+            className="rounded-lg bg-brand-9 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-40"
           >
             Export triggers CSV
           </button>
@@ -97,7 +97,7 @@ export function SessionConsoleView() {
             onClick={() => setView(v)}
             className={cn(
               'rounded-md px-3 py-1 text-sm font-medium',
-              view === v ? 'bg-brand-500/10 text-brand-700' : 'text-ink-3 hover:text-ink-1',
+              view === v ? 'bg-brand-9/10 text-brand-11' : 'text-ink-3 hover:text-ink-1',
             )}
           >
             {v === 'log' ? 'Event log' : `Triggers (${triggers.length})`}

--- a/apps/web/src/views/SessionConsoleView.tsx
+++ b/apps/web/src/views/SessionConsoleView.tsx
@@ -15,7 +15,7 @@ import {
   downloadCsv,
 } from '../log'
 import { useLogEntries } from '../log'
-import { Button } from '@radix-ui/themes'
+import { Button, SegmentedControl, Tabs } from '@radix-ui/themes'
 import { cn } from '../components/cn'
 import { useToast } from '../components/toast'
 
@@ -91,37 +91,29 @@ export function SessionConsoleView() {
         </div>
       </div>
 
-      {/* Log / triggers sub-tabs */}
-      <div className="inline-flex rounded-lg border border-line bg-surface-2 p-1">
-        {(['log', 'triggers'] as const).map((v) => (
-          <Button
-            key={v}
-            onClick={() => setView(v)}
-            variant={view === v ? 'soft' : 'ghost'}
-            size="2"
-          >
-            {v === 'log' ? 'Event log' : `Triggers (${triggers.length})`}
-          </Button>
-        ))}
-      </div>
+      {/* Log / triggers sub-tabs (Radix Themes Tabs, primitives-backed). */}
+      <Tabs.Root
+        value={view}
+        onValueChange={(v) => setView(v as 'log' | 'triggers')}
+      >
+        <Tabs.List size="1" className="w-fit">
+          <Tabs.Trigger value="log">Event log</Tabs.Trigger>
+          <Tabs.Trigger value="triggers">Triggers ({triggers.length})</Tabs.Trigger>
+        </Tabs.List>
 
-      {view === 'log' ? (
-        <>
-          {/* Level filter */}
-          <div className="flex gap-1">
+        <Tabs.Content value="log" className="space-y-2 pt-3">
+          {/* Level filter (Radix Themes SegmentedControl = ToggleGroup primitive). */}
+          <SegmentedControl.Root
+            size="1"
+            value={levelFilter}
+            onValueChange={(v) => setLevelFilter(v as LogLevel | 'all')}
+          >
             {(['all', 'info', 'warn', 'error'] as const).map((l) => (
-              <Button
-                key={l}
-                onClick={() => setLevelFilter(l)}
-                variant={levelFilter === l ? 'soft' : 'ghost'}
-                size="1"
-                radius="full"
-                className="text-xs"
-              >
+              <SegmentedControl.Item key={l} value={l}>
                 {l === 'all' ? 'All' : l}
-              </Button>
+              </SegmentedControl.Item>
             ))}
-          </div>
+          </SegmentedControl.Root>
 
           {/* Log list */}
           <div className="max-h-[60vh] overflow-y-auto rounded-xl border border-line bg-surface-2 font-mono text-xs">
@@ -149,36 +141,38 @@ export function SessionConsoleView() {
               </ul>
             )}
           </div>
-        </>
-      ) : (
-        /* Trigger history table */
-        <div className="overflow-hidden rounded-xl border border-line bg-surface-2">
-          {triggers.length === 0 ? (
-            <div className="p-6 text-center text-sm text-ink-3">
-              No triggers yet — run detection and say the wake word.
-            </div>
-          ) : (
-            <table className="w-full text-left text-sm">
-              <thead className="border-b border-line bg-surface-3 text-xs uppercase tracking-wide text-ink-3">
-                <tr>
-                  <th className="px-3 py-2">Time</th>
-                  <th className="px-3 py-2">Wake word</th>
-                  <th className="px-3 py-2">Peak score</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-line">
-                {triggers.map((e) => (
-                  <tr key={e.id} className="text-ink-2">
-                    <td className="px-3 py-2 font-mono">{new Date(e.at).toLocaleString()}</td>
-                    <td className="px-3 py-2 font-medium text-ink-1">{e.trigger!.word}</td>
-                    <td className="px-3 py-2 font-mono">{e.trigger!.peakScore.toFixed(3)}</td>
+        </Tabs.Content>
+
+        {/* Trigger history table */}
+        <Tabs.Content value="triggers" className="pt-3">
+          <div className="overflow-hidden rounded-xl border border-line bg-surface-2">
+            {triggers.length === 0 ? (
+              <div className="p-6 text-center text-sm text-ink-3">
+                No triggers yet — run detection and say the wake word.
+              </div>
+            ) : (
+              <table className="w-full text-left text-sm">
+                <thead className="border-b border-line bg-surface-3 text-xs uppercase tracking-wide text-ink-3">
+                  <tr>
+                    <th className="px-3 py-2">Time</th>
+                    <th className="px-3 py-2">Wake word</th>
+                    <th className="px-3 py-2">Peak score</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </div>
-      )}
+                </thead>
+                <tbody className="divide-y divide-line">
+                  {triggers.map((e) => (
+                    <tr key={e.id} className="text-ink-2">
+                      <td className="px-3 py-2 font-mono">{new Date(e.at).toLocaleString()}</td>
+                      <td className="px-3 py-2 font-medium text-ink-1">{e.trigger!.word}</td>
+                      <td className="px-3 py-2 font-mono">{e.trigger!.peakScore.toFixed(3)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </Tabs.Content>
+      </Tabs.Root>
     </div>
   )
 }

--- a/apps/web/src/views/SessionConsoleView.tsx
+++ b/apps/web/src/views/SessionConsoleView.tsx
@@ -15,6 +15,7 @@ import {
   downloadCsv,
 } from '../log'
 import { useLogEntries } from '../log'
+import { Button } from '@radix-ui/themes'
 import { cn } from '../components/cn'
 import { useToast } from '../components/toast'
 
@@ -110,18 +111,16 @@ export function SessionConsoleView() {
           {/* Level filter */}
           <div className="flex gap-1">
             {(['all', 'info', 'warn', 'error'] as const).map((l) => (
-              <button
+              <Button
                 key={l}
                 onClick={() => setLevelFilter(l)}
-                className={cn(
-                  'rounded-full px-2.5 py-1 text-xs font-medium',
-                  levelFilter === l
-                    ? 'bg-surface-4 text-ink-1'
-                    : 'text-ink-3 hover:text-ink-1',
-                )}
+                variant={levelFilter === l ? 'soft' : 'ghost'}
+                size="1"
+                radius="full"
+                className="text-xs"
               >
                 {l === 'all' ? 'All' : l}
-              </button>
+              </Button>
             ))}
           </div>
 

--- a/apps/web/src/views/SessionConsoleView.tsx
+++ b/apps/web/src/views/SessionConsoleView.tsx
@@ -74,35 +74,34 @@ export function SessionConsoleView() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <button
+          <Button
             onClick={handleClear}
-            className="rounded-lg border border-line px-3 py-1.5 text-sm text-ink-2 hover:bg-surface-3"
+            variant="outline"
+            size="2"
           >
             Clear
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleExportCsv}
             disabled={triggers.length === 0}
-            className="rounded-lg bg-brand-9 px-3 py-1.5 text-sm font-medium text-ink-1 hover:bg-brand-10 disabled:opacity-40"
+            size="2"
           >
             Export triggers CSV
-          </button>
+          </Button>
         </div>
       </div>
 
       {/* Log / triggers sub-tabs */}
       <div className="inline-flex rounded-lg border border-line bg-surface-2 p-1">
         {(['log', 'triggers'] as const).map((v) => (
-          <button
+          <Button
             key={v}
             onClick={() => setView(v)}
-            className={cn(
-              'rounded-md px-3 py-1 text-sm font-medium',
-              view === v ? 'bg-brand-9/10 text-brand-11' : 'text-ink-3 hover:text-ink-1',
-            )}
+            variant={view === v ? 'soft' : 'ghost'}
+            size="2"
           >
             {v === 'log' ? 'Event log' : `Triggers (${triggers.length})`}
-          </button>
+          </Button>
         ))}
       </div>
 

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -11,6 +11,7 @@
  */
 
 import * as React from 'react'
+import { Button } from '@radix-ui/themes'
 import { renderParamRow } from '@wake-studio/module-kit'
 import { useToast } from '../components/toast'
 import {
@@ -159,13 +160,13 @@ export function SettingsView({
         <span className="text-xs text-ink-3">
           {dirty ? 'Unsaved changes' : 'All changes saved'}
         </span>
-        <button
+        <Button
           onClick={handleSave}
           disabled={!dirty}
-          className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-white hover:bg-brand-10 disabled:opacity-40"
+          size="2"
         >
           Save
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -162,7 +162,7 @@ export function SettingsView({
         <button
           onClick={handleSave}
           disabled={!dirty}
-          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-400 disabled:opacity-40"
+          className="rounded-lg bg-brand-9 px-4 py-2 text-sm font-medium text-white hover:bg-brand-10 disabled:opacity-40"
         >
           Save
         </button>

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -331,7 +331,7 @@ function WorkspaceInner({
           <div className="sticky top-0 z-20 bg-surface pt-3">
             <div className="rounded-xl bg-surface-1/90 px-2 pb-2 shadow-md shadow-black/5 backdrop-blur-md">
             <div className="mb-2 flex flex-wrap items-center gap-2 border-b border-line pb-2">
-              <span className="rounded bg-brand-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-brand-300">
+              <span className="rounded bg-brand-9/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-brand-11">
                 Setup
               </span>
               <span className="text-xs text-ink-3">configure each module, then Start — Stop returns here</span>
@@ -411,7 +411,7 @@ function WorkspaceInner({
                         setKwsPreloadOnStart(e.target.checked)
                         persistWs({ kwsPreloadOnStart: e.target.checked })
                       }}
-                      className="h-3.5 w-3.5 rounded accent-brand-500"
+                      className="h-3.5 w-3.5 rounded accent-brand-9"
                     />
                     <span className="text-ink-2">Preload KWS models on Start</span>
                     <span className="text-xs text-ink-3">

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -206,15 +206,13 @@ function WorkspaceInner({
 
   // Step A source state (re-seeded per project via the keyed wrapper).
   const source = useSourceConfig(wsCfg, persistWs, fallbackChannels)
-  const sourceRef = React.useRef(source)
-  sourceRef.current = source
-
-  // What you see is what runs: commit the working source draft when the
-  // pipeline starts, so the project snapshot matches the source in use.
-  const handleStartWithSource = React.useCallback(() => {
-    source.apply()
-    onStart()
-  }, [source, onStart])
+  const sourceRef = React.useRef<import('../workspace/useSourceConfig').SourceState>(
+    source.appliedSource,
+  )
+  // The pipeline reads the source at Start time - it must use the APPLIED
+  // source, never the working draft (browsing the other tab must not change
+  // what the system uses; only the explicit Apply button commits).
+  sourceRef.current = source.appliedSource
 
   // AFE engine lifecycle (commandRef feeds the unified runner).
   const { afeRef, running, error, commandRef } = useAfePipeline({
@@ -262,7 +260,9 @@ function WorkspaceInner({
 
   const previewVisible = runState.afeRunning || runState.kwsRunning
   const sourcePreview =
-    source.kind === 'file' ? `Files (${source.files.length})` : 'Mic · default'
+    source.appliedSource.kind === 'file'
+      ? `Files (${source.appliedSource.files.length})`
+      : 'Mic · default'
   const afeInfo = `AFE · ${afeCfg?.topology ?? 'single-worklet'} · ${afeCfg?.latencyBudgetMs ?? 150} ms`
 
   const stageCards = [
@@ -344,7 +344,7 @@ function WorkspaceInner({
               </span>
               <span className="text-xs text-ink-3">configure each module, then Start — Stop returns here</span>
               <div className="ml-auto">
-                <RunControl runState={runState} onStart={handleStartWithSource} onStop={onStop} />
+                <RunControl runState={runState} onStart={onStart} onStop={onStop} />
               </div>
             </div>
             <PipelineTabs
@@ -468,7 +468,7 @@ function WorkspaceInner({
               </span>
               <span className="text-xs text-ink-3">running effects — Stop to reconfigure</span>
               <div className="ml-auto">
-                <RunControl runState={runState} onStart={handleStartWithSource} onStop={onStop} />
+                <RunControl runState={runState} onStart={onStart} onStop={onStop} />
               </div>
             </div>
             {/* Live stage cards — identical to the Setup cards: same count,

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -16,6 +16,7 @@
  */
 
 import * as React from 'react'
+import { Checkbox } from '@radix-ui/themes'
 import { KWSPanel } from '../components/KWSPanel'
 import { ProjectBar } from '../components/ProjectBar'
 import { RecentProjectsMenu } from '../components/RecentProjectsMenu'
@@ -404,14 +405,13 @@ function WorkspaceInner({
               <StageSection>
                 <div className="space-y-3">
                   <label className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={kwsPreloadOnStart}
-                      onChange={(e) => {
-                        setKwsPreloadOnStart(e.target.checked)
-                        persistWs({ kwsPreloadOnStart: e.target.checked })
+                      onCheckedChange={(v) => {
+                        setKwsPreloadOnStart(v === true)
+                        persistWs({ kwsPreloadOnStart: v === true })
                       }}
-                      className="h-3.5 w-3.5 rounded accent-brand-9"
+                      size="1"
                     />
                     <span className="text-ink-2">Preload KWS models on Start</span>
                     <span className="text-xs text-ink-3">

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -209,6 +209,13 @@ function WorkspaceInner({
   const sourceRef = React.useRef(source)
   sourceRef.current = source
 
+  // What you see is what runs: commit the working source draft when the
+  // pipeline starts, so the project snapshot matches the source in use.
+  const handleStartWithSource = React.useCallback(() => {
+    source.apply()
+    onStart()
+  }, [source, onStart])
+
   // AFE engine lifecycle (commandRef feeds the unified runner).
   const { afeRef, running, error, commandRef } = useAfePipeline({
     sourceRef,
@@ -337,7 +344,7 @@ function WorkspaceInner({
               </span>
               <span className="text-xs text-ink-3">configure each module, then Start — Stop returns here</span>
               <div className="ml-auto">
-                <RunControl runState={runState} onStart={onStart} onStop={onStop} />
+                <RunControl runState={runState} onStart={handleStartWithSource} onStop={onStop} />
               </div>
             </div>
             <PipelineTabs
@@ -461,7 +468,7 @@ function WorkspaceInner({
               </span>
               <span className="text-xs text-ink-3">running effects — Stop to reconfigure</span>
               <div className="ml-auto">
-                <RunControl runState={runState} onStart={onStart} onStop={onStop} />
+                <RunControl runState={runState} onStart={handleStartWithSource} onStop={onStop} />
               </div>
             </div>
             {/* Live stage cards — identical to the Setup cards: same count,

--- a/apps/web/src/views/WorkspaceView.tsx
+++ b/apps/web/src/views/WorkspaceView.tsx
@@ -261,7 +261,7 @@ function WorkspaceInner({
   const stageCards = [
     {
       id: 'source' as const,
-      label: 'Source & AFE',
+      label: 'Source',
       preview: (
         <>
           <div>{sourcePreview}</div>
@@ -469,7 +469,7 @@ function WorkspaceInner({
             <div className="flex flex-wrap gap-2">
               <StageCard
                 id="source"
-                label="Source & AFE"
+                label="Source"
                 glyph="⌗"
                 color="#64748b"
                 enabled

--- a/apps/web/src/views/placeholders.tsx
+++ b/apps/web/src/views/placeholders.tsx
@@ -17,7 +17,7 @@ export function ComingSoonView({
 }) {
   return (
     <div className="flex min-h-[50vh] flex-col items-center justify-center gap-3 text-center">
-      <div className="rounded-full bg-brand-500/10 px-3 py-1 text-xs font-medium text-brand-700">
+      <div className="rounded-full bg-brand-9/10 px-3 py-1 text-xs font-medium text-brand-11">
         Coming soon
       </div>
       <h2 className="text-lg font-semibold text-ink-1">{title}</h2>

--- a/apps/web/src/workspace/useSourceConfig.ts
+++ b/apps/web/src/workspace/useSourceConfig.ts
@@ -3,7 +3,14 @@
  *
  * Lifted out of the AFE panel so the Step A source editor renders in the
  * workspace's Phase 1 flow while the pipeline start (owned by the AFE panel)
- * reads the same source. Persisted to the workspace snapshot (`source` key).
+ * reads the same source.
+ *
+ * Draft/apply model (UX #113): switching the source tab (mic/file) and editing
+ * the mic/file configs only updates the in-memory WORKING draft - nothing is
+ * persisted. The draft becomes the project's saved source only on `apply()`
+ * (explicit Apply button, or automatically when the pipeline starts, so what
+ * you see is what runs). `dirty` reports whether the working draft differs
+ * from the last persisted source.
  */
 
 import * as React from 'react'
@@ -18,16 +25,37 @@ export interface SourceState {
 }
 
 export interface SourceActions {
+  /** Update the working mic config (draft only - not persisted). */
   updateMic: (next: MicSourceConfig) => void
+  /** Switch the working source kind (draft only - not persisted). */
   updateKind: (kind: 'mic' | 'file') => void
+  /** Update the working file list (draft only - not persisted). */
   updateFiles: (next: FileSourceItem[]) => void
+  /** Persist the working draft as the project's source. */
+  apply: () => void
+}
+
+/** Stable serialization (key-order insensitive) for draft-change detection. */
+function stableKey(v: unknown): string {
+  if (Array.isArray(v)) return '[' + v.map(stableKey).join(',') + ']'
+  if (v && typeof v === 'object') {
+    return (
+      '{' +
+      Object.keys(v)
+        .sort()
+        .map((k) => `${k}:${stableKey((v as Record<string, unknown>)[k])}`)
+        .join(',') +
+      '}'
+    )
+  }
+  return JSON.stringify(v)
 }
 
 export function useSourceConfig(
   wsCfg: WorkspaceConfig | undefined,
   persistWs: (patch: Partial<WorkspaceConfig>) => void,
   fallbackChannelCount: 1 | 2,
-): SourceState & SourceActions {
+): SourceState & SourceActions & { kindChanged: boolean; dirty: boolean } {
   const [mic, setMic] = React.useState<MicSourceConfig>(() => {
     const s = wsCfg?.source
     if (s?.kind === 'mic') {
@@ -56,33 +84,36 @@ export function useSourceConfig(
       : [],
   )
 
-  const updateMic = React.useCallback(
-    (next: MicSourceConfig) => {
-      setMic(next)
-      persistWs({ source: { kind: 'mic', mic: next } })
-    },
-    [persistWs],
+  // The last applied source: what the project snapshot holds (seeded from the
+  // snapshot; updated on apply). `dirty` tracks the source KIND switch and the
+  // FILE LIST - mic config knobs (device auto-pick, browser DSP toggles) are
+  // ephemeral and don't flag the draft.
+  const [appliedKind, setAppliedKind] = React.useState<'mic' | 'file'>(kind)
+  const [appliedFilesKey, setAppliedFilesKey] = React.useState<string>(() =>
+    stableKey(files),
   )
 
-  const updateKind = React.useCallback(
-    (next: 'mic' | 'file') => {
-      setKind(next)
-      if (next === 'mic') {
-        persistWs({ source: { kind: 'mic', mic } })
-      } else {
-        persistWs({ source: { kind: 'file', files } })
-      }
-    },
-    [persistWs, mic, files],
-  )
+  const updateMic = React.useCallback((next: MicSourceConfig) => {
+    setMic(next)
+  }, [])
 
-  const updateFiles = React.useCallback(
-    (next: FileSourceItem[]) => {
-      setFiles(next)
-      persistWs({ source: { kind: 'file', files: next } })
-    },
-    [persistWs],
-  )
+  const updateKind = React.useCallback((next: 'mic' | 'file') => {
+    setKind(next)
+  }, [])
 
-  return { kind, mic, files, updateMic, updateKind, updateFiles }
+  const updateFiles = React.useCallback((next: FileSourceItem[]) => {
+    setFiles(next)
+  }, [])
+
+  const apply = React.useCallback(() => {
+    const next = { kind, mic, files }
+    persistWs({ source: next })
+    setAppliedKind(kind)
+    setAppliedFilesKey(stableKey(files))
+  }, [persistWs, kind, mic, files])
+
+  const kindChanged = kind !== appliedKind
+  const dirty = kindChanged || stableKey(files) !== appliedFilesKey
+
+  return { kind, mic, files, updateMic, updateKind, updateFiles, apply, kindChanged, dirty }
 }

--- a/apps/web/src/workspace/useSourceConfig.ts
+++ b/apps/web/src/workspace/useSourceConfig.ts
@@ -55,7 +55,8 @@ export function useSourceConfig(
   wsCfg: WorkspaceConfig | undefined,
   persistWs: (patch: Partial<WorkspaceConfig>) => void,
   fallbackChannelCount: 1 | 2,
-): SourceState & SourceActions & { kindChanged: boolean; dirty: boolean } {
+): SourceState &
+  SourceActions & { kindChanged: boolean; dirty: boolean; appliedSource: SourceState } {
   const [mic, setMic] = React.useState<MicSourceConfig>(() => {
     const s = wsCfg?.source
     if (s?.kind === 'mic') {
@@ -84,14 +85,17 @@ export function useSourceConfig(
       : [],
   )
 
-  // The last applied source: what the project snapshot holds (seeded from the
-  // snapshot; updated on apply). `dirty` tracks the source KIND switch and the
-  // FILE LIST - mic config knobs (device auto-pick, browser DSP toggles) are
-  // ephemeral and don't flag the draft.
-  const [appliedKind, setAppliedKind] = React.useState<'mic' | 'file'>(kind)
-  const [appliedFilesKey, setAppliedFilesKey] = React.useState<string>(() =>
-    stableKey(files),
-  )
+  // The last APPLIED source: what the project snapshot holds and what the
+
+  // pipeline uses on Start (seeded from the snapshot; updated on apply). The
+  // working `kind`/`mic`/`files` draft never affects Start - only Apply does.
+  // `dirty` tracks the source KIND switch and the FILE LIST; mic config knobs
+  // (device auto-pick, browser DSP toggles) are ephemeral and don't flag it.
+  const [appliedSource, setAppliedSource] = React.useState<SourceState>(() => ({
+    kind,
+    mic,
+    files,
+  }))
 
   const updateMic = React.useCallback((next: MicSourceConfig) => {
     setMic(next)
@@ -106,14 +110,25 @@ export function useSourceConfig(
   }, [])
 
   const apply = React.useCallback(() => {
-    const next = { kind, mic, files }
+    const next: SourceState = { kind, mic, files }
     persistWs({ source: next })
-    setAppliedKind(kind)
-    setAppliedFilesKey(stableKey(files))
+    setAppliedSource(next)
   }, [persistWs, kind, mic, files])
 
-  const kindChanged = kind !== appliedKind
-  const dirty = kindChanged || stableKey(files) !== appliedFilesKey
+  const kindChanged = kind !== appliedSource.kind
+  const dirty = kindChanged || stableKey(files) !== stableKey(appliedSource.files)
 
-  return { kind, mic, files, updateMic, updateKind, updateFiles, apply, kindChanged, dirty }
+  return {
+    kind,
+    mic,
+    files,
+    updateMic,
+    updateKind,
+    updateFiles,
+    apply,
+    kindChanged,
+    dirty,
+    /** The committed source - what the pipeline actually uses on Start. */
+    appliedSource,
+  }
 }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -15,22 +15,25 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Radix sky scale (1-12) - https://www.radix-ui.com/colors
+        // Radix Colors accent scale (1-12) - https://www.radix-ui.com/colors
         // Roles: 1-5 tints, 6-8 borders/rings, 9-10 accent solid/hover,
-        // 11-12 text on light. Stored as rgb() triples for opacity modifiers.
+        // 11-12 text on light. Backed by --ws-brand-N CSS vars which the app
+        // syncs to the user's accent theme (Settings -> Accent color), so
+        // module-kit rendered panels follow the theme too. rgb() triples for
+        // opacity modifiers.
         brand: {
-          1: 'rgb(249 254 255 / <alpha-value>)',
-          2: 'rgb(241 250 253 / <alpha-value>)',
-          3: 'rgb(225 246 253 / <alpha-value>)',
-          4: 'rgb(209 240 250 / <alpha-value>)',
-          5: 'rgb(190 231 245 / <alpha-value>)',
-          6: 'rgb(169 218 237 / <alpha-value>)',
-          7: 'rgb(141 202 227 / <alpha-value>)',
-          8: 'rgb(96 179 215 / <alpha-value>)',
-          9: 'rgb(124 226 254 / <alpha-value>)',
-          10: 'rgb(116 218 248 / <alpha-value>)',
-          11: 'rgb(0 116 158 / <alpha-value>)',
-          12: 'rgb(29 62 86 / <alpha-value>)',
+          1: 'rgb(var(--ws-brand-1) / <alpha-value>)',
+          2: 'rgb(var(--ws-brand-2) / <alpha-value>)',
+          3: 'rgb(var(--ws-brand-3) / <alpha-value>)',
+          4: 'rgb(var(--ws-brand-4) / <alpha-value>)',
+          5: 'rgb(var(--ws-brand-5) / <alpha-value>)',
+          6: 'rgb(var(--ws-brand-6) / <alpha-value>)',
+          7: 'rgb(var(--ws-brand-7) / <alpha-value>)',
+          8: 'rgb(var(--ws-brand-8) / <alpha-value>)',
+          9: 'rgb(var(--ws-brand-9) / <alpha-value>)',
+          10: 'rgb(var(--ws-brand-10) / <alpha-value>)',
+          11: 'rgb(var(--ws-brand-11) / <alpha-value>)',
+          12: 'rgb(var(--ws-brand-12) / <alpha-value>)',
         },
         // Semantic tokens (light theme) - see index.css for values.
         // Stored as rgb() triples so Tailwind can compose opacity modifiers.

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -15,19 +15,27 @@ export default {
   theme: {
     extend: {
       colors: {
+        // Radix sky scale (1-12) - https://www.radix-ui.com/colors
+        // Roles: 1-5 tints, 6-8 borders/rings, 9-10 accent solid/hover,
+        // 11-12 text on light. Stored as rgb() triples for opacity modifiers.
         brand: {
-          50: '#f0f9ff',
-          100: '#e0f2fe',
-          200: '#bae6fd',
-          300: '#7dd3fc',
-          400: '#38bdf8',
-          500: '#0ea5e9',
-          600: '#0284c7',
-          700: '#0369a1',
+          1: 'rgb(249 254 255 / <alpha-value>)',
+          2: 'rgb(241 250 253 / <alpha-value>)',
+          3: 'rgb(225 246 253 / <alpha-value>)',
+          4: 'rgb(209 240 250 / <alpha-value>)',
+          5: 'rgb(190 231 245 / <alpha-value>)',
+          6: 'rgb(169 218 237 / <alpha-value>)',
+          7: 'rgb(141 202 227 / <alpha-value>)',
+          8: 'rgb(96 179 215 / <alpha-value>)',
+          9: 'rgb(124 226 254 / <alpha-value>)',
+          10: 'rgb(116 218 248 / <alpha-value>)',
+          11: 'rgb(0 116 158 / <alpha-value>)',
+          12: 'rgb(29 62 86 / <alpha-value>)',
         },
         // Semantic tokens (light theme) - see index.css for values.
         // Stored as rgb() triples so Tailwind can compose opacity modifiers.
         surface: 'rgb(var(--ws-surface) / <alpha-value>)',
+        'surface-1': 'rgb(var(--ws-surface-1) / <alpha-value>)',
         'surface-2': 'rgb(var(--ws-surface-2) / <alpha-value>)',
         'surface-3': 'rgb(var(--ws-surface-3) / <alpha-value>)',
         'surface-4': 'rgb(var(--ws-surface-4) / <alpha-value>)',

--- a/packages/module-kit/src/ui/canvas.tsx
+++ b/packages/module-kit/src/ui/canvas.tsx
@@ -58,7 +58,7 @@ export function UiBar({ value, label, height = 6, threshold = 0.5, className }: 
       >
         <div
           className={`h-full rounded-full transition-all duration-100 ${
-            over ? 'bg-emerald-500' : 'bg-brand-500'
+            over ? 'bg-emerald-500' : 'bg-brand-9'
           }`}
           style={{ width: `${pct}%` }}
         />

--- a/packages/module-kit/src/ui/controls.tsx
+++ b/packages/module-kit/src/ui/controls.tsx
@@ -91,7 +91,7 @@ export function UiNumber({ value, min, max, step = 1, unit, onChange, disabled }
           if (Number.isFinite(n)) onChange(n)
         }}
         disabled={disabled}
-        className="h-8 w-24 rounded-lg border border-line bg-surface-3 px-2.5 text-right font-mono text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+        className="h-8 w-24 rounded-lg border border-line bg-surface-3 px-2.5 text-right font-mono text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8 disabled:opacity-40"
       />
       {unit && <span className="text-xs text-ink-3">{unit}</span>}
     </div>
@@ -135,7 +135,7 @@ export function UiSelect({ value, options, onChange, disabled, placeholder = 'Se
             {options.map((opt) => (
               <SelectPrimitive.Item key={opt.value} value={opt.value} className={SELECT_CLS.item}>
                 <SelectPrimitive.ItemText>{opt.label}</SelectPrimitive.ItemText>
-                <SelectPrimitive.ItemIndicator className="ml-2 inline-flex text-brand-400">
+                <SelectPrimitive.ItemIndicator className="ml-2 inline-flex text-brand-11">
                   <Check className="h-3.5 w-3.5" />
                 </SelectPrimitive.ItemIndicator>
               </SelectPrimitive.Item>
@@ -219,7 +219,7 @@ export function UiProgress({ value, indeterminate }: UiProgressProps) {
     >
       <ProgressPrimitive.Indicator
         className={cn(
-          'h-full w-full bg-brand-500 transition-transform',
+          'h-full w-full bg-brand-9 transition-transform',
           indeterminate && 'animate-pulse',
         )}
         style={{ transform: `translateX(-${100 - (indeterminate ? 40 : value)}%)` }}

--- a/packages/module-kit/src/ui/mapper.tsx
+++ b/packages/module-kit/src/ui/mapper.tsx
@@ -102,7 +102,7 @@ export function renderParamControl({ param, value, onChange, disabled }: ParamCo
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
           placeholder="••••••••"
-          className="h-8 w-48 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+          className="h-8 w-48 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8 disabled:opacity-40"
         />
       )
     case 'string':
@@ -113,7 +113,7 @@ export function renderParamControl({ param, value, onChange, disabled }: ParamCo
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
           placeholder={typeof param.default === 'string' ? String(param.default) : ''}
-          className="h-8 w-48 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40"
+          className="h-8 w-48 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8 disabled:opacity-40"
         />
       )
     default:

--- a/packages/module-kit/src/ui/styles.ts
+++ b/packages/module-kit/src/ui/styles.ts
@@ -18,10 +18,10 @@ export const LABEL_CLS = 'flex items-center justify-between gap-3 text-sm'
 
 /** Base for buttons (primary / secondary / danger). */
 export const BTN_BASE =
-  'inline-flex items-center justify-center gap-1.5 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 disabled:opacity-40 disabled:pointer-events-none'
+  'inline-flex items-center justify-center gap-1.5 rounded-lg px-3.5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8 disabled:opacity-40 disabled:pointer-events-none'
 
 export const BTN_VARIANTS = {
-  primary: 'bg-brand-600 text-white hover:bg-brand-500',
+  primary: 'bg-brand-11 text-white hover:bg-brand-9',
   secondary:
     'border border-line bg-surface-2 text-ink-2 hover:bg-surface-4/60',
   danger: 'bg-danger/90 text-white hover:bg-danger',
@@ -33,17 +33,17 @@ export const SLIDER_CLS = {
   root: 'relative flex h-5 w-full min-w-44 touch-none select-none items-center',
   track:
     'relative h-1.5 w-full grow overflow-hidden rounded-full bg-surface-4',
-  range: 'absolute h-full rounded-full bg-brand-500',
+  range: 'absolute h-full rounded-full bg-brand-9',
   // Radix positions the thumb via inline left + translateX; it MUST be
   // absolutely positioned within the (relative) root or the knob visually
   // detaches from the value. top-1/2 -translate-y-1/2 centers it vertically.
   thumb:
-    'absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-white shadow ring-1 ring-line-2 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+    'absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-white shadow ring-1 ring-line-2 transition-colors hover:bg-brand-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8',
 }
 
 /** Radix switch (toggle) styling. */
 export const SWITCH_CLS = {
-  root: 'relative h-5 w-9 shrink-0 rounded-full bg-surface-4 transition-colors data-[state=checked]:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+  root: 'relative h-5 w-9 shrink-0 rounded-full bg-surface-4 transition-colors data-[state=checked]:bg-brand-9 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8',
   thumb:
     'block h-4 w-4 translate-x-0.5 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-[18px]',
 }
@@ -51,10 +51,10 @@ export const SWITCH_CLS = {
 /** Radix select trigger styling. */
 export const SELECT_CLS = {
   trigger:
-    'inline-flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-2 hover:bg-surface-4/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400',
+    'inline-flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-lg border border-line bg-surface-3 px-2.5 text-sm text-ink-2 hover:bg-surface-4/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-8',
   content:
     'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-line bg-surface-2 p-1 shadow-xl',
-  item: 'cursor-default select-none rounded-md px-2.5 py-1.5 text-sm text-ink-2 outline-none data-[highlighted]:bg-brand-50 data-[highlighted]:text-ink-1',
+  item: 'cursor-default select-none rounded-md px-2.5 py-1.5 text-sm text-ink-2 outline-none data-[highlighted]:bg-brand-2 data-[highlighted]:text-ink-1',
 }
 
 /** Radix collapsible (Primary/Advanced dual layer, ADR-024). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@radix-ui/colors':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.23
         version: 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.16
         version: 1.2.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/themes':
+        specifier: ^3.3.0
+        version: 3.3.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wake-studio/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -1842,14 +1845,95 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
+  '@radix-ui/colors@3.0.0':
+    resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
+
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
 
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
 
+  '@radix-ui/react-accessible-icon@1.1.15':
+    resolution: {integrity: sha512-WTQwcAvQf5sOcuUyi90lKPbhwcvQ+j55cjrSmeaN+L2vKU3DooOvlKw2MDeiJ5IkV5N905KW0/fGojKOBhD11A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.20':
+    resolution: {integrity: sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.23':
+    resolution: {integrity: sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.15':
     resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.15':
+    resolution: {integrity: sha512-fy+dyVR+90nelK8rqIznFlxzx7uPcGbhxH8Nfr2bHb4UfSe+e3hklOC0luK0hDwVwnRX7xTRySpsrQVeW+/oNQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.2.6':
+    resolution: {integrity: sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.11':
+    resolution: {integrity: sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1894,6 +1978,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.7':
+    resolution: {integrity: sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.2.2':
@@ -1975,6 +2072,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.16':
+    resolution: {integrity: sha512-Q4TLEn2A7TAypxwmd6R9EwrlXDvkfYSDMrq9/887AXAGh+G1rH+kYJKSTv+Si9Y0JPKTwKYv6PviAJosysNimA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.23':
+    resolution: {integrity: sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-icons@1.3.2':
     resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
     peerDependencies:
@@ -1989,8 +2112,86 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.15':
+    resolution: {integrity: sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.24':
     resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.24':
+    resolution: {integrity: sha512-eeVs0vf7cuqXaM0qLQCPcufImiJNVBXdJDLu7ZGYl2732UH23Qat/foNGrr6vYV3/DdTsBqASoggUFgH14OcZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.22':
+    resolution: {integrity: sha512-ou7iLEJ+yrhQndkkA4U21XIdS/CS45F4iXIkTZcb6/Ne9EMsOuDudVmCwmDnfFZZ+y1FZqXRNSIgBy+YMvZVZg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.16':
+    resolution: {integrity: sha512-Tj9P6ntAJEw52oq/F0AGknXR4XncxEt7XU47O3xJQOiWfLzEy3d9gtgKfvjSzGxzHkfL+VzvxGu2KTFsloJqXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.11':
+    resolution: {integrity: sha512-4gvFnmDXu3dgj21CqsufzIameRvlRd4SBqaWhcrlrNhRo0Y5i/49AmRJYe1fdAM3G2VNBbmin4b0D6cdQocwgw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.23':
+    resolution: {integrity: sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2067,6 +2268,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-radio-group@1.4.7':
+    resolution: {integrity: sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.19':
     resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
     peerDependencies:
@@ -2080,8 +2294,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-scroll-area@1.2.18':
+    resolution: {integrity: sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.3.7':
     resolution: {integrity: sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.15':
+    resolution: {integrity: sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2128,8 +2368,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.21':
+    resolution: {integrity: sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-toast@1.2.23':
     resolution: {integrity: sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.19':
+    resolution: {integrity: sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.18':
+    resolution: {integrity: sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.19':
+    resolution: {integrity: sha512-Ph0IvtYw4VB12ZnZg+YtrGs8yJQsnizwo/zu0R4Y/nWugtJzA7Pg1eWeuDR9+LSqn+xjamss+UOSOJJJ4gx8jw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2174,6 +2466,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.5':
     resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.5':
+    resolution: {integrity: sha512-ge3ipobwSXTj4JyVtswQ7qZj0ZHdtbGuOno/LrgAAeSxtsJ6Vs4Gz5IkPH2bmqpjcLUFoqGhA/mueuIf63UXlA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2241,6 +2542,19 @@ packages:
 
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
+
+  '@radix-ui/themes@3.3.0':
+    resolution: {integrity: sha512-I0/h2CRNTpYNB7Mi3xFIvSsQq5a108d7kK8dTO5zp5b9HR5QJXKag6B8tjpz2ITkVYkFdkGk45doNkSr7OxwNw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: 16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2746,6 +3060,9 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3775,6 +4092,19 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  radix-ui@1.6.7:
+    resolution: {integrity: sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -5458,13 +5788,92 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
+  '@radix-ui/colors@3.0.0': {}
+
   '@radix-ui/number@1.1.3': {}
 
   '@radix-ui/primitive@1.1.7': {}
 
+  '@radix-ui/react-accessible-icon@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-accordion@1.2.20(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@radix-ui/react-arrow@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-aspect-ratio@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-avatar@1.2.6(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-checkbox@1.3.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -5504,6 +5913,19 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.31
+
+  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@radix-ui/react-context@1.2.2(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
@@ -5585,6 +6007,37 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
+  '@radix-ui/react-form@0.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-label': 2.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-hover-card@1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@radix-ui/react-icons@1.3.2(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -5595,6 +6048,15 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.31
+
+  '@radix-ui/react-label@2.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@radix-ui/react-menu@2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5614,6 +6076,105 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-menubar@1.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-navigation-menu@1.2.22(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-one-time-password-field@0.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-password-toggle-field@0.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-popover@1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -5678,6 +6239,23 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
+  '@radix-ui/react-radio-group@1.4.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -5690,6 +6268,23 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-scroll-area@1.2.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -5723,6 +6318,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-separator@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
@@ -5767,6 +6371,22 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
+  '@radix-ui/react-tabs@1.1.21(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@radix-ui/react-toast@1.2.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -5781,6 +6401,47 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-toggle-group@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-toggle@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@radix-ui/react-toolbar@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -5830,6 +6491,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
 
+  '@radix-ui/react-use-escape-keydown@1.1.5(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.31
+
   '@radix-ui/react-use-is-hydrated@0.1.3(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -5872,6 +6540,18 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@radix-ui/rect@1.1.3': {}
+
+  '@radix-ui/themes@3.3.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/colors': 3.0.0
+      classnames: 2.5.1
+      radix-ui: 1.6.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.31)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -6391,6 +7071,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  classnames@2.5.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -7588,6 +8270,69 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radix-ui@1.6.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-accessible-icon': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-alert-dialog': 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-aspect-ratio': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-avatar': 1.2.6(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox': 1.3.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-form': 0.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label': 2.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menubar': 1.1.24(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-one-time-password-field': 0.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-password-toggle-field': 0.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group': 1.4.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select': 2.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider': 1.4.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-switch': 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast': 1.2.23(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toolbar': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.2.16(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.5(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@18.3.31)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Adopt the **Radix UI stack** across the web app: `@radix-ui/themes` as the component + theming layer, Radix Colors for the palette, Radix primitives for interactive controls, and a safer source-selection UX. Builds on the icon migration (PR #112).

### Themes + Colors
- `@radix-ui/themes` installed; app wrapped in `<Theme accentColor grayColor="slate">`
- Semantic tokens (`--ws-*`) revalued to Radix Colors scales (slate neutrals, green/amber/red status); `brand-*` becomes the 12-step Radix scale, synced to the user's **accent theme** so module-kit generated panels follow it too
- **Six accent themes** (Jade / Gray / Indigo / Orange / Mint / Sky, gray default) selectable in Settings → General → Accent color, applied on Save, persisted

### Component migration
- All hand-rolled UI → Radix Themes components: `Button`/`IconButton`/`Card`/`TextField`/`Checkbox`/`Slider`/`Switch`, Themes `Dialog`, `Tabs`, and `SegmentedControl` (built on the ToggleGroup primitive)
- Nav row geometry normalized (ghost-variant content-box bug); segmented controls no longer clip icons (svg preflight fix); device select widened
- Dropdown/Tooltip/Toast stay on Radix primitives (behavior-critical, already token-styled); module-kit (ADR-025) and data-viz untouched

### Source selection UX (draft + Apply)
- Clicking the Microphone | Audio files tab only edits a working draft — nothing persists and nothing changes what the pipeline uses
- An explicit **"Use … as source"** button commits; the pipeline always starts with the applied source (browsing the other tab can never cause the "Add at least one audio file" error)

### Verification
- `pnpm typecheck` / `pnpm build` / lint clean; 177 unit tests; **20 UI e2e specs** plus targeted probes (accent apply-on-save + reload, draft/apply persistence, source-on-Start semantics)

Closes #113
