### PR TITLE
fix(web): stop BackendDetail GET /jobs storm (#166)

### DIFF
--- a/apps/web/src/views/BackendsView.tsx
+++ b/apps/web/src/views/BackendsView.tsx
@@ -16,7 +16,7 @@
  * - Health: `GET /health` on mount + every 30s + manual refresh.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, TextField } from '@radix-ui/themes'
 import { useAppSettings } from '../settings'
 import { createStudioClient } from '../training/studio-client'
@@ -278,7 +278,10 @@ function BackendDetail({ backend }: { backend: ManagedBackend }) {
   const [jobs, setJobs] = useState<StudioJob[] | null>(null)
   const [logs, setLogs] = useState<{ jobId: string; lines: string[] } | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const client = createStudioClient(backend.baseUrl, backend.token)
+  const client = useMemo(
+    () => createStudioClient(backend.baseUrl, backend.token),
+    [backend.baseUrl, backend.token],
+  )
 
   const loadJobs = useCallback(async () => {
     setError(null)


### PR DESCRIPTION
## Summary
Fixes the Backends detail pane storming the studio-backend `GET /jobs` endpoint (issue #166).

## Root cause
`BackendDetail` (`apps/web/src/views/BackendsView.tsx`) built a fresh `StudioClient` on every render:

```ts
const client = createStudioClient(backend.baseUrl, backend.token)
```

`loadJobs` is `useCallback(…, [client])` and the data effect is `useEffect(…, [loadJobs])`. Because `client` is a new object every render, `loadJobs` (and the effect) change identity every render. The effect calls `setJobs(await client.listJobs())`; the new array reference re-renders the component, which recreates `client`, which re-runs the effect — an **infinite render/fetch loop** against `GET /jobs`.

## Fix
Memoize the client on stable inputs so `loadJobs`/`openLogs` stay referentially stable:

```ts
const client = useMemo(
  () => createStudioClient(backend.baseUrl, backend.token),
  [backend.baseUrl, backend.token],
)
```

Now `GET /jobs` fires once on mount (plus the manual Refresh button).

## Verification
- `apps/web` `tsc --noEmit` and `eslint` pass.
- Audited other `createStudioClient` sites: `useStudioJob.ts` already wraps in `useMemo`; `TrainingConsole.tsx` call sites are inside `useCallback` action handlers (created on demand, not in render/effect deps).

Closes #166
