### PR TITLE
fix(training): browser back walks wizard steps and review/backend sub-panels (#136)

### DIFF
--- a/apps/web/e2e/training-wizard-back.spec.ts
+++ b/apps/web/e2e/training-wizard-back.spec.ts
@@ -74,3 +74,69 @@ test('browser forward re-enters the step it was on', async ({ page }) => {
   await page.goForward()
   await expect(page.getByText('Set the training params for the chosen module.')).toBeVisible()
 })
+
+test('wizard notebook review: browser back returns to the Ready step', async ({ page }) => {
+  await page.goto('/#/training')
+
+  await page.getByRole('button', { name: 'New' }).click()
+  await page.getByRole('button', { name: /OpenWakeWord/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: /Google Colab/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await expect(page.getByText('Review the train, then start it.')).toBeVisible()
+
+  // Open the notebook review — it is its own history entry.
+  await page.getByRole('button', { name: 'Review', exact: true }).click()
+  await expect(page.getByText('Notebook review — train.ipynb')).toBeVisible()
+  await expect(page).toHaveURL(/#\/training\/new\/ready\/review$/)
+
+  // Browser back closes the review and returns to the Ready step.
+  await page.goBack()
+  await expect(page.getByText('Notebook review — train.ipynb')).toBeHidden()
+  await expect(page.getByText('Review the train, then start it.')).toBeVisible()
+})
+
+test('train details notebook review: browser back returns to the details pane', async ({ page }) => {
+  await page.goto('/#/training')
+
+  // Create a train (Colab) so the details pane has a notebook to review.
+  await page.getByRole('button', { name: 'New' }).click()
+  await page.getByRole('button', { name: /OpenWakeWord/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: /Google Colab/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+
+  // The details pane's Inputs review opens the full notebook review.
+  await page.getByRole('button', { name: 'Review', exact: true }).click()
+  await expect(page.getByText('Notebook review — train.ipynb')).toBeVisible()
+
+  // Browser back returns to the train details.
+  await page.goBack()
+  await expect(page.getByText('Notebook review — train.ipynb')).toBeHidden()
+  await expect(page.getByText('Inputs review')).toBeVisible()
+})
+
+test('Backends: New editor and Colab guide/preview are back-closeable', async ({ page }) => {
+  await page.goto('/#/backends')
+
+  // New → full-panel editor; browser back returns to the list.
+  await page.getByRole('button', { name: 'New', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'New backend' })).toBeVisible()
+  await page.goBack()
+  await expect(page.getByRole('heading', { name: 'New backend' })).toBeHidden()
+  await expect(page.getByRole('heading', { name: 'Backends', level: 2 })).toBeVisible()
+
+  // Free On Google Colab → guide; Review → preview; back walks both.
+  await page.getByRole('button', { name: /Free On Google Colab/ }).click()
+  await expect(page.getByRole('heading', { name: 'Free on Google Colab' })).toBeVisible()
+  await page.getByRole('button', { name: 'Review', exact: true }).click()
+  await expect(page.getByText('Notebook review — studio-backend.ipynb')).toBeVisible()
+  await page.goBack()
+  await expect(page.getByText('Notebook review — studio-backend.ipynb')).toBeHidden()
+  await expect(page.getByRole('heading', { name: 'Free on Google Colab' })).toBeVisible()
+  await page.goBack()
+  await expect(page.getByRole('heading', { name: 'Backends', level: 2 })).toBeVisible()
+})

--- a/apps/web/e2e/training-wizard-back.spec.ts
+++ b/apps/web/e2e/training-wizard-back.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * New-train wizard browser-history navigation (issue #136).
+ *
+ * Wizard steps are hash-encoded (`#/training/new[/<step>]`), so each step is
+ * its own history entry: browser back/forward walk the steps instead of
+ * leaving the Training view. Leaving the wizard with unsaved progress still
+ * asks first.
+ */
+
+test('browser back walks the New-train wizard steps, then leaves cleanly', async ({ page }) => {
+  await page.goto('/#/training')
+
+  await page.getByRole('button', { name: 'New' }).click()
+
+  // Step 1 — choose a model type.
+  await expect(page.getByText('Pick the module you want to train.')).toBeVisible()
+  await page.getByRole('button', { name: /OpenWakeWord/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+
+  // Step 2 — configure.
+  await expect(page.getByText('Set the training params for the chosen module.')).toBeVisible()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+
+  // Step 3 — choose a train method.
+  await expect(
+    page.getByText('Pick where training runs, from the methods the module supports.'),
+  ).toBeVisible()
+  await page.getByRole('button', { name: /Google Colab/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+
+  // Step 4 — ready to start.
+  await expect(page.getByText('Review the train, then start it.')).toBeVisible()
+
+  // Browser back walks the steps in reverse (the bug: it used to jump
+  // straight out of the Training view).
+  await page.goBack()
+  await expect(
+    page.getByText('Pick where training runs, from the methods the module supports.'),
+  ).toBeVisible()
+  await page.goBack()
+  await expect(page.getByText('Set the training params for the chosen module.')).toBeVisible()
+  await page.goBack()
+  await expect(page.getByText('Pick the module you want to train.')).toBeVisible()
+
+  // Selections survive the walk (same wizard instance, only the step moved).
+  await expect(page.getByRole('button', { name: /OpenWakeWord/ })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  )
+
+  // One more back leaves the wizard — unsaved progress asks first.
+  await page.goBack()
+  await expect(page.getByText('Leave without saving this train?')).toBeVisible()
+  await page.getByRole('button', { name: 'Leave anyway' }).click()
+
+  // Back on the Trains list.
+  await expect(page.getByRole('button', { name: 'New' })).toBeVisible()
+  await expect(page).toHaveURL(/#\/training$/)
+})
+
+test('browser forward re-enters the step it was on', async ({ page }) => {
+  await page.goto('/#/training')
+
+  await page.getByRole('button', { name: 'New' }).click()
+  await page.getByRole('button', { name: /OpenWakeWord/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await expect(page.getByText('Set the training params for the chosen module.')).toBeVisible()
+
+  // Back one step, then forward again: the wizard follows both directions.
+  await page.goBack()
+  await expect(page.getByText('Pick the module you want to train.')).toBeVisible()
+  await page.goForward()
+  await expect(page.getByText('Set the training params for the chosen module.')).toBeVisible()
+})

--- a/apps/web/src/__tests__/router.test.ts
+++ b/apps/web/src/__tests__/router.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Router hash helpers — New-train wizard step encoding (issue #136).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { TRAIN_NEW_HASH_PREFIX, trainNewStepFromHash } from '../router'
+
+describe('trainNewStepFromHash', () => {
+  it('returns the wizard step for `#/training/new/<step>`', () => {
+    expect(trainNewStepFromHash('#/training/new/config')).toBe('config')
+    expect(trainNewStepFromHash('#/training/new/method')).toBe('method')
+    expect(trainNewStepFromHash('#/training/new/ready')).toBe('ready')
+  })
+
+  it('returns undefined for the wizard-open hash (its first step)', () => {
+    expect(trainNewStepFromHash('#/training/new')).toBeUndefined()
+    expect(trainNewStepFromHash('#/training/new/')).toBeUndefined()
+  })
+
+  it('returns undefined for non-wizard hashes', () => {
+    expect(trainNewStepFromHash('#/training')).toBeUndefined()
+    expect(trainNewStepFromHash('#/workspace')).toBeUndefined()
+    expect(trainNewStepFromHash('#/settings/modules/plixkws')).toBeUndefined()
+    expect(trainNewStepFromHash('')).toBeUndefined()
+  })
+
+  it('tolerates hashes without the leading #', () => {
+    expect(trainNewStepFromHash('/training/new/ready')).toBe('ready')
+  })
+
+  it('exposes the wizard hash prefix for building entries', () => {
+    expect(TRAIN_NEW_HASH_PREFIX).toBe('/training/new')
+    expect(`#${TRAIN_NEW_HASH_PREFIX}/config`).toBe('#/training/new/config')
+  })
+})

--- a/apps/web/src/__tests__/router.test.ts
+++ b/apps/web/src/__tests__/router.test.ts
@@ -3,7 +3,15 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { TRAIN_NEW_HASH_PREFIX, trainNewStepFromHash } from '../router'
+import {
+  BACKENDS_HASH_PREFIX,
+  TRAIN_NEW_HASH_PREFIX,
+  TRAIN_REVIEW_HASH_PREFIX,
+  backendsSubFromHash,
+  trainNewReviewFromHash,
+  trainNewStepFromHash,
+  trainReviewJobFromHash,
+} from '../router'
 
 describe('trainNewStepFromHash', () => {
   it('returns the wizard step for `#/training/new/<step>`', () => {
@@ -31,5 +39,48 @@ describe('trainNewStepFromHash', () => {
   it('exposes the wizard hash prefix for building entries', () => {
     expect(TRAIN_NEW_HASH_PREFIX).toBe('/training/new')
     expect(`#${TRAIN_NEW_HASH_PREFIX}/config`).toBe('#/training/new/config')
+  })
+})
+
+describe('trainNewReviewFromHash', () => {
+  it('detects the wizard review sub-panel', () => {
+    expect(trainNewReviewFromHash('#/training/new/ready/review')).toBe(true)
+    expect(trainNewReviewFromHash('#/training/new/review')).toBe(true)
+  })
+
+  it('is false for plain step and non-wizard hashes', () => {
+    expect(trainNewReviewFromHash('#/training/new/ready')).toBe(false)
+    expect(trainNewReviewFromHash('#/training/new')).toBe(false)
+    expect(trainNewReviewFromHash('#/training/review/train-1')).toBe(false)
+    expect(trainNewReviewFromHash('#/workspace')).toBe(false)
+  })
+})
+
+describe('trainReviewJobFromHash', () => {
+  it('extracts the job id from `#/training/review/<jobId>`', () => {
+    expect(trainReviewJobFromHash('#/training/review/train-123')).toBe('train-123')
+    expect(trainReviewJobFromHash('#/training/review/train-123/extra')).toBe('train-123')
+  })
+
+  it('returns undefined for non-review hashes', () => {
+    expect(trainReviewJobFromHash('#/training')).toBeUndefined()
+    expect(trainReviewJobFromHash('#/training/new/ready/review')).toBeUndefined()
+    expect(trainReviewJobFromHash('#/backends')).toBeUndefined()
+    expect(TRAIN_REVIEW_HASH_PREFIX).toBe('/training/review')
+  })
+})
+
+describe('backendsSubFromHash', () => {
+  it('extracts the Backends full-panel sub-route', () => {
+    expect(backendsSubFromHash('#/backends/new')).toBe('new')
+    expect(backendsSubFromHash('#/backends/colab')).toBe('colab')
+    expect(backendsSubFromHash('#/backends/colab/preview')).toBe('colab/preview')
+  })
+
+  it('returns undefined for the plain Backends list and other hashes', () => {
+    expect(backendsSubFromHash('#/backends')).toBeUndefined()
+    expect(backendsSubFromHash('#/training')).toBeUndefined()
+    expect(backendsSubFromHash('')).toBeUndefined()
+    expect(BACKENDS_HASH_PREFIX).toBe('/backends')
   })
 })

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -8,7 +8,8 @@
  * Sub-route hashes: `#/settings/modules/<backendId>` keeps the Settings
  * Modules view focused on a driver; `#/training/new[/<step>]` opens the
  * New-train wizard (each step is its own history entry so browser back
- * walks the steps, issue #136).
+ * walks the steps, issue #136); `#/training/review/<jobId>` and
+ * `#/backends/new|colab[/preview]` are back-closeable sub-panels.
  */
 
 import * as React from 'react'
@@ -149,10 +150,39 @@ export function trainNewStepFromHash(hash: string): string | undefined {
   return raw.slice(TRAIN_NEW_HASH_PREFIX.length + 1).split('/')[0] || undefined
 }
 
+/** True for a New-train wizard review hash, e.g. `#/training/new/ready/review`. */
+export function trainNewReviewFromHash(hash: string): boolean {
+  const raw = hash.replace(/^#/, '')
+  return raw.startsWith(`${TRAIN_NEW_HASH_PREFIX}/`) && raw.endsWith('/review')
+}
+
+/** Hash prefix of a train-details notebook review: `#/training/review/<jobId>`. */
+export const TRAIN_REVIEW_HASH_PREFIX = '/training/review'
+
+/** The train job id embedded in a review hash, e.g. `#/training/review/train-…`. */
+export function trainReviewJobFromHash(hash: string): string | undefined {
+  const raw = hash.replace(/^#/, '')
+  if (!raw.startsWith(`${TRAIN_REVIEW_HASH_PREFIX}/`)) return undefined
+  return raw.slice(TRAIN_REVIEW_HASH_PREFIX.length + 1).split('/')[0] || undefined
+}
+
+/** Hash prefix of the Backends view sub-panels: `#/backends/new|colab[/preview]`. */
+export const BACKENDS_HASH_PREFIX = '/backends'
+
+/** Backends sub-route embedded in the hash, e.g. 'new', 'colab', 'colab/preview'. */
+export function backendsSubFromHash(hash: string): string | undefined {
+  const raw = hash.replace(/^#/, '')
+  if (!raw.startsWith(`${BACKENDS_HASH_PREFIX}/`)) return undefined
+  return raw.slice(BACKENDS_HASH_PREFIX.length + 1)
+}
+
 function parseHash(): ConsoleRoute {
   const raw = window.location.hash.replace(/^#/, '')
-  // /training/new[/<step>] is the New-train wizard inside the Training view.
+  // /training/new[/<step>] and /training/review/<jobId> live inside Training.
   if (raw.startsWith(TRAIN_NEW_HASH_PREFIX)) return 'training'
+  if (raw.startsWith(TRAIN_REVIEW_HASH_PREFIX)) return 'training'
+  // /backends/new|colab[/preview] are Backends full-panel modes.
+  if (raw.startsWith(`${BACKENDS_HASH_PREFIX}/`)) return 'backends'
   // /settings/modules/<backendId> also maps to settings-modules.
   if (raw.startsWith('/settings/modules/')) return 'settings-modules'
   return ROUTE_BY_HASH[raw] ?? DEFAULT_ROUTE

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -4,6 +4,11 @@
  * Views are keyed by hash path, e.g. `#/workspace`, `#/library`,
  * `#/projects`, `#/playground/rnnoise`. Deep-linkable and bookmarkable.
  * Unknown hashes fall back to the default view.
+ *
+ * Sub-route hashes: `#/settings/modules/<backendId>` keeps the Settings
+ * Modules view focused on a driver; `#/training/new[/<step>]` opens the
+ * New-train wizard (each step is its own history entry so browser back
+ * walks the steps, issue #136).
  */
 
 import * as React from 'react'
@@ -130,8 +135,24 @@ export function settingsSectionOf(route: ConsoleRoute): SettingsSection | undefi
   }
 }
 
+/** Hash prefix of the New-train wizard full panel: `#/training/new[/<step>]`. */
+export const TRAIN_NEW_HASH_PREFIX = '/training/new'
+
+/**
+ * The New-train wizard step embedded in the hash, if any.
+ * `#/training/new` (no step) means the wizard's first step; this returns
+ * `undefined` for it and for any non-wizard hash.
+ */
+export function trainNewStepFromHash(hash: string): string | undefined {
+  const raw = hash.replace(/^#/, '')
+  if (!raw.startsWith(`${TRAIN_NEW_HASH_PREFIX}/`)) return undefined
+  return raw.slice(TRAIN_NEW_HASH_PREFIX.length + 1).split('/')[0] || undefined
+}
+
 function parseHash(): ConsoleRoute {
   const raw = window.location.hash.replace(/^#/, '')
+  // /training/new[/<step>] is the New-train wizard inside the Training view.
+  if (raw.startsWith(TRAIN_NEW_HASH_PREFIX)) return 'training'
   // /settings/modules/<backendId> also maps to settings-modules.
   if (raw.startsWith('/settings/modules/')) return 'settings-modules'
   return ROUTE_BY_HASH[raw] ?? DEFAULT_ROUTE

--- a/apps/web/src/training/console/NewTrainWizard.tsx
+++ b/apps/web/src/training/console/NewTrainWizard.tsx
@@ -29,6 +29,7 @@ import { TrainParamsPanel } from '@wake-studio/module-training/web'
 import { cn } from '../../components/cn'
 import { IconChevronRight } from '../../components/icons'
 import { useAppSettings } from '../../settings'
+import { TRAIN_NEW_HASH_PREFIX, trainNewStepFromHash } from '../../router'
 import { findTrainableModule, type TrainableModule } from '../train-modules'
 import { ConfirmDialog } from './ConfirmDialog'
 import { InlineGuide } from './InlineGuide'
@@ -69,6 +70,30 @@ export function NewTrainWizard({
   const [reviewing, setReviewing] = useState(false)
   const [confirmCancel, setConfirmCancel] = useState(false)
   const { backends } = useAppSettings()
+
+  // Wizard steps are hash-encoded (`#/training/new[/<step>]`, issue #136):
+  // every step is its own history entry, so browser back/forward walk the
+  // steps instead of leaving the Training view. Hash changes sync the step.
+  useEffect(() => {
+    const onHash = () => {
+      const s = trainNewStepFromHash(window.location.hash)
+      setStep(STEP_ORDER.includes(s as TrainingStepId) ? (s as TrainingStepId) : 'model')
+    }
+    window.addEventListener('hashchange', onHash)
+    return () => window.removeEventListener('hashchange', onHash)
+  }, [])
+
+  /** Advance a step as a forward history entry (browser back can undo it). */
+  const goNext = useCallback(() => {
+    const n = advanceStep(step) ?? step
+    setStep(n)
+    window.location.hash = `#${TRAIN_NEW_HASH_PREFIX}/${n}`
+  }, [step])
+
+  /** Go back one step by popping history — never push (issue #136). */
+  const goBack = useCallback(() => {
+    window.history.back()
+  }, [])
 
   const module = findTrainableModule(modules, moduleId ?? undefined)
   const def = STEP_DEFS.find((d) => d.id === step) ?? STEP_DEFS[0]
@@ -244,7 +269,7 @@ export function NewTrainWizard({
         <div className="flex items-center justify-between">
           <Button
             type="button"
-            onClick={() => setStep(STEP_ORDER[STEP_ORDER.indexOf(step) - 1])}
+            onClick={goBack}
             disabled={!canGoBack(step)}
             variant="outline"
             size="2"
@@ -254,7 +279,7 @@ export function NewTrainWizard({
           {next ? (
             <Button
               type="button"
-              onClick={() => setStep(advanceStep(step) ?? step)}
+              onClick={goNext}
               disabled={!canNext}
               size="2"
             >

--- a/apps/web/src/training/console/NewTrainWizard.tsx
+++ b/apps/web/src/training/console/NewTrainWizard.tsx
@@ -29,7 +29,7 @@ import { TrainParamsPanel } from '@wake-studio/module-training/web'
 import { cn } from '../../components/cn'
 import { IconChevronRight } from '../../components/icons'
 import { useAppSettings } from '../../settings'
-import { TRAIN_NEW_HASH_PREFIX, trainNewStepFromHash } from '../../router'
+import { TRAIN_NEW_HASH_PREFIX, trainNewReviewFromHash, trainNewStepFromHash } from '../../router'
 import { findTrainableModule, type TrainableModule } from '../train-modules'
 import { ConfirmDialog } from './ConfirmDialog'
 import { InlineGuide } from './InlineGuide'
@@ -73,11 +73,13 @@ export function NewTrainWizard({
 
   // Wizard steps are hash-encoded (`#/training/new[/<step>]`, issue #136):
   // every step is its own history entry, so browser back/forward walk the
-  // steps instead of leaving the Training view. Hash changes sync the step.
+  // steps instead of leaving the Training view. Hash changes sync the step
+  // and the notebook review sub-panel (`#/training/new/<step>/review`).
   useEffect(() => {
     const onHash = () => {
       const s = trainNewStepFromHash(window.location.hash)
       setStep(STEP_ORDER.includes(s as TrainingStepId) ? (s as TrainingStepId) : 'model')
+      setReviewing(trainNewReviewFromHash(window.location.hash))
     }
     window.addEventListener('hashchange', onHash)
     return () => window.removeEventListener('hashchange', onHash)
@@ -159,7 +161,11 @@ export function NewTrainWizard({
       <NotebookReviewView
         fileName={reviewFile.fileName}
         rawUrl={reviewFile.rawUrl ?? ''}
-        onBack={() => setReviewing(false)}
+        onBack={() => {
+          // Pop the review entry (`#/training/new/<step>/review`) — the step
+          // entry below it restores the wizard state (issue #136).
+          window.history.back()
+        }}
         personalize={
           module && reviewFile.kind === 'notebook'
             ? { params: module.train.params ?? [], values: params }
@@ -252,7 +258,11 @@ export function NewTrainWizard({
             method={method}
             params={params}
             backend={backends.find((b) => b.id === backendId) ?? null}
-            onReview={() => setReviewing(true)}
+            onReview={() => {
+              // The review is its own history entry (issue #136): browser back
+              // returns to the Ready step.
+              window.location.hash = `#${TRAIN_NEW_HASH_PREFIX}/ready/review`
+            }}
           />
         )}
 

--- a/apps/web/src/training/console/TrainDetails.tsx
+++ b/apps/web/src/training/console/TrainDetails.tsx
@@ -31,6 +31,7 @@ import { studioJobPatch, type StudioJobPatch } from '../studio-client'
 import { ConfirmDialog } from './ConfirmDialog'
 import { FileReviewCard } from './FileReviewCard'
 import { NotebookReviewView } from './NotebookReviewView'
+import { TRAIN_REVIEW_HASH_PREFIX, trainReviewJobFromHash } from '../../router'
 import { StatusChip } from './StatusChip'
 import { trainInputFile } from './train-files'
 
@@ -99,8 +100,19 @@ export function TrainDetails({
     if (!same) onLiveUpdate(patch)
   }, [live, job, onLiveUpdate])
 
-  // Full-panel notebook review (Back preserves the details state, #105).
-  const [reviewing, setReviewing] = useState(false)
+  // Full-panel notebook review, hash-driven (`#/training/review/<jobId>`,
+  // issue #136): opening pushes an entry, browser back closes it. The hash
+  // also restores the review across a refresh.
+  const [reviewing, setReviewing] = useState(
+    () => trainReviewJobFromHash(window.location.hash) === job.id,
+  )
+  useEffect(() => {
+    const onHash = () => {
+      setReviewing(trainReviewJobFromHash(window.location.hash) === job.id)
+    }
+    window.addEventListener('hashchange', onHash)
+    return () => window.removeEventListener('hashchange', onHash)
+  }, [job.id])
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [logsOpen, setLogsOpen] = useState(false)
   const personalizable = useMemo(
@@ -116,7 +128,11 @@ export function TrainDetails({
       <NotebookReviewView
         fileName={file.fileName}
         rawUrl={file.rawUrl ?? ''}
-        onBack={() => setReviewing(false)}
+        onBack={() => {
+          // Pop the review entry — the `#/training` entry below restores the
+          // train details (issue #136).
+          window.history.back()
+        }}
         personalize={personalizable}
       />
     )
@@ -373,7 +389,11 @@ export function TrainDetails({
             openUrl={file.openUrl}
             openLabel={file.openLabel}
             description={file.description}
-            onReview={() => setReviewing(true)}
+            onReview={() => {
+              // The review is its own history entry (issue #136): browser back
+              // returns to the train details.
+              window.location.hash = `#${TRAIN_REVIEW_HASH_PREFIX}/${job.id}`
+            }}
             params={job.params}
             paramMeta={module?.train.params}
           />

--- a/apps/web/src/training/console/TrainingConsole.tsx
+++ b/apps/web/src/training/console/TrainingConsole.tsx
@@ -29,6 +29,7 @@ import { deleteJob, listJobs, saveJob } from '@wake-studio/module-training'
 import { ConsolePanel } from '../../components/ConsolePanel'
 import { IconWand } from '../../components/icons'
 import { useAppSettings } from '../../settings'
+import { TRAIN_NEW_HASH_PREFIX } from '../../router'
 import { NewTrainWizard } from './NewTrainWizard'
 import { TrainDetails } from './TrainDetails'
 import { TrainList } from './TrainList'
@@ -65,8 +66,16 @@ export function TrainingConsole() {
         lastHashRef.current = target
         return
       }
-      if (viewRef.current.kind !== 'wizard' || !wizardDirtyRef.current) {
+      // Walking wizard steps (`#/training/new[/<step>]`, issue #136) is always
+      // allowed; the guard fires only when the hash leaves the wizard route.
+      const leavingWizard =
+        viewRef.current.kind === 'wizard' &&
+        !target.startsWith(`#${TRAIN_NEW_HASH_PREFIX}`)
+      if (!leavingWizard || !wizardDirtyRef.current) {
         lastHashRef.current = target
+        // Leaving without unsaved progress (e.g. browser back to the Trains
+        // list): close the wizard and return to the pre-wizard view.
+        if (leavingWizard) setView((v) => (v.kind === 'wizard' ? v.from : v))
         return
       }
       // Revert and ask.
@@ -75,6 +84,14 @@ export function TrainingConsole() {
     }
     window.addEventListener('hashchange', onHash)
     return () => window.removeEventListener('hashchange', onHash)
+  }, [])
+
+  // A refresh while the wizard was open leaves a `#/training/new/...` hash but
+  // no wizard state — drop the stale entry so back/forward behave (issue #136).
+  useEffect(() => {
+    if (location.hash.startsWith(`#${TRAIN_NEW_HASH_PREFIX}`)) {
+      location.replace('#/training')
+    }
   }, [])
 
   const handleDirtyChange = useCallback((dirty: boolean) => {
@@ -179,6 +196,10 @@ export function TrainingConsole() {
         recordJob(job)
         setView({ kind: 'details', jobId: job.id })
       }
+      // The wizard's step entries stay in history — replace the current one
+      // with the Trains list so back from the details pane does not re-enter
+      // the finished wizard (issue #136).
+      location.replace('#/training')
     },
     [backends, recordJob, patchJob],
   )
@@ -239,7 +260,12 @@ export function TrainingConsole() {
         <NewTrainWizard
           modules={modules}
           onStarted={handleWizardStarted}
-          onCancel={() => setView(view.from)}
+          onCancel={() => {
+            setView(view.from)
+            // Replace the current step entry (not push) so the Trains list is
+            // the new top of history (issue #136).
+            location.replace('#/training')
+          }}
           onDirtyChange={handleDirtyChange}
         />
       ) : (
@@ -249,7 +275,12 @@ export function TrainingConsole() {
           actions={
             <Button
               type="button"
-              onClick={() => setView({ kind: 'wizard', from: view })}
+              onClick={() => {
+                setView({ kind: 'wizard', from: view })
+                // Opening the wizard is a history entry itself: browser back
+                // from step 1 returns to the Trains list (issue #136).
+                location.hash = `#${TRAIN_NEW_HASH_PREFIX}`
+              }}
               size="2"
               className="shrink-0 gap-1.5 font-semibold"
             >
@@ -323,6 +354,9 @@ export function TrainingConsole() {
           if (confirmNav) {
             navGuardRef.current = true
             location.hash = confirmNav.target
+            // Leave the wizard too — the hash may be the Trains list itself
+            // (browser back), which does not unmount the console (issue #136).
+            setView((v) => (v.kind === 'wizard' ? v.from : v))
           }
           setConfirmNav(null)
         }}

--- a/apps/web/src/training/console/TrainingConsole.tsx
+++ b/apps/web/src/training/console/TrainingConsole.tsx
@@ -29,7 +29,7 @@ import { deleteJob, listJobs, saveJob } from '@wake-studio/module-training'
 import { ConsolePanel } from '../../components/ConsolePanel'
 import { IconWand } from '../../components/icons'
 import { useAppSettings } from '../../settings'
-import { TRAIN_NEW_HASH_PREFIX } from '../../router'
+import { TRAIN_NEW_HASH_PREFIX, trainReviewJobFromHash } from '../../router'
 import { NewTrainWizard } from './NewTrainWizard'
 import { TrainDetails } from './TrainDetails'
 import { TrainList } from './TrainList'
@@ -48,7 +48,12 @@ export function TrainingConsole() {
   const [jobs, setJobs] = useState<HistoryJob[]>([])
   const [modules, setModules] = useState<TrainableModule[]>([])
   const [modulesError, setModulesError] = useState<string | null>(null)
-  const [view, setView] = useState<View>({ kind: 'empty' })
+  const [view, setView] = useState<View>(() => {
+    // A review hash (`#/training/review/<jobId>`) reopens that train's
+    // details after a refresh (issue #136).
+    const jobId = trainReviewJobFromHash(window.location.hash)
+    return jobId ? { kind: 'details', jobId } : { kind: 'empty' }
+  })
 
   // Unsaved-progress guard: leaving the wizard via another menu asks first.
   const wizardDirtyRef = useRef(false)

--- a/apps/web/src/views/BackendsView.tsx
+++ b/apps/web/src/views/BackendsView.tsx
@@ -27,6 +27,7 @@ import { BACKEND_NOTEBOOK_FILENAME, downloadBackendNotebook } from '../backends/
 import { NotebookReviewView } from '../training/console/NotebookReviewView'
 import { ConsolePanel } from '../components/ConsolePanel'
 import { ConfirmDialog } from '../training/console/ConfirmDialog'
+import { BACKENDS_HASH_PREFIX, backendsSubFromHash } from '../router'
 
 const HEALTH_POLL_MS = 30_000
 
@@ -541,12 +542,30 @@ type BackendsViewMode =
   | { kind: 'colab-guide' }
   | { kind: 'colab-preview' }
 
+/** Map the Backends hash sub-route onto a full-panel mode (issue #136). */
+function modeFromHash(): BackendsViewMode {
+  const sub = backendsSubFromHash(window.location.hash)
+  if (sub === 'new') return { kind: 'new-editor', mode: 'new' }
+  if (sub === 'colab') return { kind: 'colab-guide' }
+  if (sub === 'colab/preview') return { kind: 'colab-preview' }
+  return { kind: 'list' }
+}
+
 export function BackendsView() {
   const { backends, upsertBackend, removeBackend } = useAppSettings()
-  const [view, setView] = useState<BackendsViewMode>({ kind: 'list' })
+  const [view, setView] = useState<BackendsViewMode>(modeFromHash)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
   const [blobUrl, setBlobUrl] = useState<string | null>(null)
+
+  // Full-panel modes are hash-encoded (`#/backends/new`, `#/backends/colab[/preview]`,
+  // issue #136): each is its own history entry, so browser back/forward walk
+  // them instead of leaving the Backends view.
+  useEffect(() => {
+    const onHash = () => setView(modeFromHash())
+    window.addEventListener('hashchange', onHash)
+    return () => window.removeEventListener('hashchange', onHash)
+  }, [])
 
   // Health checks: mount + every 30s + manual refresh (list read via ref).
   const backendsRef = useRef(backends)
@@ -622,9 +641,10 @@ export function BackendsView() {
           } else if (editingBackend) {
             upsertBackend({ ...editingBackend, ...input })
           }
-          setView({ kind: 'list' })
+          // Replace the editor entry with the list — never re-enter it via back.
+          location.replace(`#${BACKENDS_HASH_PREFIX}`)
         }}
-        onCancel={() => setView({ kind: 'list' })}
+        onCancel={() => location.replace(`#${BACKENDS_HASH_PREFIX}`)}
       />
     )
   }
@@ -633,8 +653,10 @@ export function BackendsView() {
     return (
       <ColabGuide
         blobUrl={blobUrl ?? ''}
-        onBack={() => setView({ kind: 'list' })}
-        onPreview={() => setView({ kind: 'colab-preview' })}
+        onBack={() => window.history.back()}
+        onPreview={() => {
+          window.location.hash = `#${BACKENDS_HASH_PREFIX}/colab/preview`
+        }}
       />
     )
   }
@@ -646,7 +668,11 @@ export function BackendsView() {
         <NotebookReviewView
           fileName={BACKEND_NOTEBOOK_FILENAME}
           rawUrl={blobUrl}
-          onBack={() => setView({ kind: 'colab-guide' })}
+          onBack={() => {
+            // Pop the preview entry — the guide entry below restores the
+            // 3-step guide (issue #136).
+            window.history.back()
+          }}
         />
       </div>
     )
@@ -664,14 +690,18 @@ export function BackendsView() {
               type="button"
               size="2"
               variant="soft"
-              onClick={() => setView({ kind: 'colab-guide' })}
+              onClick={() => {
+                window.location.hash = `#${BACKENDS_HASH_PREFIX}/colab`
+              }}
             >
               Free On Google Colab
             </Button>
             <Button
               type="button"
               size="2"
-              onClick={() => setView({ kind: 'new-editor', mode: 'new' })}
+              onClick={() => {
+                window.location.hash = `#${BACKENDS_HASH_PREFIX}/new`
+              }}
             >
               New
             </Button>


### PR DESCRIPTION
### Summary

Fixes browser back/forward navigation across the training and backends
sub-panels. Sub-panels were pure React state — no history entries — so back
jumped out of the view instead of undoing the last step.

### Changes

Every sub-panel is now hash-encoded so each open/step is its own history
entry; browser back/forward walk them; in-app Back pops (`history.back()`);
Save/Cancel replace the entry so finished panels are never re-entered via
back.

- **New-train wizard steps** — `#/training/new[/<step>]` (Next pushes, Back
  pops, hashchange syncs both directions). The leave-guard now fires only
  when actually leaving the wizard route; non-dirty leave closes the wizard.
- **Train-details notebook review** — `#/training/review/<jobId>`; also
  restores the train's details across a refresh.
- **Wizard notebook review** — `#/training/new/<step>/review`.
- **Backends full panels** — `#/backends/new` and `#/backends/colab[/preview]`.

### Tests

- `apps/web/src/__tests__/router.test.ts` — hash-helper unit tests (6 new).
- `apps/web/e2e/training-wizard-back.spec.ts` — 5 e2e tests: step walk
  back/forward, dirty-leave dialog, wizard review back, train-details review
  back, Backends editor/guide/preview walk.
- Typecheck + lint clean; 219 unit tests and the smoke suite pass.

Closes #136
