### PR TITLE
feat(training): Retry button re-submits a finished job (#150)

### DIFF
--- a/apps/web/src/training/console/TrainDetails.tsx
+++ b/apps/web/src/training/console/TrainDetails.tsx
@@ -43,6 +43,8 @@ export interface TrainDetailsProps {
   onTunnelUrlChange: (url: string) => void
   /** Submit the Colab job to the pasted tunnel URL (issue #122). */
   onConnectColab: () => void
+  /** Retry this run: re-submit the same module/params as a fresh job. */
+  onRetry: () => void
   /** Merge live studio-backend state into the recorded job (issue #122). */
   onLiveUpdate: (patch: StudioJobPatch) => void
   /** Delete this train from history (confirmed by the details pane). */
@@ -60,6 +62,7 @@ export function TrainDetails({
   onImported,
   onTunnelUrlChange,
   onConnectColab,
+  onRetry,
   onLiveUpdate,
   onDelete,
 }: TrainDetailsProps) {
@@ -268,6 +271,18 @@ export function TrainDetails({
                   Cancel
                 </Button>
               )}
+            </div>
+          )}
+
+          {/* Retry a finished run (same module + params, new job on the endpoint). */}
+          {!isActiveStatus(job.status) && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" size="1" variant="soft" onClick={onRetry}>
+                Retry
+              </Button>
+              <span className="text-[11px] text-ink-3">
+                Re-submits the same config as a fresh run.
+              </span>
             </div>
           )}
 

