### PR TITLE
feat(dry-run): demo module + instant fake training for local web-flow checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ apps/studio-backend/data/
 apps/studio-backend/.pytest_cache/
 **/__pycache__/
 apps/studio-backend/*.egg-info/
+
+# standard artifact bundle output (docs/modules/training.md §6)
+**/wake-studio-results/

--- a/apps/studio-backend/registry.example.json
+++ b/apps/studio-backend/registry.example.json
@@ -13,5 +13,15 @@
       "WAKE_BACKEND": "self-hosted",
       "UPSTREAM_PYTHON": "{env.UPSTREAM_PYTHON}"
     }
+  },
+  "dry-run": {
+    "cwd": "../../packages/modules/dry-run/train",
+    "engine": "direct",
+    "entry": "dry_run.py",
+    "env": {
+      "WAKE_PHRASE": "{params.wakePhrase}",
+      "WAKE_STEPS": "{params.steps}",
+      "WAKE_BACKEND": "self-hosted"
+    }
   }
 }

--- a/apps/studio-backend/registry.json
+++ b/apps/studio-backend/registry.json
@@ -13,5 +13,15 @@
       "WAKE_BACKEND": "self-hosted",
       "UPSTREAM_PYTHON": "{env.UPSTREAM_PYTHON}"
     }
+  },
+  "dry-run": {
+    "cwd": "../../packages/modules/dry-run/train",
+    "engine": "direct",
+    "entry": "dry_run.py",
+    "env": {
+      "WAKE_PHRASE": "{params.wakePhrase}",
+      "WAKE_STEPS": "{params.steps}",
+      "WAKE_BACKEND": "self-hosted"
+    }
   }
 }

