### PR TITLE
fix(web): register dry-run demo module in the Colab backend notebook (#148)

### DIFF
--- a/apps/web/src/backends/__tests__/backend-notebook.test.ts
+++ b/apps/web/src/backends/__tests__/backend-notebook.test.ts
@@ -40,6 +40,15 @@ describe('backend notebook template', () => {
     expect(src).toContain('trycloudflare')
   })
 
+  it('registers the dry-run demo module so jobs work on a generic runtime', () => {
+    const src = buildBackendNotebook()
+      .map((c) => c.source.join(''))
+      .join('\n')
+    expect(src).toContain('"dry-run": {')
+    expect(src).toContain('dry_run.py')
+    expect(src).toContain('WAKE_PHRASE')
+  })
+
   it('downloads under the stable filename', () => {
     expect(BACKEND_NOTEBOOK_FILENAME).toBe('studio-backend.ipynb')
   })

--- a/apps/web/src/backends/backend-notebook.ts
+++ b/apps/web/src/backends/backend-notebook.ts
@@ -56,6 +56,9 @@ const CODE_LAUNCH = `# --- Start the studio-backend service + tunnel -----------
 # Installs the service from this repo (pinned to main) and starts it with the
 # colab launcher: service thread + cloudflared, URL printed, fresh URL on
 # reconnect (issue #123). The service reports instance=short-term via /health.
+# The dry-run demo module is fetched alongside (stdlib-only trainer: ~1s, no
+# GPU/data) and registered as 'dry-run', so the full wizard flow can be
+# exercised against this runtime too.
 import os, secrets
 
 !pip install -q "git+https://github.com/awareride/wake-studio@main#subdirectory=apps/studio-backend"
@@ -65,8 +68,26 @@ from wake_training_service.colab_launcher import launch
 
 WAKE_SERVICE_TOKEN = WAKE_SERVICE_TOKEN or secrets.token_urlsafe(24)
 
+# Fetch the dry-run demo trainer (runs anywhere: stdlib only, ~1s, no GPU/data).
+DRY_RUN_DIR = os.path.abspath("./wake-studio-runtime/dry-run")
+os.makedirs(DRY_RUN_DIR, exist_ok=True)
+!curl -fsSL "https://raw.githubusercontent.com/awareride/wake-studio/main/packages/modules/dry-run/train/dry_run.py" -o "{DRY_RUN_DIR}/dry_run.py"
+if not os.path.isfile(os.path.join(DRY_RUN_DIR, "dry_run.py")):
+    raise SystemExit("failed to fetch the dry-run demo module - check your network")
+
 launcher = launch(
-    registry={},  # no module train scripts in this generic runtime
+    registry={
+        "dry-run": {
+            "cwd": DRY_RUN_DIR,
+            "engine": "direct",
+            "entry": "dry_run.py",
+            "env": {
+                "WAKE_PHRASE": "{params.wakePhrase}",
+                "WAKE_STEPS": "{params.steps}",
+                "WAKE_BACKEND": "self-hosted",
+            },
+        },
+    },
     port=WAKE_SERVICE_PORT,
     token=WAKE_SERVICE_TOKEN,
     instance="short-term",


### PR DESCRIPTION
## Problem
Connecting a backend via the generated **Free On Google Colab** notebook and submitting a **dry-run** job fails:

```
400: unknown module 'dry-run' (not in registry)
```

## Root cause
The generated notebook (`apps/web/src/backends/backend-notebook.ts`) started the launcher with `registry={}` — a generic runtime with no module train scripts.

## Fix
The dry-run demo trainer is the one module that needs zero setup (stdlib-only, ~1s, no GPU/data). The notebook now:
1. Fetches `packages/modules/dry-run/train/dry_run.py` from the repo (pinned to `main`, same as the `pip install` cell) into `wake-studio-runtime/dry-run/`.
2. Fails fast with a clear message if the fetch fails.
3. Registers it as `dry-run` with the `WAKE_PHRASE`/`WAKE_STEPS`/`WAKE_BACKEND` env mapping (same contract as `apps/studio-backend/registry.json`).

The `wake_train_kit.report` reporter (used by `dry_run.py`) ships with the studio-backend package, so the script's reporter import resolves on Colab too.

## Verification
- New unit test asserts the notebook registers `dry-run` + env mapping.
- `pnpm typecheck`: clean. `pnpm vitest run`: **221 passed** (16 files).
- Rendered the generated launch cell — valid Python, `{params.wakePhrase}` templating intact (no TS interpolation).

Closes #148