### PR TITLE
docs: WIP tips (Radix-first UI) + WIP status in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,26 @@ pnpm dev
 | `pnpm fetch:all` | Sync every CI-built artifact. |
 | `pnpm pwa-assets` | Regenerate raster PWA icons from `public/icon.svg`. |
 
+## WIP tips (working conventions)
+
+Conventions collected during development. Keep this list short and actionable —
+add a tip only when it saved real time or prevented a mistake.
+
+- **App UI: Radix first.** Build every piece of app UI on `@radix-ui/*` before
+  reaching for hand-rolled CSS or a new dependency:
+  - **Basic components** — `@radix-ui/themes` (Button, Card, Dialog, Select,
+    Tabs, …); add primitive packages (`@radix-ui/react-dialog`,
+    `react-dropdown-menu`, `react-toast`, `react-tooltip`) when a Themes
+    component doesn't cover the interaction.
+  - **Colors** — `@radix-ui/colors` scales (see `apps/web/src/settings/accent-colors.ts`);
+    no hand-picked hex values.
+  - **Icons** — `@radix-ui/react-icons` (see `apps/web/src/components/icons.tsx`);
+    no emoji or ad-hoc SVGs.
+  - **Themes** — `@radix-ui/themes` `<Theme>` wrapper (`ThemedShell` in
+    `apps/web/src/App.tsx`) owns appearance + accent; don't fork your own
+    theming.
+  - Fall back to custom CSS only when Radix genuinely can't express the design.
+
 ## Testing layers (ADR-026)
 
 - **L1 unit (vitest, fast):** pure logic - DSP (in `@wake-studio/dsp`, ADR-032),

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ pnpm fetch:all
 
 > The first `pnpm install` requires authorization per `AGENTS.md`.
 