--- a/apps/web/src/training/console/TrainingConsole.tsx
+++ b/apps/web/src/training/console/TrainingConsole.tsx
@@ -19,6 +19,7 @@ import { Button } from '@radix-ui/themes'
 import {
   backendForMethod,
   importedJob,
+  retriedJob,
   sortJobsNewestFirst,
   startedJob,
   upsertJob,
@@ -239,6 +240,67 @@ export function TrainingConsole() {
     [platform, patchJob],
   )
 
+  // Retry a finished run: re-submit the same module/params as a fresh job on
+  // the same endpoint (new id, new list entry). Studio-backend jobs re-target
+  // their managed backend; Colab jobs re-target the pasted tunnel URL.
+  const handleRetry = useCallback(
+    (job: HistoryJob) => {
+      const id = `train-${Date.now()}`
+      const fresh = retriedJob(job, id)
+      const fail = (error: string) => {
+        recordJob({ ...fresh, status: 'failed', error, finishedAtMs: Date.now() })
+        setView({ kind: 'details', jobId: id })
+      }
+
+      if (job.method === 'studio-backend') {
+        const backend = job.backendId ? backends.find((b) => b.id === job.backendId) : undefined
+        const endpoint = backend?.baseUrl ?? job.endpoint
+        if (!endpoint) {
+          fail('No studio-backend endpoint to retry against — add the backend again.')
+          return
+        }
+        recordJob({ ...fresh, endpoint, backendId: job.backendId })
+        setView({ kind: 'details', jobId: id })
+        const client = createStudioClient(endpoint, backend?.token || undefined)
+        void client
+          .createJob(job.moduleId, job.params, id)
+          .then(() => patchJob(id, { submitted: true }))
+          .catch((err: unknown) =>
+            patchJob(id, {
+              status: 'failed',
+              error: err instanceof Error ? err.message : String(err),
+              finishedAtMs: Date.now(),
+            }),
+          )
+      } else if (job.method === 'colab') {
+        const endpoint = job.endpoint ?? job.tunnelUrl
+        if (!endpoint) {
+          fail('No Colab tunnel URL — paste one first, then retry.')
+          return
+        }
+        const token = platform['backend.apiKey'] || platform['backend.secret'] || undefined
+        recordJob({ ...fresh, endpoint, ...(job.tunnelUrl ? { tunnelUrl: job.tunnelUrl } : {}) })
+        setView({ kind: 'details', jobId: id })
+        const client = createStudioClient(endpoint, token)
+        void client
+          .createJob(job.moduleId, job.params, id)
+          .then(() => patchJob(id, { submitted: true }))
+          .catch((err: unknown) =>
+            patchJob(id, {
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          )
+      } else {
+        // CI and other methods have no studio-backend endpoint to resubmit to;
+        // record a fresh queued run for traceability.
+        recordJob(fresh)
+        setView({ kind: 'details', jobId: id })
+      }
+      rememberSelection('training', id)
+    },
+    [backends, platform, recordJob, patchJob],
+  )
+
   // Colab import success: record/update the job, open its review.
   const handleImported = useCallback(
     (result: ColabImportResult) => {
@@ -335,6 +397,7 @@ export function TrainingConsole() {
                   onImported={handleImported}
                   onTunnelUrlChange={(url) => patchJob(selectedJob.id, { tunnelUrl: url }, true)}
                   onConnectColab={() => handleConnectColab(selectedJob)}
+                  onRetry={() => handleRetry(selectedJob)}
                   onLiveUpdate={(patch: StudioJobPatch) => patchJob(selectedJob.id, patch)}
                   onDelete={() => handleDeleteJob(selectedJob.id)}
                 />

--- a/packages/modules/training/core/history.ts
+++ b/packages/modules/training/core/history.ts
@@ -86,6 +86,19 @@ export function startedJob(input: StartedJobInput): HistoryJob {
   }
 }
 
+/** A fresh run that retries a past job: same module/method/backend/params,
+ *  new id and timestamp (the run is re-queued on its endpoint). */
+export function retriedJob(job: HistoryJob, id: string, startedAtMs?: number): HistoryJob {
+  return startedJob({
+    id,
+    moduleId: job.moduleId,
+    method: job.method,
+    backend: job.backend,
+    params: job.params,
+    startedAtMs,
+  })
+}
+
 /** Map an artifact-bundle backend to a train method id. */
 export function backendToMethod(backend: TrainingJob['backend']): TrainMethodId {
   switch (backend) {

--- a/packages/modules/training/core/index.ts
+++ b/packages/modules/training/core/index.ts
@@ -48,6 +48,7 @@ export {
 } from './methods'
 export {
   startedJob,
+  retriedJob,
   importedJob,
   backendToMethod,
   sortJobsNewestFirst,

--- a/packages/modules/training/tests/history.test.ts
+++ b/packages/modules/training/tests/history.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   startedJob,
+  retriedJob,
   importedJob,
   backendToMethod,
   sortJobsNewestFirst,
@@ -62,6 +63,29 @@ describe('startedJob', () => {
     })
     expect(job.startedAtMs).toBeGreaterThanOrEqual(before)
     expect(job.phrase).toBe('')
+  })
+})
+
+describe('retriedJob', () => {
+  it('re-queues a past job with the same module/method/backend/params and a new id', () => {
+    const original = startedJob({
+      id: 'train-original',
+      moduleId: 'dry-run',
+      method: 'studio-backend',
+      backend: 'self-hosted',
+      params: { wakePhrase: 'hey studio', steps: '5' },
+      startedAtMs: 1_000,
+    })
+    const retried = retriedJob(original, 'train-retry', 2_000)
+    expect(retried.id).toBe('train-retry')
+    expect(retried.status).toBe('queued')
+    expect(retried.moduleId).toBe('dry-run')
+    expect(retried.method).toBe('studio-backend')
+    expect(retried.backend).toBe('self-hosted')
+    expect(retried.params).toEqual({ wakePhrase: 'hey studio', steps: '5' })
+    expect(retried.phrase).toBe('hey studio')
+    expect(retried.startedAtMs).toBe(2_000)
+    expect(retried.artifactRef).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## What
Adds a **Retry** button in the training console's details pane (live-status section) for tracked jobs in a terminal state (succeeded / failed / canceled). Clicking it re-submits the same module + params as a fresh run on the same endpoint and opens the new run's details.

## Behavior
- **studio-backend** → re-targets the managed backend (baseUrl + token) and `POST /jobs` with a new id.
- **colab** → re-targets the pasted tunnel URL and `POST /jobs`.
- **other methods** → records a fresh queued run (no backend to resubmit to).
- Missing endpoint → records the run as failed with a clear error.

## Changes
- `packages/modules/training/core/history.ts`: new pure helper `retriedJob()` (same module/method/backend/params, new id/timestamp).
- `apps/web/src/training/console/TrainingConsole.tsx`: `handleRetry()` wiring + `onRetry` prop.
- `apps/web/src/training/console/TrainDetails.tsx`: Retry button + hint in the live-status actions.

## Verification
- `packages/modules/training`: **62 tests pass** (new `retriedJob` test included).
- `apps/web`: **221 tests pass**, `pnpm typecheck` clean, `pnpm lint` 0 errors.

Closes #150