### PR TITLE
feat(web): Dark/Light/System theme mode + top-toolbar switch (#142)

### DIFF
--- a/apps/web/e2e/theme-mode.spec.ts
+++ b/apps/web/e2e/theme-mode.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Theme mode (issue #142): top-bar switch for Light / Dark / System.
+ *
+ * - Light and Dark apply the matching token layer (data-theme + color-scheme).
+ * - System follows the OS preference, live.
+ * - The choice persists across reloads.
+ */
+
+async function openThemeMenu(page: Page) {
+  await page.getByRole('button', { name: /Theme:/ }).click()
+}
+
+test('top-bar switch applies Light and Dark and persists', async ({ page }) => {
+  await page.goto('/')
+  // Default is Light.
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
+
+  // Switch to Dark.
+  await openThemeMenu(page)
+  await page.getByRole('menuitem', { name: 'Dark' }).click()
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+  const dark = await page.evaluate(() => ({
+    colorScheme: getComputedStyle(document.documentElement).colorScheme,
+    bodyBg: getComputedStyle(document.body).backgroundColor,
+    surface: getComputedStyle(document.documentElement).getPropertyValue('--ws-surface'),
+  }))
+  expect(dark.colorScheme).toBe('dark')
+  // Dark surface resolves to a real (dark) color, not transparent.
+  expect(dark.surface.trim()).toBe('17 17 19')
+  expect(dark.bodyBg).not.toBe('rgba(0, 0, 0, 0)')
+
+  // Switch back to Light.
+  await openThemeMenu(page)
+  await page.getByRole('menuitem', { name: 'Light' }).click()
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
+
+  // Dark persists across a reload.
+  await openThemeMenu(page)
+  await page.getByRole('menuitem', { name: 'Dark' }).click()
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+  await page.reload()
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+})
+
+test('System follows the OS color scheme, live', async ({ page }) => {
+  await page.goto('/')
+
+  // Emulate the OS via CDP: unlike page.emulateMedia, this fires the
+  // matchMedia change event the app listens to.
+  const session = await page.context().newCDPSession(page)
+  const setOs = (colorScheme: 'light' | 'dark') =>
+    session.send('Emulation.setEmulatedMedia', {
+      features: [{ name: 'prefers-color-scheme', value: colorScheme }],
+    })
+
+  await setOs('dark')
+  await openThemeMenu(page)
+  await page.getByRole('menuitem', { name: 'System' }).click()
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+  // OS preference change is picked up without a reload.
+  await setOs('light')
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,19 +50,20 @@ export default function App() {
 /**
  * Radix Themes wrapper - accent comes from the saved platform setting
  * (Settings -> General -> Accent color; default gray). Gray is the default;
- * Sky is the classic WakeStudio look. Dark mode (appearance) lands with the
- * dark token set - today the app is light-only.
+ * Sky is the classic WakeStudio look. appearance follows the resolved
+ * theme mode (Light/Dark/System, Settings or the top-bar switch) so Radix
+ * components match the token layer (issue #142).
  */
 function ThemedShell() {
-  const { platform } = useAppSettings();
+  const { platform, resolvedTheme } = useAppSettings();
   const accent = platform['theme.accent'] ?? 'gray';
   // Sync the brand CSS vars (module-kit rendered panels read them) to the
-  // selected accent scale, alongside the Themes accentColor.
+  // selected accent scale (light + dark), alongside the Themes accentColor.
   React.useEffect(() => {
     setBrandAccentVars(accent);
   }, [accent]);
   return (
-    <Theme appearance="light" accentColor={accent} grayColor="slate">
+    <Theme appearance={resolvedTheme} accentColor={accent} grayColor="slate">
       <AppShell />
     </Theme>
   );

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -27,7 +27,19 @@ import {
   Cross2Icon,
   HamburgerMenuIcon,
   StopIcon,
+  SunIcon,
+  MoonIcon,
+  LaptopIcon,
+  CheckIcon,
 } from '@radix-ui/react-icons'
+import { useAppSettings } from '../settings'
+import type { ThemeMode } from '../settings'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './ui'
 import { PRIMARY_NAV, SECONDARY_NAV, isSettingsRoute, type NavItem } from './shell-nav'
 import { useLiveAfe, useLiveKws } from '../workspace/live'
 import { cn } from './cn'
@@ -281,6 +293,51 @@ export function Sidebar({
   )
 }
 
+/**
+ * Theme mode switch — top-bar dropdown (Light / Dark / System, issue #142).
+ * Writes the same persisted setting as Settings -> General -> Theme, so both
+ * stay in sync; System follows the OS preference live.
+ */
+const THEME_OPTIONS: ReadonlyArray<{ mode: ThemeMode; label: string; Icon: typeof SunIcon }> = [
+  { mode: 'light', label: 'Light', Icon: SunIcon },
+  { mode: 'dark', label: 'Dark', Icon: MoonIcon },
+  { mode: 'system', label: 'System', Icon: LaptopIcon },
+]
+
+function ThemeSwitchButton() {
+  const { platform, set } = useAppSettings()
+  const mode: ThemeMode = platform.theme ?? 'light'
+  const current = THEME_OPTIONS.find((o) => o.mode === mode) ?? THEME_OPTIONS[0]
+  const CurrentIcon = current.Icon
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <IconButton
+          variant="ghost"
+          size="2"
+          aria-label={`Theme: ${current.label}`}
+          title="Theme"
+          className="text-ink-3"
+        >
+          <CurrentIcon className="h-4 w-4" />
+        </IconButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-44">
+        {THEME_OPTIONS.map(({ mode: m, label, Icon }) => (
+          <DropdownMenuItem key={m} onSelect={() => set('theme', m)}>
+            <span className="flex flex-1 items-center gap-2">
+              <Icon className="h-3.5 w-3.5 text-ink-3" />
+              <span className="text-sm">{label}</span>
+            </span>
+            {mode === m && <CheckIcon className="h-3.5 w-3.5 text-brand-11" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 /** Drivers with a spec, for the Modules sub-menu (registry-driven, ADR-024). */
 function useSettingsDrivers(): ReadonlyArray<{ backendId: string; label: string }> {
   // The KWS backend registry is populated at import time by driver modules;
@@ -318,6 +375,7 @@ export function TopBar({
         <h1 className="truncate text-sm font-semibold text-ink-1">{title}</h1>
       </div>
       <div className="flex items-center gap-2">
+        <ThemeSwitchButton />
         <MiniPipelineBar open={barOpen} onToggle={() => setBarOpen((v) => !v)} />
       </div>
     </header>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -60,21 +60,92 @@
   --ws-danger: 206 44 49;       /* red-11 */
 
   /* Brand = the user's accent theme (Settings -> Accent color; default
-     gray). Sync'd at runtime to the chosen Radix scale via
-     settings/accent-colors.ts; these :root values are the gray fallback
-     before the app boots. */
-  --ws-brand-1: 252 252 252;    /* gray-1 */
-  --ws-brand-2: 249 249 249;    /* gray-2 */
-  --ws-brand-3: 240 240 240;    /* gray-3 */
-  --ws-brand-4: 232 232 232;    /* gray-4 */
-  --ws-brand-5: 224 224 224;    /* gray-5 */
-  --ws-brand-6: 217 217 217;    /* gray-6 */
-  --ws-brand-7: 206 206 206;    /* gray-7 */
-  --ws-brand-8: 187 187 187;    /* gray-8 */
-  --ws-brand-9: 141 141 141;    /* gray-9 - accent solid */
-  --ws-brand-10: 131 131 131;   /* gray-10 */
-  --ws-brand-11: 100 100 100;   /* gray-11 - text on light */
-  --ws-brand-12: 32 32 32;      /* gray-12 */
+     gray). Sync'd at runtime to the chosen Radix scale (light + dark) via
+     settings/accent-colors.ts; these :root values are the gray fallbacks
+     before the app boots. --ws-brand-N picks the active scale: light by
+     default, the dark scale under [data-theme='dark']. */
+  --ws-brand-light-1: 252 252 252;  /* gray-1 */
+  --ws-brand-light-2: 249 249 249;  /* gray-2 */
+  --ws-brand-light-3: 240 240 240;  /* gray-3 */
+  --ws-brand-light-4: 232 232 232;  /* gray-4 */
+  --ws-brand-light-5: 224 224 224;  /* gray-5 */
+  --ws-brand-light-6: 217 217 217;  /* gray-6 */
+  --ws-brand-light-7: 206 206 206;  /* gray-7 */
+  --ws-brand-light-8: 187 187 187;  /* gray-8 */
+  --ws-brand-light-9: 141 141 141;  /* gray-9 - accent solid */
+  --ws-brand-light-10: 131 131 131; /* gray-10 */
+  --ws-brand-light-11: 100 100 100; /* gray-11 - text on light */
+  --ws-brand-light-12: 32 32 32;    /* gray-12 */
+
+  --ws-brand-dark-1: 17 17 17;      /* gray-1 */
+  --ws-brand-dark-2: 25 25 25;      /* gray-2 */
+  --ws-brand-dark-3: 34 34 34;      /* gray-3 */
+  --ws-brand-dark-4: 42 42 42;      /* gray-4 */
+  --ws-brand-dark-5: 49 49 49;      /* gray-5 */
+  --ws-brand-dark-6: 58 58 58;      /* gray-6 */
+  --ws-brand-dark-7: 72 72 72;      /* gray-7 */
+  --ws-brand-dark-8: 96 96 96;      /* gray-8 */
+  --ws-brand-dark-9: 110 110 110;   /* gray-9 - accent solid */
+  --ws-brand-dark-10: 123 123 123;  /* gray-10 */
+  --ws-brand-dark-11: 180 180 180;  /* gray-11 - text on dark */
+  --ws-brand-dark-12: 238 238 238;  /* gray-12 */
+
+  /* Active brand scale (light by default; dark block swaps it below). */
+  --ws-brand-1: var(--ws-brand-light-1);
+  --ws-brand-2: var(--ws-brand-light-2);
+  --ws-brand-3: var(--ws-brand-light-3);
+  --ws-brand-4: var(--ws-brand-light-4);
+  --ws-brand-5: var(--ws-brand-light-5);
+  --ws-brand-6: var(--ws-brand-light-6);
+  --ws-brand-7: var(--ws-brand-light-7);
+  --ws-brand-8: var(--ws-brand-light-8);
+  --ws-brand-9: var(--ws-brand-light-9);
+  --ws-brand-10: var(--ws-brand-light-10);
+  --ws-brand-11: var(--ws-brand-light-11);
+  --ws-brand-12: var(--ws-brand-light-12);
+}
+
+/* Dark theme (Settings -> Theme / top-bar switch): the semantic tokens swap
+   to the Radix slate dark scale + dark status steps (text on dark). Brand
+   follows the runtime-set dark accent scale. applyTheme() sets data-theme
+   on <html>. */
+[data-theme='dark'] {
+  color-scheme: dark;
+
+  /* Surfaces (Radix slate dark). */
+  --ws-surface: 17 17 19;       /* slate-1 - page bg */
+  --ws-surface-1: 24 25 27;     /* slate-2 - subtle bg (floating panels) */
+  --ws-surface-2: 33 34 37;     /* slate-3 - card bg */
+  --ws-surface-3: 39 42 45;     /* slate-4 - inset/input bg */
+  --ws-surface-4: 46 49 53;     /* slate-5 - hover/active bg */
+
+  /* Ink (Radix slate dark). */
+  --ws-ink-1: 237 238 240;      /* slate-12 - primary text */
+  --ws-ink-2: 176 180 186;      /* slate-11 - secondary text */
+  --ws-ink-3: 119 123 132;      /* slate-10 - tertiary/captions */
+
+  /* Lines (Radix slate dark). */
+  --ws-line: 54 58 63;          /* slate-6 - hairlines */
+  --ws-line-2: 67 72 78;        /* slate-7 - stronger borders */
+
+  /* Semantic (Radix status scales, step 11 = text on dark). */
+  --ws-success: 61 214 140;     /* green-11 */
+  --ws-warning: 255 202 22;     /* amber-11 */
+  --ws-danger: 255 149 146;     /* red-11 */
+
+  /* Brand: the runtime-set dark accent scale (accent-colors.ts). */
+  --ws-brand-1: var(--ws-brand-dark-1);
+  --ws-brand-2: var(--ws-brand-dark-2);
+  --ws-brand-3: var(--ws-brand-dark-3);
+  --ws-brand-4: var(--ws-brand-dark-4);
+  --ws-brand-5: var(--ws-brand-dark-5);
+  --ws-brand-6: var(--ws-brand-dark-6);
+  --ws-brand-7: var(--ws-brand-dark-7);
+  --ws-brand-8: var(--ws-brand-dark-8);
+  --ws-brand-9: var(--ws-brand-dark-9);
+  --ws-brand-10: var(--ws-brand-dark-10);
+  --ws-brand-11: var(--ws-brand-dark-11);
+  --ws-brand-12: var(--ws-brand-dark-12);
 }
 
 /* Always show the scrollbar: prevents a feedback loop where content height

--- a/apps/web/src/settings/accent-colors.ts
+++ b/apps/web/src/settings/accent-colors.ts
@@ -10,6 +10,14 @@
  */
 
 import { jade, gray, indigo, orange, mint, sky } from '@radix-ui/colors'
+import {
+  jadeDark,
+  grayDark,
+  indigoDark,
+  orangeDark,
+  mintDark,
+  skyDark,
+} from '@radix-ui/colors'
 import type { AccentTheme } from './types'
 
 /** #rrggbb -> "r g b" (Tailwind <alpha-value> triple format). */
@@ -26,7 +34,7 @@ function toScale(name: string, colors: Record<string, string>): Record<string, s
   return out
 }
 
-/** rgb-triple values for each accent scale (steps 1-12). */
+/** rgb-triple values for each accent scale (steps 1-12, light theme). */
 export const ACCENT_SCALE_TRIPLES: Record<AccentTheme, Record<string, string>> = {
   jade: toScale('jade', jade),
   gray: toScale('gray', gray),
@@ -36,16 +44,29 @@ export const ACCENT_SCALE_TRIPLES: Record<AccentTheme, Record<string, string>> =
   sky: toScale('sky', sky),
 }
 
+/** rgb-triple values for each accent scale (steps 1-12, dark theme). */
+export const ACCENT_SCALE_DARK_TRIPLES: Record<AccentTheme, Record<string, string>> = {
+  jade: toScale('jade', jadeDark),
+  gray: toScale('gray', grayDark),
+  indigo: toScale('indigo', indigoDark),
+  orange: toScale('orange', orangeDark),
+  mint: toScale('mint', mintDark),
+  sky: toScale('sky', skyDark),
+}
+
 /**
- * Sync the `--ws-brand-N` CSS vars to the given accent scale (no-op outside
- * the browser). Called on accent change; the tailwind `brand-*` classes read
- * these vars, so the whole app - including module-kit rendered panels -
- * follows the selected theme.
+ * Sync the `--ws-brand-light-N` / `--ws-brand-dark-N` CSS vars to the given
+ * accent scale (no-op outside the browser). The active `--ws-brand-N` picks
+ * light or dark via the `[data-theme='dark']` rule in index.css, so the
+ * whole app - including module-kit rendered panels - follows the selected
+ * theme and accent.
  */
 export function setBrandAccentVars(accent: AccentTheme): void {
   if (typeof document === 'undefined') return
-  const scale = ACCENT_SCALE_TRIPLES[accent]
+  const light = ACCENT_SCALE_TRIPLES[accent]
+  const dark = ACCENT_SCALE_DARK_TRIPLES[accent]
   for (let i = 1; i <= 12; i++) {
-    document.documentElement.style.setProperty(`--ws-brand-${i}`, scale[String(i)])
+    document.documentElement.style.setProperty(`--ws-brand-light-${i}`, light[String(i)])
+    document.documentElement.style.setProperty(`--ws-brand-dark-${i}`, dark[String(i)])
   }
 }


### PR DESCRIPTION
### Summary

Implements the Dark / Light / System theme mode end to end, with a switch
button in the top toolbar. The theme setting existed but was half-wired:
`index.css` had only light tokens, the Radix `<Theme appearance>` was
hardcoded to `"light"`, and brand accent vars only received light-scale
values — so Dark/System rendered a light-looking app.

### Changes

- **`index.css`** — a full `[data-theme='dark']` token set: Radix slate dark
  surfaces/ink/line, dark status steps, `color-scheme: dark`. Brand vars now
  resolve through dual scales (`--ws-brand-light-N` / `--ws-brand-dark-N`) so
  the user's accent color follows the theme.
- **`settings/accent-colors.ts`** — `setBrandAccentVars` writes both scales;
  gray fallbacks stay in `:root` for pre-boot.
- **`App.tsx`** — Radix `<Theme appearance={resolvedTheme}>` follows the
  resolved mode (Light / Dark / System), so Radix components match the token
  layer.
- **`components/shell.tsx`** — new `ThemeSwitchButton` in the top bar: a
  sun/moon/laptop icon button opening a Light / Dark / System dropdown with
  the current mode indicated. It writes the same persisted setting as
  Settings → General → Theme, so both UIs stay in sync; System follows the OS
  preference live.

### Tests

- New `e2e/theme-mode.spec.ts` (2 tests): Light/Dark apply the token layer
  and persist on reload; System follows the OS color scheme live (via CDP
  emulation, which fires `matchMedia` change events — `page.emulateMedia`
  does not).
- Full re-verification: typecheck + lint clean, 220 unit tests, 23 e2e tests.

Closes #142
