### PR TITLE
feat(web): decouple Projects selection, remember per-view selection, Monitor switch (#138 #139 #140)

### DIFF
--- a/apps/web/e2e/view-selection-monitor.spec.ts
+++ b/apps/web/e2e/view-selection-monitor.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * View selection independence/remembering (issues #138, #139) and the source
+ * panel Monitor switch (issue #140).
+ *
+ * - Projects selection is independent of the Workspace's current project and
+ *   is remembered across view switches.
+ * - Trains keeps its selected train when switching views.
+ * - The mic source panel's Monitor toggle shows a feedback warning when on.
+ */
+
+async function createProject(page: Page, name: string, word: string) {
+  // The trigger shows the current project name (or "No project selected").
+  await page.getByRole('button', { name: /No project selected|Alpha/ }).first().click()
+  await page.getByRole('menuitem', { name: /New project/ }).click()
+  await page.getByRole('textbox', { name: 'Project name' }).fill(name)
+  await page.getByRole('textbox', { name: 'Wake word' }).fill(word)
+  await page.getByRole('button', { name: 'Create' }).click()
+}
+
+test('Projects selection is independent of the Workspace project and remembered', async ({
+  page,
+}) => {
+  await page.goto('/#/workspace')
+  await createProject(page, 'Alpha', 'hey alpha')
+  await createProject(page, 'Beta', 'hey beta')
+
+  // The Workspace's active project is Beta (last created).
+  await expect(page.getByRole('button', { name: 'Beta' })).toBeVisible()
+
+  // Projects view: select Alpha — it must not change the Workspace project.
+  await page.goto('/#/projects')
+  await page.getByRole('button', { name: /Alpha/ }).click()
+  await expect(page.getByRole('heading', { name: 'Alpha' })).toBeVisible()
+
+  // Workspace project unchanged (still Beta).
+  await page.goto('/#/workspace')
+  await expect(page.getByRole('button', { name: 'Beta' })).toBeVisible()
+
+  // Projects selection is remembered when switching back.
+  await page.goto('/#/projects')
+  await expect(page.getByRole('heading', { name: 'Alpha' })).toBeVisible()
+})
+
+test('selected train is remembered when switching views', async ({ page }) => {
+  await page.goto('/#/training')
+
+  // Create a train (Colab) so the details pane has content.
+  await page.getByRole('button', { name: 'New' }).click()
+  await page.getByRole('button', { name: /OpenWakeWord/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: /Google Colab/ }).click()
+  await page.getByRole('button', { name: 'Next', exact: true }).click()
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+  await expect(page.getByText('Inputs review')).toBeVisible()
+
+  // Switch away and back: the same train is still selected.
+  await page.goto('/#/workspace')
+  await page.goto('/#/training')
+  await expect(page.getByText('Inputs review')).toBeVisible()
+})
+
+test('source panel Monitor switch shows a feedback warning', async ({ page }) => {
+  await page.goto('/#/workspace')
+
+  const monitor = page.getByRole('checkbox', { name: /Monitor/ })
+  await expect(monitor).toBeVisible()
+  await expect(page.getByText(/Monitor is on/)).toBeHidden()
+
+  await monitor.check()
+  await expect(page.getByText(/Monitor is on/)).toBeVisible()
+
+  await monitor.uncheck()
+  await expect(page.getByText(/Monitor is on/)).toBeHidden()
+})

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -162,6 +162,13 @@ export const KWSPanel = memo(function KWSPanel({
   const [artifact, setArtifact] = useState<UserArtifact | null>(null)
   const [detecting, setDetecting] = useState(false)
   const { projectConfig: fsProjCfg, persist: persistFs } = useProjectStageConfig('fewShot')
+  // Mic monitor flag from the workspace source config (issue #140): recording
+  // only plays through the speakers when the user opted in — otherwise the
+  // mic feeds back into itself without headphones.
+  const { projectConfig: wsProjCfg } = useProjectStageConfig('workspace')
+  const monitorRecording = wsProjCfg?.source?.kind === 'mic'
+    ? wsProjCfg.source.mic.monitor ?? false
+    : false
   const [fsConfig, setFsConfig] = useState<{
     threshold: number
     minDurationMs: number
@@ -609,7 +616,9 @@ export const KWSPanel = memo(function KWSPanel({
           if (e.data.type === 'chunk') chunks.push(e.data.samples)
         }
         source.connect(node)
-        node.connect(ctx.destination)
+        // Monitor (speaker) only when the source config opted in — the mic
+        // feeds back into itself without headphones (issue #140).
+        if (monitorRecording) node.connect(ctx.destination)
 
         await new Promise((r) => setTimeout(r, RECORD_MS))
         node.disconnect()
@@ -639,7 +648,7 @@ export const KWSPanel = memo(function KWSPanel({
         if (ctx) await ctx.close().catch(() => {})
       }
     },
-    [ensureFsEngines],
+    [ensureFsEngines, monitorRecording],
   )
 
   const handleBuildPrototype = useCallback(async () => {

--- a/apps/web/src/components/SourceSelector.tsx
+++ b/apps/web/src/components/SourceSelector.tsx
@@ -140,6 +140,13 @@ export function SourceSelector({ value, onChange, disabled }: Props) {
           onChecked={(v) => onChange({ ...value, autoGainControl: v })}
           disabled={disabled}
         />
+        <ToggleRow
+          label="Monitor"
+          hint="(speaker)"
+          checked={value.monitor ?? false}
+          onChecked={(v) => onChange({ ...value, monitor: v })}
+          disabled={disabled}
+        />
         <label className="flex items-center gap-2 text-xs">
           <span className="text-ink-2">Channels</span>
           <select
@@ -160,6 +167,14 @@ export function SourceSelector({ value, onChange, disabled }: Props) {
         Browser DSP is off by default — our RNNoise is the only noise
         suppressor. Toggle browser AEC/NS/AGC to let the device do it instead.
       </p>
+
+      {value.monitor && (
+        <p className="w-full rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-700">
+          ⚠️ Monitor is on: mic audio plays through your speakers. Without
+          headphones the speakers feed back into the mic (feedback noise) —
+          wear headphones or turn Monitor off.
+        </p>
+      )}
     </Card>
   )
 }

--- a/apps/web/src/training/console/TrainingConsole.tsx
+++ b/apps/web/src/training/console/TrainingConsole.tsx
@@ -30,6 +30,7 @@ import { ConsolePanel } from '../../components/ConsolePanel'
 import { IconWand } from '../../components/icons'
 import { useAppSettings } from '../../settings'
 import { TRAIN_NEW_HASH_PREFIX, trainReviewJobFromHash } from '../../router'
+import { rememberSelection, rememberedSelection } from '../../view-selection'
 import { NewTrainWizard } from './NewTrainWizard'
 import { TrainDetails } from './TrainDetails'
 import { TrainList } from './TrainList'
@@ -108,6 +109,14 @@ export function TrainingConsole() {
     let alive = true
     void listJobs().then((all) => {
       if (alive) setJobs(sortJobsNewestFirst(all))
+      // Restore the last-selected train (issue #139) unless a review hash
+      // already pinned one (issue #136).
+      if (!trainReviewJobFromHash(window.location.hash)) {
+        const last = rememberedSelection('training')
+        if (last && all.some((j) => j.id === last)) {
+          setView({ kind: 'details', jobId: last })
+        }
+      }
     })
     fetchTrainableModules()
       .then((mods) => alive && setModules(mods))
@@ -204,6 +213,7 @@ export function TrainingConsole() {
       // The wizard's step entries stay in history — replace the current one
       // with the Trains list so back from the details pane does not re-enter
       // the finished wizard (issue #136).
+      rememberSelection('training', id)
       location.replace('#/training')
     },
     [backends, recordJob, patchJob],
@@ -240,12 +250,19 @@ export function TrainingConsole() {
         classifierRef: result.classifierRef,
       })
       recordJob(job)
+      rememberSelection('training', job.id)
       setView({ kind: 'details', jobId: job.id })
     },
     [recordJob],
   )
 
-  const openTrain = useCallback((jobId: string) => setView({ kind: 'details', jobId }), [])
+  const openTrain = useCallback(
+    (jobId: string) => {
+      rememberSelection('training', jobId)
+      setView({ kind: 'details', jobId })
+    },
+    [],
+  )
 
   /** Per-train delete (details → Operations → Delete, issue #105). */
   const handleDeleteJob = useCallback(
@@ -253,8 +270,11 @@ export function TrainingConsole() {
       setJobs((prev) => prev.filter((j) => j.id !== jobId))
       void deleteJob(jobId)
       setView((v) => (v.kind === 'details' && v.jobId === jobId ? { kind: 'empty' } : v))
+      if (view.kind === 'details' && view.jobId === jobId) {
+        rememberSelection('training', null)
+      }
     },
-    [],
+    [view],
   )
 
   return (

--- a/apps/web/src/view-selection.ts
+++ b/apps/web/src/view-selection.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-view selected-item memory (issue #139).
+ *
+ * Views unmount when the route changes, so a list-detail selection (selected
+ * train / backend / project) is lost on every view switch. This tiny
+ * sessionStorage-backed store remembers the last selected id per view key;
+ * views restore it on mount and update it on selection change.
+ *
+ * sessionStorage (not module state) so the selection also survives a reload
+ * in the same tab; it clears when the tab closes.
+ */
+
+const PREFIX = 'wake-studio:view-selection:'
+
+/** Remember the selected item for a view; pass null to clear it. */
+export function rememberSelection(key: string, id: string | null): void {
+  try {
+    if (id === null || id === '') sessionStorage.removeItem(PREFIX + key)
+    else sessionStorage.setItem(PREFIX + key, id)
+  } catch {
+    // Storage unavailable (private mode): selection just won't survive reloads.
+  }
+}
+
+/** The last remembered selected item for a view, or null. */
+export function rememberedSelection(key: string): string | null {
+  try {
+    return sessionStorage.getItem(PREFIX + key)
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/views/BackendsView.tsx
+++ b/apps/web/src/views/BackendsView.tsx
@@ -28,6 +28,7 @@ import { NotebookReviewView } from '../training/console/NotebookReviewView'
 import { ConsolePanel } from '../components/ConsolePanel'
 import { ConfirmDialog } from '../training/console/ConfirmDialog'
 import { BACKENDS_HASH_PREFIX, backendsSubFromHash } from '../router'
+import { rememberSelection, rememberedSelection } from '../view-selection'
 
 const HEALTH_POLL_MS = 30_000
 
@@ -554,9 +555,19 @@ function modeFromHash(): BackendsViewMode {
 export function BackendsView() {
   const { backends, upsertBackend, removeBackend } = useAppSettings()
   const [view, setView] = useState<BackendsViewMode>(modeFromHash)
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(() =>
+    rememberedSelection('backends'),
+  )
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
   const [blobUrl, setBlobUrl] = useState<string | null>(null)
+
+  // Drop a remembered selection whose backend no longer exists (deleted).
+  useEffect(() => {
+    if (backends.length > 0 && selectedId && !backends.some((b) => b.id === selectedId)) {
+      setSelectedId(null)
+      rememberSelection('backends', null)
+    }
+  }, [selectedId, backends])
 
   // Full-panel modes are hash-encoded (`#/backends/new`, `#/backends/colab[/preview]`,
   // issue #136): each is its own history entry, so browser back/forward walk
@@ -733,7 +744,9 @@ export function BackendsView() {
                 <button
                   type="button"
                   onClick={() => {
-                    setSelectedId(b.id === selected?.id ? null : b.id)
+                    const next = b.id === selected?.id ? null : b.id
+                    setSelectedId(next)
+                    rememberSelection('backends', next)
                     close()
                   }}
                   aria-pressed={selected?.id === b.id}
@@ -805,7 +818,10 @@ export function BackendsView() {
         onConfirm={() => {
           if (confirmDelete) {
             removeBackend(confirmDelete)
-            if (selectedId === confirmDelete) setSelectedId(null)
+            if (selectedId === confirmDelete) {
+              setSelectedId(null)
+              rememberSelection('backends', null)
+            }
           }
           setConfirmDelete(null)
         }}

--- a/apps/web/src/views/ProjectsView.tsx
+++ b/apps/web/src/views/ProjectsView.tsx
@@ -4,16 +4,17 @@
  * Left rail: the project list (name, domain badge, last-updated). Right
  * pane: the selected project's details (wake word, target, samples,
  * prototypes, notes) — read-only; project creation stays in the Workspace.
- * Selection is shared with the workspace via the projects context
- * (selectProject/current).
+ * Selection is INDEPENDENT of the Workspace's active project (issue #138)
+ * and remembered across view switches (issue #139).
  */
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@radix-ui/themes'
 import { ConsolePanel } from '../components/ConsolePanel'
 import { useProjects } from '../projects'
 import { ConfirmDialog } from '../training/console/ConfirmDialog'
 import { cn } from '../components/cn'
+import { rememberSelection, rememberedSelection } from '../view-selection'
 
 const DOMAIN_STYLE: Record<string, string> = {
   mcu: 'bg-surface-3 text-ink-2',
@@ -22,8 +23,24 @@ const DOMAIN_STYLE: Record<string, string> = {
 }
 
 export function ProjectsView() {
-  const { projects, current, selectProject, deleteProject } = useProjects()
+  const { projects, deleteProject } = useProjects()
   const [confirmDelete, setConfirmDelete] = useState(false)
+  // Own selection — not the Workspace's current project (issue #138), and
+  // remembered across view switches (issue #139).
+  const [selectedId, setSelectedId] = useState<string | null>(() =>
+    rememberedSelection('projects'),
+  )
+
+  const selected = projects.find((p) => p.id === selectedId) ?? null
+
+  // Drop a remembered selection whose project no longer exists (deleted
+  // here or from the Workspace).
+  useEffect(() => {
+    if (projects.length > 0 && selectedId && !projects.some((p) => p.id === selectedId)) {
+      setSelectedId(null)
+      rememberSelection('projects', null)
+    }
+  }, [selectedId, projects])
 
   const ordered = useMemo(
     () => [...projects].sort((a, b) => b.updatedAtMs - a.updatedAtMs),
@@ -45,13 +62,14 @@ export function ProjectsView() {
             </li>
           )}
           {ordered.map((p) => {
-            const selected = current?.id === p.id
+            const selected = selectedId === p.id
             return (
               <li key={p.id}>
                 <button
                   type="button"
                   onClick={() => {
-                    selectProject(p.id)
+                    setSelectedId(p.id)
+                    rememberSelection('projects', p.id)
                     close()
                   }}
                   aria-pressed={selected}
@@ -88,55 +106,55 @@ export function ProjectsView() {
         </ul>
       )}
       details={
-        current ? (
+        selected ? (
           <>
             <section className="rounded-xl border border-line bg-surface-2 p-4">
             <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-base font-semibold text-ink-1">{current.name}</h3>
+              <h3 className="text-base font-semibold text-ink-1">{selected.name}</h3>
               <span
                 className={cn(
                   'rounded-full px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide',
-                  DOMAIN_STYLE[current.domain] ?? 'bg-surface-3 text-ink-3',
+                  DOMAIN_STYLE[selected.domain] ?? 'bg-surface-3 text-ink-3',
                 )}
               >
-                {current.domain}
+                {selected.domain}
               </span>
             </div>
             <dl className="mt-3 grid gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
               <div className="flex justify-between gap-3">
                 <dt className="text-ink-3">Wake word</dt>
-                <dd className="truncate font-mono text-ink-1">{current.targetWord || '—'}</dd>
+                <dd className="truncate font-mono text-ink-1">{selected.targetWord || '—'}</dd>
               </div>
-              {current.targetChip && (
+              {selected.targetChip && (
                 <div className="flex justify-between gap-3">
                   <dt className="text-ink-3">Target chip</dt>
-                  <dd className="truncate font-mono text-ink-1">{current.targetChip}</dd>
+                  <dd className="truncate font-mono text-ink-1">{selected.targetChip}</dd>
                 </div>
               )}
               <div className="flex justify-between gap-3">
                 <dt className="text-ink-3">Samples</dt>
-                <dd className="font-mono text-ink-1">{current.sampleIds.length}</dd>
+                <dd className="font-mono text-ink-1">{selected.sampleIds.length}</dd>
               </div>
               <div className="flex justify-between gap-3">
                 <dt className="text-ink-3">Prototypes</dt>
-                <dd className="font-mono text-ink-1">{current.prototypeIds.length}</dd>
+                <dd className="font-mono text-ink-1">{selected.prototypeIds.length}</dd>
               </div>
               <div className="flex justify-between gap-3">
                 <dt className="text-ink-3">Created</dt>
                 <dd className="font-mono text-ink-1">
-                  {new Date(current.createdAtMs).toLocaleString()}
+                  {new Date(selected.createdAtMs).toLocaleString()}
                 </dd>
               </div>
               <div className="flex justify-between gap-3">
                 <dt className="text-ink-3">Updated</dt>
                 <dd className="font-mono text-ink-1">
-                  {new Date(current.updatedAtMs).toLocaleString()}
+                  {new Date(selected.updatedAtMs).toLocaleString()}
                 </dd>
               </div>
             </dl>
-            {current.notes && (
+            {selected.notes && (
               <p className="mt-3 rounded-lg border border-line bg-surface-1 px-3 py-2 text-xs leading-relaxed text-ink-2">
-                {current.notes}
+                {selected.notes}
               </p>
             )}
             <p className="mt-3 text-[11px] text-ink-3">
@@ -184,7 +202,11 @@ export function ProjectsView() {
         message="Deletes the project and its stored config, samples and prototypes. This cannot be undone."
         confirmLabel="Delete"
         onConfirm={() => {
-          if (current) void deleteProject(current.id)
+          if (selected) {
+            void deleteProject(selected.id)
+            setSelectedId(null)
+            rememberSelection('projects', null)
+          }
           setConfirmDelete(false)
         }}
         onCancel={() => setConfirmDelete(false)}

--- a/apps/web/src/workspace/useSourceConfig.ts
+++ b/apps/web/src/workspace/useSourceConfig.ts
@@ -66,6 +66,7 @@ export function useSourceConfig(
         noiseSuppression: s.mic.noiseSuppression ?? false,
         autoGainControl: s.mic.autoGainControl ?? false,
         channelCount: s.mic.channelCount ?? fallbackChannelCount,
+        monitor: s.mic.monitor ?? false,
       }
     }
     return {
@@ -97,9 +98,19 @@ export function useSourceConfig(
     files,
   }))
 
-  const updateMic = React.useCallback((next: MicSourceConfig) => {
-    setMic(next)
-  }, [])
+  const updateMic = React.useCallback(
+    (next: MicSourceConfig) => {
+      setMic(next)
+      // Mic knobs (device, browser DSP, monitor) are LIVE config: sync the
+      // applied source + persist immediately, so the next Start uses them
+      // without an explicit Apply (the Apply button only tracks kind/file
+      // changes; monitor must reach the pipeline or there is no audio,
+      // issue #140).
+      setAppliedSource((prev) => ({ ...prev, mic: next }))
+      persistWs({ source: { kind: 'mic', mic: next } })
+    },
+    [persistWs],
+  )
 
   const updateKind = React.useCallback((next: 'mic' | 'file') => {
     setKind(next)

--- a/packages/modules/afe/graph/core/AFEPipeline.ts
+++ b/packages/modules/afe/graph/core/AFEPipeline.ts
@@ -100,6 +100,8 @@ export class AFEPipeline {
     const fileSource = (source as FileSourceConfig | undefined)?.nodes
       ? (source as FileSourceConfig)
       : null
+    // Mic config (used below for getUserMedia options + monitor routing).
+    const micSource = source as MicSourceConfig | undefined
 
     if (fileSource) {
       // File source (epic #53 P3): the host already decoded + scheduled the
@@ -107,7 +109,6 @@ export class AFEPipeline {
       this._fileNodes = fileSource.nodes
       this._fileDispose = fileSource.dispose
     } else {
-      const micSource = source as MicSourceConfig | undefined
       // Request microphone. Browser DSP toggles + device come from the source
       // config (epic #53 P2); defaults keep the current behavior (browser DSP
       // off so ours is the only processing, default device).
@@ -146,8 +147,12 @@ export class AFEPipeline {
       this._source = this._ctx.createMediaStreamSource(this._stream!)
       this._source.connect(this._node)
     }
-    // Connect to destination so the user can monitor the processed audio.
-    this._node.connect(this._ctx.destination)
+    // Connect to destination so the user can monitor the processed audio —
+    // only when the mic config opts in (monitor, issue #140): speaker output
+    // feeds back into the mic without headphones, so it is off by default.
+    // File sources keep monitoring (no mic -> no feedback loop).
+    const monitor = fileSource ? true : (micSource?.monitor ?? false)
+    if (monitor) this._node.connect(this._ctx.destination)
 
     // Message handling.
     this._node.port.onmessage = (e: MessageEvent<WorkletMessage>) => {

--- a/packages/modules/afe/graph/core/types.ts
+++ b/packages/modules/afe/graph/core/types.ts
@@ -45,6 +45,11 @@ export interface MicSourceConfig {
   noiseSuppression?: boolean
   autoGainControl?: boolean
   channelCount?: 1 | 2
+  /**
+   * Send the mic through to the speakers (monitor). Off by default: speaker
+   * output feeds back into the mic without headphones (issue #140).
+   */
+  monitor?: boolean
 }
 
 /**


### PR DESCRIPTION
### Summary

Three UX fixes: the Projects view selection is decoupled from the Workspace's
active project, list-detail selections (train / backend / project) are
remembered across view switches, and mic audio no longer reaches the speakers
by default — with a Monitor switch + feedback warning in the source panel.

### Changes

**#138 — Projects selection independent of the Workspace project.**
`ProjectsView` keeps its own selection; picking a project there no longer
changes the Workspace's active project (and vice versa). The Workspace keeps
its existing persisted current-project behavior.

**#139 — per-view selection remembered.** New tiny store
(`src/view-selection.ts`, sessionStorage-backed): the selected train, backend
and project are each restored when switching back to the view (also across a
reload in the same tab). Deleting the selected item clears the memory.

**#140 — monitor switch + feedback warning.** Mic audio is no longer routed to
the speakers by default:
- `MicSourceConfig` gains a `monitor` flag (default off)
- `AFEPipeline` connects mic output to the speakers only when monitor is on
  (file sources keep monitoring — no feedback loop without a mic)
- Few-Shot enrollment recording plays to the speaker only when monitor is on
- The Workspace source panel (mic tab) has a **Monitor (speaker)** toggle with
  an amber feedback warning when on
- Mic knobs (Monitor / AEC / NS / AGC) are now **live**: toggling applies and
  persists immediately, so the next Start actually uses them (previously they
  stayed in the working draft — Monitor never reached the pipeline, so there
  was no audio)

### Tests

- New `e2e/view-selection-monitor.spec.ts` (3 tests): Projects decoupling +
  memory, train selection memory, Monitor warning UI.
- Full suites re-verified: typecheck + lint clean, 220 unit tests, 17 e2e tests.

Closes #138
Closes #139
Closes #140
