### PR TITLE
fix(studio-backend): download cloudflared binary instead of pip install (#146)

### DIFF
--- a/apps/studio-backend/src/wake_training_service/colab_launcher.py
+++ b/apps/studio-backend/src/wake_training_service/colab_launcher.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import platform
 import re
 import secrets
 import shutil
@@ -58,23 +59,66 @@ def parse_tunnel_url(line: str) -> str | None:
     return m.group(0) if m else None
 
 
+def cloudflared_download_url(arch: str | None = None) -> str:
+    """GitHub latest-release URL for the cloudflared binary for `arch`.
+
+    Maps the local machine arch to the release asset name
+    (cloudflared-linux-<goarch>). Pass arch explicitly to test the mapping.
+    """
+    goarch = {
+        "x86_64": "amd64", "amd64": "amd64", "i386": "386", "i686": "386",
+        "aarch64": "arm64", "arm64": "arm64", "armv7l": "arm", "armv6l": "arm",
+    }.get((arch or platform.machine()).lower())
+    if goarch is None:
+        raise RuntimeError(
+            "unsupported platform for automatic cloudflared download: "
+            f"{arch or platform.machine()}"
+        )
+    return (
+        "https://github.com/cloudflare/cloudflared/releases/latest/download/"
+        f"cloudflared-linux-{goarch}"
+    )
+
+
+def _download_cloudflared(dest: Path, print_fn: Callable[[str], None]) -> None:
+    """Download the cloudflared binary to `dest` (user-writable, no root)."""
+    url = cloudflared_download_url()
+    print_fn(f"[wake-colab] downloading cloudflared ({url}) …")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(dest.name + ".part")
+    try:
+        with urllib.request.urlopen(url, timeout=180) as res, tmp.open("wb") as out:
+            shutil.copyfileobj(res, out)
+        os.chmod(tmp, 0o755)
+        # sanity check: a real binary must run and report a version
+        subprocess.run([str(tmp), "--version"], capture_output=True, timeout=30, check=True)
+        tmp.replace(dest)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
 def find_or_install_cloudflared(print_fn: Callable[[str], None] = print) -> str:
-    """Locate the cloudflared binary; pip-install it if missing (no root)."""
+    """Locate the cloudflared binary; download it if missing (no root).
+
+    The old `pip install cloudflared` route is gone — the PyPI package no
+    longer exists (404). Cloudflare ships standalone binaries only, so we
+    fetch the GitHub latest release into ~/.local/bin (ADR-023).
+    """
     found = shutil.which("cloudflared")
     if found:
         return found
-    print_fn("[wake-colab] cloudflared not found — installing via pip …")
-    subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-q", "cloudflared"],
-        check=False,
-    )
-    found = shutil.which("cloudflared")
-    if not found:
+    dest = Path.home() / ".local" / "bin" / "cloudflared"
+    if dest.is_file():
+        return str(dest)
+    try:
+        _download_cloudflared(dest, print_fn)
+    except Exception as exc:  # noqa: BLE001
         raise RuntimeError(
-            "cloudflared is not available and pip install failed. "
-            "Install it manually (https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)."
-        )
-    return found
+            f"cloudflared is not available and the automatic download failed: {exc}. "
+            "Install it manually (https://developers.cloudflare.com/tunnel/downloads/), "
+            "put it on PATH, or pass cloudflared=<path> to launch()."
+        ) from exc
+    return str(dest)
 
 
 class ColabLauncher:

--- a/apps/studio-backend/tests/test_colab_launcher.py
+++ b/apps/studio-backend/tests/test_colab_launcher.py
@@ -7,13 +7,21 @@ the real service (uvicorn thread) with a fake tunnel and checks /health.
 
 import io
 import json
+import shutil
 import socket
+import subprocess
 import threading
 import time
+import urllib.error
 import urllib.request
+from pathlib import Path
+
+import pytest
 
 from wake_training_service.colab_launcher import (
     ColabLauncher,
+    cloudflared_download_url,
+    find_or_install_cloudflared,
     launch,
     parse_tunnel_url,
 )
@@ -134,6 +142,87 @@ def test_stop_terminates_monitor():
     launcher.stop()
     thread.join(timeout=5)
     assert not thread.is_alive()