+## UI conventions
+
+- **Radix-first.** The app UI builds on `@radix-ui/*` before hand-rolling CSS or
+  adding new dependencies:
+  - **Basic components + theming** — `@radix-ui/themes` (`<Theme>` wrapper owns appearance + accent)
+  - **Colors** — `@radix-ui/colors` scales (no hand-picked hex values)
+  - **Icons** — `@radix-ui/react-icons` (no emoji or ad-hoc SVGs)
+  - Hand-rolled CSS only when Radix can't express the design.
+- Full working-conventions list (WIP tips): [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
 ## Key docs
 
 - [`AGENTS.md`](./AGENTS.md) - ground rules for humans and coding agents.

--- a/README.md
+++ b/README.md
@@ -103,15 +103,23 @@ pnpm fetch:all
 
 > The first `pnpm install` requires authorization per `AGENTS.md`.
 
-## UI conventions
+## WIP tips (working conventions)
 
-- **Radix-first.** The app UI builds on `@radix-ui/*` before hand-rolling CSS or
-  adding new dependencies:
-  - **Basic components + theming** — `@radix-ui/themes` (`<Theme>` wrapper owns appearance + accent)
-  - **Colors** — `@radix-ui/colors` scales (no hand-picked hex values)
-  - **Icons** — `@radix-ui/react-icons` (no emoji or ad-hoc SVGs)
-  - Hand-rolled CSS only when Radix can't express the design.
-- Full working-conventions list (WIP tips): [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+Conventions collected during development. Keep them in mind when working on
+WIP code; the full list lives in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+- **App UI: Radix first.** Build every piece of app UI on `@radix-ui/*` before
+  hand-rolling CSS or adding a new dependency:
+  - **Basic components** — `@radix-ui/themes` (Button, Card, Dialog, Select,
+    Tabs, …); Radix primitives (`react-dialog`, `react-dropdown-menu`,
+    `react-toast`, `react-tooltip`) when Themes doesn't cover the interaction.
+  - **Colors** — `@radix-ui/colors` scales (see
+    `apps/web/src/settings/accent-colors.ts`); no hand-picked hex values.
+  - **Icons** — `@radix-ui/react-icons` (see `apps/web/src/components/icons.tsx`);
+    no emoji or ad-hoc SVGs.
+  - **Themes** — `@radix-ui/themes` `<Theme>` wrapper (App.tsx `ThemedShell`)
+    owns appearance + accent; don't fork your own theming.
+  - Fall back to custom CSS only when Radix genuinely can't express the design.
 
 ## Key docs
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # WakeStudio
 
+> ⚠️ **Work in progress.** WakeStudio is under active development — APIs, module
+> contracts, and UI are evolving and **may change without notice**. Not yet
+> production-ready. See [`docs/roadmap.md`](./docs/roadmap.md) for where things
+> stand.
+
 > Go from "I have a wake-word idea" to "a deployable, testable KWS bundle for my
 > target chip" - **without installing any toolchain, runtime, or Python.**
 
@@ -17,11 +22,11 @@ models.**
 
 ## Status
 
-Phases 0–3 shipped (AFE, KWS, Few-Shot, console/studio productization), and
-the module platform migration (ADR-025) is complete: all functional areas
-(AFE stages, KWS engine + drivers, Few-Shot, Training) are self-contained
-modules with specs + generated panels. Phase 4 (device SDK + export kits) is
-next. See [`docs/roadmap.md`](./docs/roadmap.md) for the full phased roadmap and
+**This project is work in progress (WIP).** While phases 0–3 shipped (AFE,
+KWS, Few-Shot, console/studio productization) and the module platform
+migration (ADR-025) is complete, v1 is not released: everything below can
+change. Phase 4 (device SDK + export kits) is next. See
+[`docs/roadmap.md`](./docs/roadmap.md) for the full phased roadmap and
 [`DECISIONS.md`](./DECISIONS.md) for recorded decisions.
 
 | Phase | Goal | Status |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,8 +257,15 @@ reference C/C++ pipelines for target chips.
 | Audio capture/processing | Web Audio API + AudioWorklet | W3C standard |
 | TTS for synthetic training data | **Piper** (`OHF-Voice/piper1-gpl` GPL-3.0 active / `rhasspy/piper` MIT archived) | GPL-3.0 / MIT (verify voices) |
 | Visualization | Canvas 2D / WebGL (custom, or `regl`-based) | MIT |
-| UI (ADR-004) | React 18 + Vite 5 + TypeScript 5 + Tailwind 3 | MIT |
+| UI (ADR-004) | React 18 + Vite 5 + TypeScript 5 + Tailwind 3; **Radix-first** — `@radix-ui/themes` (components + theming), `@radix-ui/colors` (scales), `@radix-ui/react-icons` | MIT |
 
+> **UI convention (WIP tip):** app UI is **Radix-first** — basic components
+> and theming come from `@radix-ui/themes`, color scales from
+> `@radix-ui/colors`, icons from `@radix-ui/react-icons` (plus Radix primitive
+> packages when a Themes component doesn't cover the interaction). Hand-rolled
+> CSS only when Radix can't express the design. See the WIP tips section in
+> `CONTRIBUTING.md`.
+>
 > **Training-data sources (ADR-022):** audio generation and datasets are a
 > pluggable, in-app-configurable data-source layer (local services / project APIs /
 > public TTS endpoints); generation **never runs in WASM** - it runs in the selected


### PR DESCRIPTION
### Summary

Documents the Radix-first app UI convention as WIP tips and marks the project
status as work-in-progress in the README, so users and developers know what to
expect.

### Changes

- **CONTRIBUTING.md** — new "WIP tips (working conventions)" section: build app
  UI on `@radix-ui/*` first (`@radix-ui/themes` components + theming,
  `@radix-ui/colors` scales, `@radix-ui/react-icons`), with file pointers and
  the fallback rule (custom CSS only when Radix can't express the design).
- **docs/architecture.md** — §4.3 UI stack row updated to "Radix-first" +
  callout linking to the WIP tips section.
- **README.md** — WIP tips section inlined; ⚠️ **Work in progress** banner at
  the top and an explicit WIP lead in the Status section (v1 not released,
  everything can change).

### Notes

- Doc-only change, no code touched.
- The WIP tips list is structured so more tips can be added later.

Closes #134