--- a/apps/web/public/train-modules.json
+++ b/apps/web/public/train-modules.json
@@ -24,6 +24,43 @@
       }
     },
     {
+      "id": "dry-run",
+      "category": "dry-run",
+      "name": "Dry-run (demo)",
+      "license": "MIT",
+      "maturity": "demo",
+      "train": {
+        "entry": "train/dry_run.py",
+        "deps": "pyproject.toml",
+        "invocation": [
+          "studio-backend"
+        ],
+        "params": [
+          {
+            "id": "wakePhrase",
+            "label": "Wake phrase",
+            "group": "primary",
+            "type": "string",
+            "default": "hey studio",
+            "description": "The (fake) wake phrase to train (env WAKE_PHRASE).",
+            "env": "WAKE_PHRASE"
+          },
+          {
+            "id": "steps",
+            "label": "Steps (fake)",
+            "group": "advanced",
+            "type": "number",
+            "default": 5,
+            "min": 1,
+            "max": 50,
+            "step": 1,
+            "description": "How many fake progress steps to emit (env WAKE_STEPS); keep small — it is a demo.",
+            "env": "WAKE_STEPS"
+          }
+        ]
+      }
+    },
+    {
       "id": "kws-openwakeword",
       "category": "kws",
       "name": "OpenWakeWord KWS driver",

--- a/apps/web/public/train/dry-run/dry_run.py
+++ b/apps/web/public/train/dry-run/dry_run.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Dry-run trainer (demo module) — instant fake training for local
+web-function checks (no GPU, no upstream repo, no data download).
+
+Runs in ~1s and produces a **standard bundle zip** (docs/modules/training.md
+§6), so the full PWA training flow — wizard submit → live status (progress /
+metrics / log tail) → artifact download — can be exercised against a local
+studio-backend (`uv run wake-service` with the default registry).
+
+Emits the NDJSON reporting protocol (§4.4) on stdout: log, progress (per
+step), metrics, heartbeat, artifact (the bundle zip), done.
+
+Params (env, the registry maps job params to these):
+    WAKE_PHRASE  WAKE_STEPS  WAKE_JOB_ID  WAKE_BACKEND  WORK_DIR  OUT_DIR
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+try:  # the service's reporter (installed with wake-service)
+    from wake_train_kit.report import Reporter
+except ImportError:  # standalone fallback
+    class Reporter:  # type: ignore[no-redef]
+        def emit(self, event: str, **fields: Any) -> None:
+            print(json.dumps({"event": event, **fields}), flush=True)
+
+
+def build_bundle(phrase: str, steps: int, job_id: str, backend: str,
+                 out_dir: Path, reporter: Reporter) -> Path:
+    """Standard bundle (§6): model + metrics/metadata/provenance/config + zip."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "model.onnx").write_bytes(
+        b"dry-run-model:" + phrase.encode("utf-8") + b"\x00"
+    )
+
+    metrics = {
+        "status": "ok",
+        "note": "fake metrics from the dry-run demo trainer",
+        "recall": 0.97,
+        "accuracy": 0.98,
+        "false_positives_per_hour": 0.2,
+        "steps": steps,
+    }
+    (out_dir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    metadata = {
+        "jobId": job_id,
+        "moduleId": "dry-run",
+        "backend": backend,
+        "provider": backend,
+        "params": {"wakePhrase": phrase, "epochs": str(steps)},
+        "trainedAtMs": int(time.time() * 1000),
+    }
+    (out_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    provenance = {
+        "license": "user-owned",
+        "sourceData": [{"name": "dry-run demo data", "license": "MIT", "source": "wake-studio"}],
+        "notes": "Fake model produced by the dry-run demo trainer — for testing the web flow only.",
+    }
+    (out_dir / "provenance.json").write_text(json.dumps(provenance, indent=2), encoding="utf-8")
+
+    config = {"wakePhrase": phrase, "backend": backend, "steps": steps,
+              "model_type": "dnn", "layer_size": 32}
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+    zip_path = out_dir / "wake-studio-results.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name in ("model.onnx", "metrics.json", "metadata.json",
+                     "provenance.json", "config.json"):
+            p = out_dir / name
+            if p.is_file():
+                zf.write(p, arcname=f"{job_id}/{name}")
+    reporter.emit("log", level="info", message=f"bundle ready: {zip_path}")
+    return zip_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    reporter = Reporter()
+    phrase = os.environ.get("WAKE_PHRASE", "") or "hey studio"
+    raw_steps = os.environ.get("WAKE_STEPS", "")
+    steps = int(raw_steps) if raw_steps else 5
+    job_id = os.environ.get("WAKE_JOB_ID", "") or f"dry-run-{int(time.time() * 1000)}"
+    backend = os.environ.get("WAKE_BACKEND", "") or "self-hosted"
+    work = Path(os.environ.get("WORK_DIR", ".")).resolve()
+    out = Path(os.environ.get("OUT_DIR", work / "wake-studio-results")) / job_id
+
+    reporter.emit("log", level="info",
+                  message=f"dry-run: phrase={phrase!r} steps={steps} backend={backend}")
+    for i in range(1, steps + 1):
+        time.sleep(0.05)
+        reporter.emit("progress", step=i, total=steps, progress=i / steps,
+                      message=f"fake step {i}")
+        reporter.emit("metrics", loss=round(1.0 / i, 4) if i else 0.0, step=i)
+        if i % 2 == 0:
+            reporter.emit("heartbeat")
+
+    try:
+        zip_path = build_bundle(phrase, steps, job_id, backend, out, reporter)
+    except Exception as exc:  # noqa: BLE001
+        reporter.emit("error", message=f"bundle error: {exc}")
+        return 1
+
+    reporter.emit("artifact", path=str(zip_path))
+    reporter.emit("done", exitCode=0)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/modules/dry-run/spec/module.spec.json
+++ b/packages/modules/dry-run/spec/module.spec.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../../../contracts/src/module-spec.schema.json",
+  "meta": {
+    "id": "dry-run",
+    "name": "Dry-run (demo)",
+    "category": "training",
+    "version": "0.1.0",
+    "maturity": "demo",
+    "owner": "WakeStudio team",
+    "license": "MIT",
+    "status": "accepted",
+    "description": "Instant fake training for local web-function checks (no GPU, no data). Produces a standard bundle zip so the full PWA training flow can be exercised against a local studio-backend."
+  },
+  "params": [],
+  "actions": [],
+  "status": {},
+  "runtime": {
+    "web": {
+      "engine": "none"
+    }
+  },
+  "tests": {
+    "required": []
+  },
+  "playground": {
+    "route": "/dry-run",
+    "entry": "none"
+  },
+  "interfaces": {
+    "provides": [],
+    "consumes": []
+  },
+  "train": {
+    "entry": "train/dry_run.py",
+    "deps": "pyproject.toml",
+    "invocation": ["studio-backend"],
+    "params": [
+      {
+        "id": "wakePhrase",
+        "label": "Wake phrase",
+        "group": "primary",
+        "type": "string",
+        "default": "hey studio",
+        "description": "The (fake) wake phrase to train (env WAKE_PHRASE).",
+        "env": "WAKE_PHRASE"
+      },
+      {
+        "id": "steps",
+        "label": "Steps (fake)",
+        "group": "advanced",
+        "type": "number",
+        "default": 5,
+        "min": 1,
+        "max": 50,
+        "step": 1,
+        "description": "How many fake progress steps to emit (env WAKE_STEPS); keep small — it is a demo.",
+        "env": "WAKE_STEPS"
+      }
+    ]
+  }
+}

--- a/packages/modules/dry-run/train/dry_run.py
+++ b/packages/modules/dry-run/train/dry_run.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Dry-run trainer (demo module) — instant fake training for local
+web-function checks (no GPU, no upstream repo, no data download).
+
+Runs in ~1s and produces a **standard bundle zip** (docs/modules/training.md
+§6), so the full PWA training flow — wizard submit → live status (progress /
+metrics / log tail) → artifact download — can be exercised against a local
+studio-backend (`uv run wake-service` with the default registry).
+
+Emits the NDJSON reporting protocol (§4.4) on stdout: log, progress (per
+step), metrics, heartbeat, artifact (the bundle zip), done.
+
+Params (env, the registry maps job params to these):
+    WAKE_PHRASE  WAKE_STEPS  WAKE_JOB_ID  WAKE_BACKEND  WORK_DIR  OUT_DIR
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+try:  # the service's reporter (installed with wake-service)
+    from wake_train_kit.report import Reporter
+except ImportError:  # standalone fallback
+    class Reporter:  # type: ignore[no-redef]
+        def emit(self, event: str, **fields: Any) -> None:
+            print(json.dumps({"event": event, **fields}), flush=True)
+
+
+def build_bundle(phrase: str, steps: int, job_id: str, backend: str,
+                 out_dir: Path, reporter: Reporter) -> Path:
+    """Standard bundle (§6): model + metrics/metadata/provenance/config + zip."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "model.onnx").write_bytes(
+        b"dry-run-model:" + phrase.encode("utf-8") + b"\x00"
+    )
+
+    metrics = {
+        "status": "ok",
+        "note": "fake metrics from the dry-run demo trainer",
+        "recall": 0.97,
+        "accuracy": 0.98,
+        "false_positives_per_hour": 0.2,
+        "steps": steps,
+    }
+    (out_dir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    metadata = {
+        "jobId": job_id,
+        "moduleId": "dry-run",
+        "backend": backend,
+        "provider": backend,
+        "params": {"wakePhrase": phrase, "epochs": str(steps)},
+        "trainedAtMs": int(time.time() * 1000),
+    }
+    (out_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    provenance = {
+        "license": "user-owned",
+        "sourceData": [{"name": "dry-run demo data", "license": "MIT", "source": "wake-studio"}],
+        "notes": "Fake model produced by the dry-run demo trainer — for testing the web flow only.",
+    }
+    (out_dir / "provenance.json").write_text(json.dumps(provenance, indent=2), encoding="utf-8")
+
+    config = {"wakePhrase": phrase, "backend": backend, "steps": steps,
+              "model_type": "dnn", "layer_size": 32}
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+    zip_path = out_dir / "wake-studio-results.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name in ("model.onnx", "metrics.json", "metadata.json",
+                     "provenance.json", "config.json"):
+            p = out_dir / name
+            if p.is_file():
+                zf.write(p, arcname=f"{job_id}/{name}")
+    reporter.emit("log", level="info", message=f"bundle ready: {zip_path}")
+    return zip_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    reporter = Reporter()
+    phrase = os.environ.get("WAKE_PHRASE", "") or "hey studio"
+    raw_steps = os.environ.get("WAKE_STEPS", "")
+    steps = int(raw_steps) if raw_steps else 5
+    job_id = os.environ.get("WAKE_JOB_ID", "") or f"dry-run-{int(time.time() * 1000)}"
+    backend = os.environ.get("WAKE_BACKEND", "") or "self-hosted"
+    work = Path(os.environ.get("WORK_DIR", ".")).resolve()
+    out = Path(os.environ.get("OUT_DIR", work / "wake-studio-results")) / job_id
+
+    reporter.emit("log", level="info",
+                  message=f"dry-run: phrase={phrase!r} steps={steps} backend={backend}")
+    for i in range(1, steps + 1):
+        time.sleep(0.05)
+        reporter.emit("progress", step=i, total=steps, progress=i / steps,
+                      message=f"fake step {i}")
+        reporter.emit("metrics", loss=round(1.0 / i, 4) if i else 0.0, step=i)
+        if i % 2 == 0:
+            reporter.emit("heartbeat")
+
+    try:
+        zip_path = build_bundle(phrase, steps, job_id, backend, out, reporter)
+    except Exception as exc:  # noqa: BLE001
+        reporter.emit("error", message=f"bundle error: {exc}")
+        return 1
+
+    reporter.emit("artifact", path=str(zip_path))
+    reporter.emit("done", exitCode=0)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/modules/dry-run/train/pyproject.toml
+++ b/packages/modules/dry-run/train/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "dry-run-train"
+version = "0.1.0"
+description = "Dry-run demo module train script (stdlib-only fake trainer; produces a standard bundle zip for local web-flow checks)."
+requires-python = ">=3.11"
+license = { text = "MIT" }
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/modules/dry-run/train/tests/test_dry_run.py
+++ b/packages/modules/dry-run/train/tests/test_dry_run.py
@@ -1,0 +1,72 @@
+"""Dry-run demo trainer tests — the script must emit the NDJSON protocol and
+produce a standard bundle zip (docs/modules/training.md §6) without any
+external deps, GPU or network."""
+
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "dry_run.py"
+
+
+def run(tmp_path: Path, **env_extra: str):
+    work = tmp_path / "work"
+    work.mkdir()
+    out = tmp_path / "out"
+    env = {
+        **os.environ,
+        "WORK_DIR": str(work),
+        "OUT_DIR": str(out),
+        "WAKE_PHRASE": "hey studio",
+        "WAKE_STEPS": "3",
+        "WAKE_BACKEND": "self-hosted",
+        **env_extra,
+    }
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT)], cwd=str(work), env=env,
+        capture_output=True, text=True, timeout=60,
+    )
+    events = [
+        json.loads(line)
+        for line in res.stdout.splitlines()
+        if line.startswith("{")
+    ]
+    return res, events
+
+
+def test_dry_run_end_to_end(tmp_path):
+    res, events = run(tmp_path)
+    assert res.returncode == 0, res.stderr
+
+    kinds = [e["event"] for e in events]
+    assert kinds[0] == "log"
+    assert "progress" in kinds
+    assert kinds[-2:] == ["artifact", "done"]
+
+    artifact = next(e for e in events if e["event"] == "artifact")
+    zip_path = Path(artifact["path"])
+    assert zip_path.is_file()
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    assert any(n.endswith("model.onnx") for n in names)
+    assert any(n.endswith("wake-studio-results.zip") is False for n in names)  # sanity
+
+    with zipfile.ZipFile(zip_path) as zf:
+        meta = json.loads(zf.read(next(n for n in names if n.endswith("metadata.json"))))
+    assert meta["moduleId"] == "dry-run"
+    assert meta["backend"] == "self-hosted"
+    assert meta["params"]["wakePhrase"] == "hey studio"
+
+
+def test_dry_run_defaults_and_progress(tmp_path):
+    res, events = run(tmp_path, WAKE_STEPS="", WAKE_PHRASE="")
+    assert res.returncode == 0
+    progress = [e for e in events if e["event"] == "progress"]
+    assert len(progress) == 5  # default steps
+    assert progress[-1]["progress"] == 1.0
+    metrics = [e for e in events if e["event"] == "metrics"]
+    assert len(metrics) == 5

