### PR TITLE
feat(web): Colab Params form for token / port / revision (#159)

### DIFF
--- a/apps/studio-backend/src/wake_training_service/manager.py
+++ b/apps/studio-backend/src/wake_training_service/manager.py
@@ -22,7 +22,8 @@ from typing import Any
 
 from .models import CAN_CANCEL, CAN_PAUSE, CAN_START, Job, JobStatus, now_ms
 from .ndjson import parse_report_line
-from .registry import ModuleStager, Registry, RegistryError
+from .registry import Registry, RegistryError
+from .staging import ModuleStager
 from .store import Store
 
 TERM_GRACE_SECONDS = 5.0

--- a/apps/studio-backend/src/wake_training_service/registry.py
+++ b/apps/studio-backend/src/wake_training_service/registry.py
@@ -20,6 +20,10 @@ WAKE_<UPPER_KEY> per param - matching the notebook env convention
 (module.spec.json) remains the source of truth in the repo; the registry is
 the service's runtime view of it (a future step can generate it from specs).
 
+Asset provisioning for generic runtimes (Colab) lives in ``staging.py``
+(ModuleStager + revision resolution); ``registry.py`` stays "how to run a
+module".
+
 Entries may declare a ``stage`` spec (generic runtimes - e.g. Colab - have no
 repo checkout; the service stages the module's assets from the repo tarball
 on demand, driven by the job's moduleId - see ModuleStager).
@@ -30,50 +34,10 @@ from __future__ import annotations
 import json
 import os
 import re
-import tarfile
-import urllib.request
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 _TMPL = re.compile(r"\{([^}]+)\}")
-
-#: Repo tarball used by ModuleStager to stage module assets on demand.
-#: Fetch from the GitHub API tarball endpoint at the service's OWN build
-#: revision (baked into the wheel at build time, #159 option A) so the
-#: installed wheel and the staged module code can never drift; falls back to
-#: "main" when the revision metadata is absent (plain-directory builds).
-def _baked_revision() -> str:
-    try:
-        from wake_training_service import _revision  # type: ignore[attr-defined]
-
-        rev = getattr(_revision, "REVISION", "") or ""
-    except Exception:  # noqa: BLE001 - baked file missing (repo checkout / sdist)
-        rev = ""
-    return rev if rev else "main"
-
-
-def _staging_revision() -> str:
-    """Revision used for module staging: explicit override > baked wheel > main.
-
-    The Colab launcher notebook passes the Params-form ``REVISION`` value via
-    ``WAKE_REVISION`` (option A', #159) so the user's explicit choice wins
-    even if a stale wheel cached a different baked revision; self-hosted/CLI
-    runs without the env fall back to the wheel's baked revision (the two are
-    identical when the wheel was built from the pinned commit).
-    """
-    override = os.environ.get("WAKE_REVISION", "").strip()
-    if override:
-        return override
-    return _baked_revision()
-
-
-def repo_tarball_url(revision: str | None = None) -> str:
-    """GitHub API tarball endpoint - accepts a branch, tag, or commit SHA."""
-    return (
-        "https://api.github.com/repos/awareride/wake-studio/tarball/"
-        f"{revision or _staging_revision()}"
-    )
-
 
 class RegistryError(ValueError):
     pass
@@ -168,111 +132,6 @@ class Registry:
         for arg in entry.get("args", []):
             cmd.append(_render(arg, params, env))
         return cmd, str(cwd), env
-
-
-def _default_fetch(url: str, dest: Path) -> None:
-    """Stream-download a URL to ``dest`` (stdlib)."""
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    req = urllib.request.Request(url, headers={"User-Agent": "wake-studio"})
-    with urllib.request.urlopen(req, timeout=120) as res, dest.open("wb") as out:
-        while True:
-            chunk = res.read(1 << 16)
-            if not chunk:
-                break
-            out.write(chunk)
-
-
-class ModuleStager:
-    """Stage registered-module assets on demand (generic runtimes, #159).
-
-    A Colab/generic runtime has no repo checkout, so the notebook stays
-    generic and the service provisions whatever module the job names: on the
-    first job for a module with a ``stage`` spec, the repo tarball is fetched
-    once and the module's declared paths are extracted under ``staged_root``.
-    Subsequent jobs reuse the staged tree (idempotent, no re-fetch).
-
-    Stage spec (per registry entry):
-
-        "stage": {
-          "paths": ["packages/modules/kws/streaming/train", "third_party/..."],
-          "cwd":   "packages/modules/kws/streaming/train",   // staged-root-relative
-          "env":   {"UPSTREAM_DIR": "third_party"}           // staged-root-relative
-        }
-    """
-
-    def __init__(
-        self,
-        staged_root: str | Path,
-        repo_url: str | None = None,
-        fetch: Callable[[str, Path], None] | None = None,
-    ) -> None:
-        self.staged_root = Path(staged_root)
-        self.repo_url = repo_url or repo_tarball_url()
-        self._fetch = fetch or _default_fetch
-        self._fetched = False
-
-    def prepare(
-        self, entry: dict[str, Any], base_dir: Path
-    ) -> tuple[Path, dict[str, str]] | None:
-        """-> (cwd, env overrides) if the entry stages assets, else None.
-
-        Returns None for entries without a stage spec (local repo checkout
-        layout - resolved against the registry base_dir as usual).
-        """
-        stage = entry.get("stage")
-        if not stage:
-            return None
-        script = entry.get("entry")
-        target = (self.staged_root / stage["cwd"]).resolve()
-        if (target / script).is_file():
-            return target, self._env_overrides(stage)
-        self._ensure_tarball()
-        self._extract(stage.get("paths", []))
-        if not (target / script).is_file():
-            raise RegistryError(
-                f"staged module '{entry.get('name', '?')}' missing entry "
-                f"{script} under {target}"
-            )
-        return target, self._env_overrides(stage)
-
-    def _env_overrides(self, stage: dict[str, Any]) -> dict[str, str]:
-        return {
-            k: str((self.staged_root / v).resolve())
-            for k, v in stage.get("env", {}).items()
-        }
-
-    def _ensure_tarball(self) -> None:
-        if self._fetched:
-            return
-        dest = self.staged_root / "_download" / "wake-studio.tar.gz"
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        self._fetch(self.repo_url, dest)
-        self._fetched = True
-
-    def _extract(self, paths: list[str]) -> None:
-        """Extract repo-root-relative ``paths`` under staged_root (strip top dir)."""
-        archive = self.staged_root / "_download" / "wake-studio.tar.gz"
-        with tarfile.open(archive) as tf:
-            top = next(
-                (m.name.split("/", 1)[0] for m in tf.getmembers() if m.name.count("/")),
-                None,
-            )
-            if not top:
-                raise RegistryError(f"repo tarball {archive} is empty")
-            wanted = set()
-            for p in paths:
-                prefix = f"{top}/{p.strip('/')}"
-                wanted.update(
-                    m.name for m in tf.getmembers() if m.name == prefix or m.name.startswith(prefix + "/")
-                )
-            members = [m for m in tf.getmembers() if m.name in wanted]
-            for m in members:
-                m.name = m.name[len(top) + 1:]
-            try:
-                tf.extractall(self.staged_root, members=members, filter="data")
-            except TypeError:  # python < 3.12 (tarfile without filter kwarg)
-                tf.extractall(self.staged_root, members=members)
-            self.staged_root.mkdir(parents=True, exist_ok=True)
 
 
 def sys_executable() -> str:

--- a/apps/studio-backend/src/wake_training_service/registry.py
+++ b/apps/studio-backend/src/wake_training_service/registry.py
@@ -52,11 +52,26 @@ def _baked_revision() -> str:
     return rev if rev else "main"
 
 
+def _staging_revision() -> str:
+    """Revision used for module staging: explicit override > baked wheel > main.
+
+    The Colab launcher notebook passes the Params-form ``REVISION`` value via
+    ``WAKE_REVISION`` (option A', #159) so the user's explicit choice wins
+    even if a stale wheel cached a different baked revision; self-hosted/CLI
+    runs without the env fall back to the wheel's baked revision (the two are
+    identical when the wheel was built from the pinned commit).
+    """
+    override = os.environ.get("WAKE_REVISION", "").strip()
+    if override:
+        return override
+    return _baked_revision()
+
+
 def repo_tarball_url(revision: str | None = None) -> str:
     """GitHub API tarball endpoint - accepts a branch, tag, or commit SHA."""
     return (
         "https://api.github.com/repos/awareride/wake-studio/tarball/"
-        f"{revision or _baked_revision()}"
+        f"{revision or _staging_revision()}"
     )
 
 

--- a/apps/studio-backend/src/wake_training_service/staging.py
+++ b/apps/studio-backend/src/wake_training_service/staging.py
@@ -1,0 +1,165 @@
+"""Module asset provisioning (staging) for generic runtimes (#159).
+
+A Colab/generic runtime has no repo checkout; before the first job for a
+registered module, :class:`ModuleStager` provisions the module's assets from
+the repo tarball (extracted under ``staged_root``). The tarball revision is
+resolved by :func:`staging_revision`:
+
+1. **REVISION** - the Colab Params-form value, passed via the ``WAKE_REVISION``
+   env var (the user's explicit choice; default source whenever present),
+2. **baked wheel revision** - the commit the installed service was built from
+   (hatch build hook -> ``_revision.py``), so wheel and staged code never
+   drift, and
+3. **main** - last-resort fallback (plain directory/sdist builds).
+
+Split out of ``registry.py`` so the registry stays "how to run a module" and
+this stays "how to provision its assets" (ADR-028/036, #159).
+"""
+
+from __future__ import annotations
+
+import os
+import tarfile
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+from .registry import RegistryError
+
+
+def baked_revision() -> str:
+    """The git revision the installed wheel was built from ("" if unknown)."""
+    try:
+        from wake_training_service import _revision  # type: ignore[attr-defined]
+
+        return getattr(_revision, "REVISION", "") or ""
+    except Exception:  # noqa: BLE001 - baked file missing (repo checkout / sdist)
+        return ""
+
+
+def staging_revision() -> str:
+    """Revision used for module staging: REVISION env > baked wheel > main.
+
+    The Colab launcher notebook passes the Params-form ``REVISION`` value via
+    ``WAKE_REVISION`` (option A', #159) so the user's explicit choice is the
+    default source; self-hosted/CLI runs without the env use the wheel's baked
+    revision (identical when the wheel was built from the pinned commit).
+    """
+    override = os.environ.get("WAKE_REVISION", "").strip()
+    if override:
+        return override
+    return baked_revision() or "main"
+
+
+def repo_tarball_url(revision: str | None = None) -> str:
+    """GitHub API tarball endpoint - accepts a branch, tag, or commit SHA."""
+    return (
+        "https://api.github.com/repos/awareride/wake-studio/tarball/"
+        f"{revision or staging_revision()}"
+    )
+
+
+def _default_fetch(url: str, dest: Path) -> None:
+    """Stream-download a URL to ``dest`` (stdlib; follows redirects)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    req = urllib.request.Request(url, headers={"User-Agent": "wake-studio"})
+    with urllib.request.urlopen(req, timeout=120) as res, dest.open("wb") as out:
+        while True:
+            chunk = res.read(1 << 16)
+            if not chunk:
+                break
+            out.write(chunk)
+
+
+class ModuleStager:
+    """Stage registered-module assets on demand (generic runtimes, #159).
+
+    On the first job for a module with a ``stage`` spec, the repo tarball is
+    fetched once (at :func:`staging_revision`) and the module's declared paths
+    are extracted under ``staged_root``. Subsequent jobs reuse the staged tree
+    (idempotent, no re-fetch).
+
+    Stage spec (per registry entry):
+
+        "stage": {
+          "paths": ["packages/modules/kws/streaming/train", "third_party/..."],
+          "cwd":   "packages/modules/kws/streaming/train",   // staged-root-relative
+          "env":   {"UPSTREAM_DIR": "third_party"}           // staged-root-relative
+        }
+    """
+
+    def __init__(
+        self,
+        staged_root: str | Path,
+        repo_url: str | None = None,
+        fetch: Callable[[str, Path], None] | None = None,
+    ) -> None:
+        self.staged_root = Path(staged_root)
+        self.repo_url = repo_url or repo_tarball_url()
+        self._fetch = fetch or _default_fetch
+        self._fetched = False
+
+    def prepare(
+        self, entry: dict[str, Any], base_dir: Path
+    ) -> tuple[Path, dict[str, str]] | None:
+        """-> (cwd, env overrides) if the entry stages assets, else None.
+
+        Returns None for entries without a stage spec (local repo checkout
+        layout - resolved against the registry base_dir as usual).
+        """
+        stage = entry.get("stage")
+        if not stage:
+            return None
+        script = entry.get("entry")
+        target = (self.staged_root / stage["cwd"]).resolve()
+        if (target / script).is_file():
+            return target, self._env_overrides(stage)
+        self._ensure_tarball()
+        self._extract(stage.get("paths", []))
+        if not (target / script).is_file():
+            raise RegistryError(
+                f"staged module '{entry.get('name', '?')}' missing entry "
+                f"{script} under {target}"
+            )
+        return target, self._env_overrides(stage)
+
+    def _env_overrides(self, stage: dict[str, Any]) -> dict[str, str]:
+        return {
+            k: str((self.staged_root / v).resolve())
+            for k, v in stage.get("env", {}).items()
+        }
+
+    def _ensure_tarball(self) -> None:
+        if self._fetched:
+            return
+        dest = self.staged_root / "_download" / "wake-studio.tar.gz"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        self._fetch(self.repo_url, dest)
+        self._fetched = True
+
+    def _extract(self, paths: list[str]) -> None:
+        """Extract repo-root-relative ``paths`` under staged_root (strip top dir)."""
+        archive = self.staged_root / "_download" / "wake-studio.tar.gz"
+        with tarfile.open(archive) as tf:
+            top = next(
+                (m.name.split("/", 1)[0] for m in tf.getmembers() if m.name.count("/")),
+                None,
+            )
+            if not top:
+                raise RegistryError(f"repo tarball {archive} is empty")
+            wanted = set()
+            for p in paths:
+                prefix = f"{top}/{p.strip('/')}"
+                wanted.update(
+                    m.name
+                    for m in tf.getmembers()
+                    if m.name == prefix or m.name.startswith(prefix + "/")
+                )
+            members = [m for m in tf.getmembers() if m.name in wanted]
+            for m in members:
+                m.name = m.name[len(top) + 1:]
+            try:
+                tf.extractall(self.staged_root, members=members, filter="data")
+            except TypeError:  # python < 3.12 (tarfile without filter kwarg)
+                tf.extractall(self.staged_root, members=members)
+            self.staged_root.mkdir(parents=True, exist_ok=True)

--- a/apps/studio-backend/tests/test_registry.py
+++ b/apps/studio-backend/tests/test_registry.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from wake_training_service import registry
+from wake_training_service import registry, staging
 from wake_training_service.registry import Registry
 
 
@@ -58,40 +58,40 @@ def test_params_env_templating(tmp_path):
 
 def test_repo_tarball_url_pins_revision():
     # a SHA pins the tarball to that commit (GitHub API endpoint)
-    url = registry.repo_tarball_url("abc123")
+    url = staging.repo_tarball_url("abc123")
     assert url == "https://api.github.com/repos/awareride/wake-studio/tarball/abc123"
 
 
 def test_repo_tarball_url_falls_back_to_baked_or_main(monkeypatch):
-    # no baked _revision (repo checkout / sdist) -> main
-    monkeypatch.setattr(registry, "_baked_revision", lambda: "main")
-    assert registry.repo_tarball_url().endswith("/tarball/main")
+    # no baked revision (repo checkout / sdist) -> main
+    monkeypatch.setattr(staging, "baked_revision", lambda: "")
+    assert staging.repo_tarball_url().endswith("/tarball/main")
     # baked revision (wheel build) wins
-    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
-    assert registry.repo_tarball_url().endswith("/tarball/deadbeef")
+    monkeypatch.setattr(staging, "baked_revision", lambda: "deadbeef")
+    assert staging.repo_tarball_url().endswith("/tarball/deadbeef")
 
 
 def test_staging_revision_prefers_env_override(monkeypatch):
     # the Colab form passes WAKE_REVISION - explicit choice wins over baked
-    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
+    monkeypatch.setattr(staging, "baked_revision", lambda: "deadbeef")
     monkeypatch.setenv("WAKE_REVISION", "cafebabe")
-    assert registry._staging_revision() == "cafebabe"
-    assert registry.repo_tarball_url().endswith("/tarball/cafebabe")
+    assert staging.staging_revision() == "cafebabe"
+    assert staging.repo_tarball_url().endswith("/tarball/cafebabe")
 
 
 def test_staging_revision_falls_back_to_baked_without_env(monkeypatch):
     monkeypatch.delenv("WAKE_REVISION", raising=False)
-    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
-    assert registry._staging_revision() == "deadbeef"
+    monkeypatch.setattr(staging, "baked_revision", lambda: "deadbeef")
+    assert staging.staging_revision() == "deadbeef"
 
 
 def test_staging_revision_ignores_blank_env(monkeypatch):
     monkeypatch.setenv("WAKE_REVISION", "  ")
-    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
-    assert registry._staging_revision() == "deadbeef"
+    monkeypatch.setattr(staging, "baked_revision", lambda: "deadbeef")
+    assert staging.staging_revision() == "deadbeef"
 
 
 def test_stager_default_url_uses_repo_tarball_url(monkeypatch, tmp_path):
-    monkeypatch.setattr(registry, "repo_tarball_url", lambda: "https://example.com/tarball/x")
-    stager = registry.ModuleStager(staged_root=tmp_path / "staged")
+    monkeypatch.setattr(staging, "repo_tarball_url", lambda: "https://example.com/tarball/x")
+    stager = staging.ModuleStager(staged_root=tmp_path / "staged")
     assert stager.repo_url == "https://example.com/tarball/x"

--- a/apps/studio-backend/tests/test_registry.py
+++ b/apps/studio-backend/tests/test_registry.py
@@ -71,6 +71,26 @@ def test_repo_tarball_url_falls_back_to_baked_or_main(monkeypatch):
     assert registry.repo_tarball_url().endswith("/tarball/deadbeef")
 
 
+def test_staging_revision_prefers_env_override(monkeypatch):
+    # the Colab form passes WAKE_REVISION - explicit choice wins over baked
+    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
+    monkeypatch.setenv("WAKE_REVISION", "cafebabe")
+    assert registry._staging_revision() == "cafebabe"
+    assert registry.repo_tarball_url().endswith("/tarball/cafebabe")
+
+
+def test_staging_revision_falls_back_to_baked_without_env(monkeypatch):
+    monkeypatch.delenv("WAKE_REVISION", raising=False)
+    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
+    assert registry._staging_revision() == "deadbeef"
+
+
+def test_staging_revision_ignores_blank_env(monkeypatch):
+    monkeypatch.setenv("WAKE_REVISION", "  ")
+    monkeypatch.setattr(registry, "_baked_revision", lambda: "deadbeef")
+    assert registry._staging_revision() == "deadbeef"
+
+
 def test_stager_default_url_uses_repo_tarball_url(monkeypatch, tmp_path):
     monkeypatch.setattr(registry, "repo_tarball_url", lambda: "https://example.com/tarball/x")
     stager = registry.ModuleStager(staged_root=tmp_path / "staged")

--- a/apps/studio-backend/tests/test_stager.py
+++ b/apps/studio-backend/tests/test_stager.py
@@ -15,7 +15,8 @@ import pytest
 from wake_training_service.app import create_app
 from wake_training_service.auth import Auth
 from wake_training_service.models import JobStatus
-from wake_training_service.registry import ModuleStager, Registry
+from wake_training_service.registry import Registry
+from wake_training_service.staging import ModuleStager
 
 from conftest import FAKE_SCRIPT, make_manager
 

--- a/apps/web/src/backends/__tests__/backend-notebook.test.ts
+++ b/apps/web/src/backends/__tests__/backend-notebook.test.ts
@@ -70,6 +70,8 @@ describe('backend notebook template', () => {
     expect(src).toContain('REVISION = "main" #@param {type:"string"}')
     // the install line reads the form value (IPython $-expansion), not a baked string
     expect(src).toContain('@$REVISION#subdirectory=apps/studio-backend')
+    // the form value is handed to the service for staging (WAKE_REVISION)
+    expect(src).toContain('os.environ["WAKE_REVISION"] = REVISION')
   })
 
   it('seeds the REVISION form field with the resolved revision when given (#159)', () => {

--- a/apps/web/src/backends/__tests__/backend-notebook.test.ts
+++ b/apps/web/src/backends/__tests__/backend-notebook.test.ts
@@ -62,17 +62,22 @@ describe('backend notebook template', () => {
     expect(BACKEND_NOTEBOOK_FILENAME).toBe('studio-backend.ipynb')
   })
 
-  it('pins the notebook to the resolved revision when one is given (#159)', () => {
+  it('renders a Colab form panel for token / port / revision (#159)', () => {
+    const src = buildBackendNotebook().map((c) => c.source.join('')).join('\n')
+    expect(src).toContain('#@title Params')
+    expect(src).toContain('WAKE_SERVICE_TOKEN = "" #@param {type:"string"}')
+    expect(src).toContain('WAKE_SERVICE_PORT = 4824 #@param {type:"integer"}')
+    expect(src).toContain('REVISION = "main" #@param {type:"string"}')
+    // the install line reads the form value (IPython $-expansion), not a baked string
+    expect(src).toContain('@$REVISION#subdirectory=apps/studio-backend')
+  })
+
+  it('seeds the REVISION form field with the resolved revision when given (#159)', () => {
     const src = buildBackendNotebook('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2')
       .map((c) => c.source.join(''))
       .join('\n')
-    expect(src).toContain('@a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2#subdirectory=apps/studio-backend')
-    expect(src).toContain('Service revision: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2')
-  })
-
-  it('defaults to main when no revision is passed', () => {
-    const src = buildBackendNotebook().map((c) => c.source.join('')).join('\n')
-    expect(src).toContain('@main#subdirectory=apps/studio-backend')
+    expect(src).toContain('REVISION = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" #@param')
+    expect(src).toContain('Service revision: {REVISION}')
   })
 
   it('resolves the latest main revision from the GitHub API, falling back to main', async () => {

--- a/apps/web/src/backends/backend-notebook.ts
+++ b/apps/web/src/backends/backend-notebook.ts
@@ -84,6 +84,10 @@ from wake_training_service.colab_launcher import launch
 
 WAKE_SERVICE_TOKEN = WAKE_SERVICE_TOKEN or secrets.token_urlsafe(24)
 
+# Hand the Params-form REVISION to the service: module staging (ModuleStager /
+# _staging_revision) prefers this explicit value over the wheel's baked one.
+os.environ["WAKE_REVISION"] = REVISION
+
 RUNTIME = os.path.abspath("./wake-studio-runtime")
 os.makedirs(RUNTIME, exist_ok=True)
 

--- a/apps/web/src/backends/backend-notebook.ts
+++ b/apps/web/src/backends/backend-notebook.ts
@@ -44,28 +44,31 @@ training jobs, watch live progress, pause/resume/cancel, and pull artifacts
 > going; see the notebook output for details).
 `
 
-const CODE_PARAMS = `# --- Params (edit if needed) ---------------------------------------------
-import os
+const CODE_PARAMS = (revision: string) => `#@title Params
+# Colab input panel - edit before running, or run as-is.
 
-# Leave empty to generate a random token (printed in the last cell).
-WAKE_SERVICE_TOKEN = os.environ.get("WAKE_SERVICE_TOKEN", "")
-WAKE_SERVICE_PORT = int(os.environ.get("WAKE_SERVICE_PORT", "4824"))
+# Leave empty to auto-generate a random token (printed in the last cell).
+WAKE_SERVICE_TOKEN = "" #@param {type:"string"}
+WAKE_SERVICE_PORT = 4824 #@param {type:"integer"}
+
+# Service revision (option A', #159): the wheel bakes it and module staging
+# fetches it - the notebook, the installed service, and the staged module
+# code are one commit. Default = latest main resolved at download time;
+# override to pin an older commit.
+REVISION = "${revision}" #@param {type:"string"}
 `
 
-function codeLaunch(revision: string): string {
-  // The service is installed from the pinned revision the PWA resolved at
-  // download time (#159, option A'): the wheel bakes that same revision, and
-  // ModuleStager stages module assets from it - one commit for notebook,
-  // service, and staged module code. Falls back to main when the resolve
-  // failed (offline / rate limit) - the baked fallback then keeps wheel and
-  // staging consistent with each other.
-  const install =
-    `!pip install -q "studio-backend @ git+https://github.com/awareride/wake-studio@${revision}#subdirectory=apps/studio-backend"`
+function codeLaunch(): string {
+  // The service is installed at $REVISION - the value from the Params form
+  // (default = the revision the PWA resolved at download time, #159 option
+  // A'). The wheel bakes that same revision and ModuleStager stages module
+  // assets from it: one commit for notebook, service, and staged module
+  // code. IPython ! shell lines expand $REVISION from the Python namespace.
   return `# --- Start the studio-backend service + tunnel -----------------------------
-# Installs the service from this repo at revision \`${revision}\` (pinned at
-# download time; the wheel bakes the same revision and module staging fetches
-# the same commit - see ModuleStager / repo_tarball_url, #159). instance=short-
-# term so /health reports the Colab nature.
+# Installs the service from this repo at revision \`$REVISION\` (Params form;
+# the wheel bakes the same revision and module staging fetches the same
+# commit - see ModuleStager / repo_tarball_url, #159). instance=short-term so
+# /health reports the Colab nature.
 #
 # This notebook is GENERIC - it knows no module names. The service loads its
 # bundled registry (all registered modules) and stages each module's assets
@@ -74,7 +77,7 @@ function codeLaunch(revision: string): string {
 # without notebook changes.
 import os, secrets
 
-${install}
+!pip install -q "studio-backend @ git+https://github.com/awareride/wake-studio@$REVISION#subdirectory=apps/studio-backend"
 !pip install -q uv  # the service's train runner (ADR-028)
 
 from wake_training_service.colab_launcher import launch
@@ -84,7 +87,7 @@ WAKE_SERVICE_TOKEN = WAKE_SERVICE_TOKEN or secrets.token_urlsafe(24)
 RUNTIME = os.path.abspath("./wake-studio-runtime")
 os.makedirs(RUNTIME, exist_ok=True)
 
-print(f"Service revision: ${revision}")
+print(f"Service revision: {REVISION}")
 
 launcher = launch(
     port=WAKE_SERVICE_PORT,
@@ -144,8 +147,8 @@ function cell(cellType: 'markdown' | 'code', source: string): NotebookCell {
 export function buildBackendNotebook(revision: string = 'main'): NotebookCell[] {
   return [
     cell('markdown', MD_INTRO),
-    cell('code', CODE_PARAMS),
-    cell('code', codeLaunch(revision)),
+    cell('code', CODE_PARAMS(revision)),
+    cell('code', codeLaunch()),
   ]
 }
 


### PR DESCRIPTION
Part of #159 (Colab notebook UX).

The generated studio-backend notebook now opens with a **Colab input panel** instead of code-editing:

```python
#@title Params
WAKE_SERVICE_TOKEN = ""   #@param {type:"string"}    ← empty = auto-generate
WAKE_SERVICE_PORT = 4824    #@param {type:"integer"}
REVISION = "<sha>"         #@param {type:"string"}    ← resolved at download time, overridable
```

- The pip install line reads the value via IPython `$-expansion` (`@$REVISION`), so editing the form re-pins the install + staging without touching code
- The launch cell prints the effective revision
- Tests: form fields present, REVISION seeded from the resolved revision, install line references the variable (7 notebook tests pass); typecheck + lint clean

**Note:** the default REVISION is still resolved at download time (option A') - the form just makes it a first-class, editable input.