### PR TITLE
fix(studio-backend): resolve registry cwd relative to the registry file (#144)

### DIFF
--- a/apps/studio-backend/src/wake_training_service/cli.py
+++ b/apps/studio-backend/src/wake_training_service/cli.py
@@ -61,7 +61,10 @@ def main(argv: list[str] | None = None) -> int:
         print("[wake-service] create one (see README.md §Registry) or pass --registry", file=sys.stderr)
         return 2
 
-    registry = Registry.load(registry_path, base_dir=Path.cwd())
+    # Relative cwd entries in the registry resolve against the registry file's
+    # directory (Registry.load default), not the process cwd - so the service
+    # can be launched from anywhere (README: run from the repo root).
+    registry = Registry.load(registry_path)
     store = Store(args.db)
     auth = Auth(args.token or None)
     manager = JobManager(


### PR DESCRIPTION
## Problem
Submitting a **dry-run** training job fails when `wake-service` is launched from the repo root (the README quick-start):

```
module 'dry-run' cwd does not exist: /Users/coocaa/Documents/packages/modules/dry-run/train
```

The resolved path is missing the `vscode/wake-studio` segment.

## Root cause
`cli.py` loaded the registry with `base_dir=Path.cwd()`. The registry's relative `cwd` entries (`../../packages/modules/dry-run/train`) are relative to the **registry file's directory** (`apps/studio-backend`), so launching from the repo root made `../../` climb two levels above the repo instead of two levels from `apps/studio-backend`.

## Fix
Drop the `base_dir` override and let `Registry.load` keep its default: the registry file's own directory. Relative paths now resolve correctly no matter where the service is launched from. The Colab launcher is untouched (it builds a one-module registry from explicit CLI args).

## Verification
- `uv run pytest` in `apps/studio-backend`: **25 passed**.
- Live check against a restarted service (port 4824): dry-run job → **exit 0**, bundle artifact `wake-studio-results.zip` produced.
- Job store shows the pre-fix failure and the post-fix successes.

Closes #144