--- a/packages/modules/dry-run/train/uv.lock
+++ b/packages/modules/dry-run/train/uv.lock
@@ -1,0 +1,78 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dry-run-train"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" }]
+provides-extras = ["dev"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]


### PR DESCRIPTION
## What

A **dry-run demo module** — instant fake training (no GPU, no upstream repo,
no data) so the full PWA training flow can be exercised against a local
studio-backend: wizard → choose "Dry-run (demo)" → Studio-backend method →
submit → live status (progress/metrics/log tail) → artifact download.

## How to use it

```bash
# 1. start the local service (default registry now includes dry-run)
uv run --project apps/studio-backend wake-service

# 2. in the app: Settings → Backend endpoint = http://127.0.0.1:4824
#    (match the token if you pass --token)

# 3. Training → New → "Dry-run (demo)" → configure → Studio-backend → Start
#    → finishes in ~1s with a downloadable bundle zip
```

## Changes

- `packages/modules/dry-run/` — minimal valid module spec (train.entry +
  `studio-backend` invocation, wakePhrase/steps params) + stdlib-only
  `dry_run.py` emitting the NDJSON protocol (log/progress/metrics/heartbeat/
  artifact/done) and building the standard bundle (model + metrics/metadata/
  provenance/config + zip, job-id-prefixed entries)
- `apps/studio-backend/registry.json` + example: `dry-run` entry
- `train-modules.json` regenerated; `dry_run.py` served from the app origin
- gitignore: `**/wake-studio-results/` (bundle output dir — caught the
  live test writing into the repo)

## Verification

- 2 tests (e2e + defaults); live e2e through the service: submit →
  `succeeded` (progress 1.0) → artifact zip 200
- Suites: service 25 · module-kit 18 · web 191 + typecheck + build ·
  registry sync check OK
