### PR TITLE
fix(kws): make kws_streaming train compatible with TensorFlow >= 2.16

### DIFF
--- a/apps/web/public/train/kws-streaming/train_adapter.py
+++ b/apps/web/public/train/kws-streaming/train_adapter.py
@@ -492,7 +492,12 @@ def main(argv: list[str] | None = None) -> int:
     # stage 2: upstream train (unmodified)
     reporter.emit("progress", step=2, total=len(STAGES), progress=2 / len(STAGES),
                   message="train")
-    train_dir.mkdir(parents=True, exist_ok=True)
+    # The upstream trainer (model_train_eval.py) creates ``train_dir`` itself and
+    # aborts with "model already exists" if the directory is already present, so
+    # we must not pre-create it here. Remove any output left by a previous run
+    # so each training pass starts from a clean directory.
+    if train_dir.exists():
+        shutil.rmtree(train_dir)
     env = dict(os.environ)
     env["PYTHONPATH"] = str(upstream_dir) + os.pathsep + env.get("PYTHONPATH", "")
     cmd = build_command(params, python, data_dir, str(train_dir), wanted)

--- a/packages/modules/kws/streaming/train/train_adapter.py
+++ b/packages/modules/kws/streaming/train/train_adapter.py
@@ -492,7 +492,12 @@ def main(argv: list[str] | None = None) -> int:
     # stage 2: upstream train (unmodified)
     reporter.emit("progress", step=2, total=len(STAGES), progress=2 / len(STAGES),
                   message="train")
-    train_dir.mkdir(parents=True, exist_ok=True)
+    # The upstream trainer (model_train_eval.py) creates ``train_dir`` itself and
+    # aborts with "model already exists" if the directory is already present, so
+    # we must not pre-create it here. Remove any output left by a previous run
+    # so each training pass starts from a clean directory.
+    if train_dir.exists():
+        shutil.rmtree(train_dir)
     env = dict(os.environ)
     env["PYTHONPATH"] = str(upstream_dir) + os.pathsep + env.get("PYTHONPATH", "")
     cmd = build_command(params, python, data_dir, str(train_dir), wanted)

--- a/third_party/kws_streaming/layers/compat.py
+++ b/third_party/kws_streaming/layers/compat.py
@@ -17,3 +17,19 @@
 
 import tensorflow.compat.v1 as tf1  # pylint: disable=unused-import
 import tensorflow.compat.v2 as tf  # pylint: disable=unused-import
+
+
+def smart_cond(pred, true_fn, false_fn, name=None):
+  """Version-agnostic wrapper around Keras' ``smart_cond``.
+
+  TensorFlow <= 2.15 exposed it at ``tf._keras_internal.utils.control_flow_util``;
+  from TensorFlow 2.16 Keras was split out of the core package and the internal
+  path was removed, leaving only the public ``tf.keras.utils.control_flow_util``
+  location. Prefer the public path and fall back to the old internal one so the
+  helper works regardless of the installed TensorFlow release.
+  """
+  try:
+    from tensorflow.keras.utils.control_flow_util import smart_cond as _smart_cond  # pytype: disable=import-error
+  except ImportError:  # TF <= 2.15 internal location
+    from tensorflow.compat.v2.keras.utils.control_flow_util import smart_cond as _smart_cond  # pytype: disable=import-error
+  return _smart_cond(pred, true_fn, false_fn, name=name)

--- a/third_party/kws_streaming/layers/non_scaling_dropout.py
+++ b/third_party/kws_streaming/layers/non_scaling_dropout.py
@@ -18,6 +18,7 @@
 import tensorflow as tf
 
 from kws_streaming.layers.compat import tf
+from kws_streaming.layers.compat import smart_cond
 from tensorflow.python.ops import array_ops  # pylint: disable=g-direct-tensorflow-import
 # TODO(b/171351822) migrate to tf v2 and improve imported dependency
 
@@ -40,7 +41,7 @@ class NonScalingDropout(tf.keras.layers.Dropout):
     if self.noise_shape is None:
       self.noise_shape = tf.shape(inputs)
 