+
+
+def test_cloudflared_download_url_mapping():
+    # arch -> GitHub latest-release asset name for the standalone binary
+    assert cloudflared_download_url("x86_64") == (
+        "https://github.com/cloudflare/cloudflared/releases/latest/download/"
+        "cloudflared-linux-amd64"
+    )
+    assert cloudflared_download_url("aarch64") == (
+        "https://github.com/cloudflare/cloudflared/releases/latest/download/"
+        "cloudflared-linux-arm64"
+    )
+    assert cloudflared_download_url("armv7l") == (
+        "https://github.com/cloudflare/cloudflared/releases/latest/download/"
+        "cloudflared-linux-arm"
+    )
+    with pytest.raises(RuntimeError, match="unsupported platform"):
+        cloudflared_download_url("sparc64")
+
+
+def test_find_or_install_uses_path_binary(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/cloudflared")
+    assert find_or_install_cloudflared(quiet) == "/usr/local/bin/cloudflared"
+
+
+def test_find_or_install_downloads_binary(monkeypatch, tmp_path):
+    # pip is dead (PyPI 404): the fallback downloads the GitHub binary
+    # into ~/.local/bin, chmods it, and sanity-checks it runs.
+    calls: dict[str, object] = {}
+
+    class FakeResp:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self, n: int = -1) -> bytes:
+            data = self._data
+            self._data = b""
+            return data
+
+    def fake_urlopen(url: str, timeout: int = 180):
+        calls["url"] = url
+        return FakeResp(b"#!/bin/sh\necho cloudflared 2024.1.1\n")
+
+    def fake_run(cmd: list[str], **_kwargs):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(
+        "wake_training_service.colab_launcher.urllib.request.urlopen", fake_urlopen
+    )
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    out = find_or_install_cloudflared(quiet)
+    assert out == str(tmp_path / ".local" / "bin" / "cloudflared")
+    assert "cloudflared-linux-" in str(calls["url"])
+    # sanity-check runs against the .part file BEFORE the final rename
+    assert calls["cmd"] == [
+        str(tmp_path / ".local" / "bin" / "cloudflared.part"), "--version"
+    ]
+    assert Path(out).is_file()
+
+
+def test_find_or_install_download_failure_raises(monkeypatch, tmp_path):
+    def boom(url: str, timeout: int = 180):
+        raise urllib.error.URLError("no network")
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(
+        "wake_training_service.colab_launcher.urllib.request.urlopen", boom
+    )
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="Install it manually"):
+        find_or_install_cloudflared(quiet)
 
 
 def test_launch_starts_service_health_ok(tmp_path):

--- a/docs/training-console.plan.md
+++ b/docs/training-console.plan.md
@@ -84,8 +84,9 @@ manual zip round-trip).
 ### Details
 
 - cloudflared works from Colab: it makes an *outbound* connection to
-  Cloudflare's edge, which Colab's sandbox allows. Install via
-  `pip install cloudflared` or the static binary; no root needed.
+  Cloudflare's edge, which Colab's sandbox allows. Install via the
+  launcher's automatic binary download (GitHub latest release →
+  `~/.local/bin`) or a static binary; no root needed.
 - CORS: the in-notebook server sets `Access-Control-Allow-Origin: *` (we own
   it, so this is trivial). No mixed-content issue — PWA and tunnel are both HTTPS.
 - Security: the URL is unguessable but treat it as public; never send


### PR DESCRIPTION
## Problem
The Colab launcher fails to bring up the trycloudflare tunnel on fresh runtimes:

```
[wake-colab] cloudflared not found — installing via pip …
[wake-colab] failed to start cloudflared: cloudflared is not available and pip install failed.
Tunnel did not come up
```

## Root cause
`pip install cloudflared` can never succeed: the PyPI package no longer exists (`https://pypi.org/pypi/cloudflared/json` → **404**). Cloudflare publishes standalone binaries only (GitHub releases).

## Fix
`find_or_install_cloudflared` now:
1. Keeps PATH lookup first (and reuses a cached `~/.local/bin/cloudflared`).
2. Downloads `cloudflared-linux-<arch>` from the GitHub latest release into `~/.local/bin` — user-writable, no root needed on Colab.
3. chmod +x and sanity-checks `cloudflared --version` **before** renaming the `.part` file into place (a corrupted/HTML download fails fast).
4. Keeps the manual-install error as the final fallback, now also hinting at `cloudflared=<path>` in `launch()`.

Docs: `docs/training-console.plan.md` no longer advertises the dead `pip install cloudflared`.

## Verification
- `uv run pytest` in `apps/studio-backend`: **29 passed** (25 existing + 4 new: arch→asset mapping, PATH lookup, download + .part sanity-check, download-failure error).

Closes #146