-    return tf._keras_internal.utils.control_flow_util.smart_cond(  # pylint:disable=protected-access
+    return smart_cond(  # pylint:disable=protected-access
         training,
         lambda: self._non_scaling_drop_op(inputs),
         lambda: array_ops.identity(inputs),

--- a/third_party/kws_streaming/layers/random_shift.py
+++ b/third_party/kws_streaming/layers/random_shift.py
@@ -18,6 +18,7 @@
 import tensorflow as tf
 
 from kws_streaming.layers.compat import tf
+from kws_streaming.layers.compat import smart_cond
 from tensorflow.python.ops import array_ops  # pylint: disable=g-direct-tensorflow-import
 
 
@@ -112,7 +113,7 @@ class RandomShift(tf.keras.layers.Layer):
     if training is None:
       training = tf.keras.backend.learning_phase()
     # pylint: disable=g-long-lambda
-    return tf._keras_internal.utils.control_flow_util.smart_cond(  # pylint:disable=protected-access
+    return smart_cond(  # pylint:disable=protected-access
         training, lambda: random_shift(
             inputs,
             self.time_shift,

--- a/third_party/kws_streaming/layers/random_stretch_squeeze.py
+++ b/third_party/kws_streaming/layers/random_stretch_squeeze.py
@@ -17,6 +17,7 @@
 import tensorflow as tf
 
 from kws_streaming.layers.compat import tf
+from kws_streaming.layers.compat import smart_cond
 from tensorflow.python.ops import array_ops  # pylint: disable=g-direct-tensorflow-import
 
 
@@ -118,7 +119,7 @@ class RandomStretchSqueeze(tf.keras.layers.Layer):
       training = tf.keras.backend.learning_phase()
 
     # pylint: disable=g-long-lambda
-    return tf._keras_internal.utils.control_flow_util.smart_cond(  # pylint:disable=protected-access
+    return smart_cond(  # pylint:disable=protected-access
         training, lambda: random_stretch_squeeze(
             inputs,
             self.resample_offset,

--- a/third_party/kws_streaming/layers/spectrogram_augment.py
+++ b/third_party/kws_streaming/layers/spectrogram_augment.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 import tensorflow_model_optimization as tfmot
 
 from kws_streaming.layers.compat import tf
+from kws_streaming.layers.compat import smart_cond
 from tensorflow.python.ops import array_ops  # pylint: disable=g-direct-tensorflow-import
 
 
@@ -98,7 +99,7 @@ class SpecAugment(tf.keras.layers.Layer):
       )
       return net
 
-    outputs = tf._keras_internal.utils.control_flow_util.smart_cond(  # pylint:disable=protected-access
+    outputs = smart_cond(  # pylint:disable=protected-access
         training,
         masked_inputs,
         lambda: array_ops.identity(inputs),

--- a/third_party/kws_streaming/layers/spectrogram_cutout.py
+++ b/third_party/kws_streaming/layers/spectrogram_cutout.py
@@ -17,6 +17,7 @@
 import tensorflow as tf
 
 from kws_streaming.layers.compat import tf
+from kws_streaming.layers.compat import smart_cond
 from tensorflow.python.ops import array_ops  # pylint: disable=g-direct-tensorflow-import
 
 
@@ -162,7 +163,7 @@ class SpecCutout(tf.keras.layers.Layer):
       net = tf.keras.backend.squeeze(net, axis=-1)
       return net
 
-    outputs = tf._keras_internal.utils.control_flow_util.smart_cond(  # pylint:disable=protected-access
+    outputs = smart_cond(  # pylint:disable=protected-access
         training,
         masked_inputs,
         lambda: array_ops.identity(inputs),

--- a/third_party/kws_streaming/models/utils.py
+++ b/third_party/kws_streaming/models/utils.py
@@ -16,7 +16,6 @@
 """Utility functions for operations on Model."""
 import os.path
 import tempfile
-import importlib
 from typing import List, Optional, Sequence
 import numpy as np
 import tensorflow as tf
@@ -30,25 +29,17 @@ from kws_streaming.models import model_utils
 from kws_streaming.models import models as kws_models
 
 
-def _resolve_keras_internals():
-  """Locate the internal Keras modules that host the model clone helpers.
+def _clone_model(model, input_tensors):
+  """Clone model with configs, except of weights.
 
-  TensorFlow <= 2.15 bundles Keras inside ``tf._keras_internal``. From
-  TensorFlow 2.16 Keras was split into a standalone package and
-  ``tf._keras_internal`` was removed, so we fall back to the package that
-  actually backs ``tf.keras`` (``tf_keras`` when the legacy Keras backend is
-  enabled, otherwise ``keras``).
+  Uses the public ``tf.keras.models.clone_model`` API so the code works across
+  TensorFlow releases: the bundled Keras in TF <= 2.15 as well as the standalone
+  Keras 3 / tf_keras backends shipped with TF >= 2.16. The original code reached
+  into private ``tf._keras_internal`` helpers that no longer exist in TF 2.16+,
+  and the equivalent private helpers were refactored out of the public module
+  paths in Keras 3.
   """
-  if hasattr(tf, '_keras_internal'):
-    return tf._keras_internal.models, tf._keras_internal.engine.functional  # pylint: disable=protected-access
-
-  backend_name = getattr(tf.keras, '__name__', '')
-  pkg_name = 'tf_keras' if 'tf_keras' in backend_name else 'keras'
-  pkg = importlib.import_module(pkg_name)  # pytype: disable=import-error
-  return pkg.src.models.functional, pkg.src.engine.functional
-
-
-models_utils, functional = _resolve_keras_internals()
+  return tf.keras.models.clone_model(model, input_tensors=input_tensors)
 
 
 def save_model_summary(model, path, file_name='model_summary.txt'):
@@ -104,33 +95,6 @@ def _get_input_output_states(model):
       if output_state not in ([], [None]):
         output_states.append(output_state)
   return input_states, output_states
-
-
-def _clone_model(model, input_tensors):
-  """Clone model with configs, except of weights."""
-  new_input_layers = {}  # Cache for created layers.
-  # pylint: disable=protected-access
-  if input_tensors is not None:
-    # Make sure that all input tensors come from a Keras layer.
-    input_tensors = tf.nest.flatten(input_tensors)
-    for i, input_tensor in enumerate(input_tensors):
-      if not tf.keras.backend.is_keras_tensor(input_tensor):
-        raise ValueError('Expected keras tensor but get', input_tensor)
-      original_input_layer = model._input_layers[i]
-      newly_created_input_layer = input_tensor._keras_history.layer
-      new_input_layers[original_input_layer] = newly_created_input_layer
-
-  model_config, created_layers = models_utils._clone_layers_and_model_config(  # pylint:disable=protected-access,line-too-long
-      model, new_input_layers, models_utils._clone_layer)
-  # pylint: enable=protected-access
-
-  # Reconstruct model from the config, using the cloned layers.
-  input_tensors, output_tensors, created_layers = (
-      functional.reconstruct_from_config(  # pylint:disable=protected-access
-          model_config, created_layers=created_layers))
-
-  new_model = tf.keras.Model(input_tensors, output_tensors, name=model.name)
-  return new_model
 
 
 def _weight_get_basename(weight):

--- a/third_party/kws_streaming/models/utils.py
+++ b/third_party/kws_streaming/models/utils.py
@@ -16,6 +16,7 @@
 """Utility functions for operations on Model."""
 import os.path
 import tempfile
+import importlib
 from typing import List, Optional, Sequence
 import numpy as np
 import tensorflow as tf
@@ -28,8 +29,26 @@ from kws_streaming.models import model_params
 from kws_streaming.models import model_utils
 from kws_streaming.models import models as kws_models
 
-models_utils = tf._keras_internal.models  # pylint: disable=protected-access
-functional = tf._keras_internal.engine.functional  # pylint: disable=protected-access
+
+def _resolve_keras_internals():
+  """Locate the internal Keras modules that host the model clone helpers.
+
+  TensorFlow <= 2.15 bundles Keras inside ``tf._keras_internal``. From
+  TensorFlow 2.16 Keras was split into a standalone package and
+  ``tf._keras_internal`` was removed, so we fall back to the package that
+  actually backs ``tf.keras`` (``tf_keras`` when the legacy Keras backend is
+  enabled, otherwise ``keras``).
+  """
+  if hasattr(tf, '_keras_internal'):
+    return tf._keras_internal.models, tf._keras_internal.engine.functional  # pylint: disable=protected-access
+
+  backend_name = getattr(tf.keras, '__name__', '')
+  pkg_name = 'tf_keras' if 'tf_keras' in backend_name else 'keras'
+  pkg = importlib.import_module(pkg_name)  # pytype: disable=import-error
+  return pkg.src.models.functional, pkg.src.engine.functional
+
+
+models_utils, functional = _resolve_keras_internals()
 
 
 def save_model_summary(model, path, file_name='model_summary.txt'):
@@ -101,13 +120,13 @@ def _clone_model(model, input_tensors):
       newly_created_input_layer = input_tensor._keras_history.layer
       new_input_layers[original_input_layer] = newly_created_input_layer
 
-  model_config, created_layers = tf._keras_internal.models._clone_layers_and_model_config(  # pylint:disable=protected-access,line-too-long
-      model, new_input_layers, tf._keras_internal.models._clone_layer)
+  model_config, created_layers = models_utils._clone_layers_and_model_config(  # pylint:disable=protected-access,line-too-long
+      model, new_input_layers, models_utils._clone_layer)
   # pylint: enable=protected-access
 
   # Reconstruct model from the config, using the cloned layers.
   input_tensors, output_tensors, created_layers = (
-      tf._keras_internal.engine.functional.reconstruct_from_config(  # pylint:disable=protected-access
+      functional.reconstruct_from_config(  # pylint:disable=protected-access
           model_config, created_layers=created_layers))
 
   new_model = tf.keras.Model(input_tensors, output_tensors, name=model.name)
@@ -215,11 +234,11 @@ def get_stride(model):
 
 
 def convert_to_inference_model(model, input_tensors, mode):
-  """Convert tf._keras_internal.engine.functional `Model` instance to a streaming inference.
+  """Convert a Keras functional `Model` instance to a streaming inference.
 
   It will create a new model with new inputs: input_tensors.
   All weights will be copied. Internal states for streaming mode will be created
-  Only tf._keras_internal.engine.functional Keras model is supported!
+  Only a Keras functional `Model` instance is supported!
 
   Args:
       model: Instance of `Model`.
@@ -578,7 +597,7 @@ def traverse_graph(prev_layer, layers):
 
 
 def sequential_to_functional(model):
-  """Converts keras sequential model to tf._keras_internal.engine.functional one."""
+  """Converts a keras sequential model to a Keras functional one."""
   input_layer = tf.keras.Input(
       batch_input_shape=model.layers[0].input_shape[0])
   prev_layer = input_layer


### PR DESCRIPTION
## Summary
Fixes the kws_streaming training breakage on TensorFlow 2.16 and later (Keras 3 backend) - see #168. Closes #168. Part of #159.

The training runtime runs TF 2.16 or newer, where Keras was split out of the TF core package and `tf._keras_internal` was removed. The vendored upstream still depended on those private internals, so `model_train_eval` crashed at import time, and the train adapter tripped the upstream model-already-exists guard by pre-creating `train_dir`.

## Changes
- `third_party/kws_streaming/models/utils.py` - `_clone_model` now uses the public `tf.keras.models.clone_model` API (stable across bundled Keras, Keras 3, and tf_keras) instead of private `tf._keras_internal` clone helpers.
- `third_party/kws_streaming/layers/compat.py` plus 5 augmentation layers - added a version-agnostic `smart_cond()` and routed the layers through the public `tf.keras.utils.control_flow_util` path.
- `packages/modules/kws/streaming/train/train_adapter.py` - stop pre-creating `train_dir`; clear any stale output so each training pass starts fresh.

## Verification
Verified by syntax compile; the runtime runs TF 2.16 or newer where these private APIs are gone. A full end-to-end train run needs the runtime environment.