### PR TITLE
docs(training): ADR-039 — multi wake words, formats/quantization, module-owned convert

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1315,3 +1315,64 @@ applied per this log and may be overridden._
     already analysed here).
   - `third_party/README.md` hardening log, `docs/modules/kws-streaming.md`,
     `LICENSES.md`, and the train `README.md` record this decision.
+
+---
+
+## ADR-039 — Trained bundles are "one canonical model + a label list"; formats/quantization are spec-driven train params; conversion is module-owned
+
+- **Status:** Accepted (2026-08-18)
+- **Origin:** Human design decision (2026-08-18 discussion) on the training
+  module contract (`docs/modules/training.md` §4/§6); resolves open questions
+  T-7 and T-8.
+- **Decision:**
+  1. **One model, many labels.** A trained bundle is one canonical model plus
+     an ordered `labels.json` matching the class index. Multi-class trainers
+     (kws-streaming) detect every label; single-phrase trainers (openwakeword)
+     carry a one-element list. `spec.train.multiWord` (capability) +
+     `wakePhrases` (array param) drive the wizard; the in-browser test's
+     phrase selector is fed from `labels.json`. Separate-models-per-phrase
+     backends are second-class — prefer a single multi-class model.
+  2. **Formats & quantization are spec-driven train params**
+     (`spec.train.formats`, `spec.train.quantization`), capability-labeled so
+     the wizard renders from the spec (ADR-025). The canonical upstream-native
+     artifact is always kept; requested formats are derived from it.
+  3. **Conversion is module-owned, like training.** `spec.train.convert`
+     declares a module convert script callable at train time (the natural
+     place for int8 static PTQ, where calibration data is present) AND
+     standalone on an already-trained canonical model ("convert existing" —
+     no retraining when the target changes). A shared `wake_train_kit.convert`
+     provides the specific well-defined transforms (tflite→onnx via tf2onnx;
+     onnx→tflite + int8 static PTQ via the TF converter; fp16 via
+     onnxruntime). It is **not** a universal router, because onnx↔tflite is
+     lossy and one-way-ish.
+  4. **In-browser testing requires onnx** for all Traditional drivers
+     (onnxruntime-web), so tflite-native trainers must also be able to derive
+     a `.onnx` for the in-browser test + the browser export row.
+  5. A tiny `calibration/` set (a few seconds of representative audio) is
+     snapshotted into the bundle so a later standalone convert can re-quantize
+     without retraining.
+- **Rationale:**
+  - Matches the module-ownership model (ADR-025) and "adapt to upstream, never
+    rewrite" (ADR-031): each upstream has its own converter quirks, so policy
+    lives in the module; a shared helper removes boilerplate only (same
+    composition style as `wake_train_kit.report` / `.data_sources`).
+  - Train-time format selection is safe because the canonical artifact is
+    kept — a later target needs conversion, not retraining.
+  - PTQ calibration data is free only at train time; snapshotting a small set
+    keeps the standalone convert path stateless.
+  - A separate "convert API" service endpoint was considered and rejected in
+    favour of module-owned convert scripts run through the existing
+    job-manager/script path — no new service.
+- **Consequences:**
+  - `docs/modules/training.md` §4.1/§4.5/§4.6/§6 gain the `multiWord` /
+    `formats` / `quantization` / `convert` spec fields, `labels.json`,
+    `calibration/`, and the metadata `formats` / `labels` keys.
+  - kws-streaming's `labels.txt` becomes the standard `labels.json`; its
+    `wantedWord` selection is the reference driver behaviour for multi-word.
+  - Each trainable module grows a convert script (`spec.train.convert`); the
+    `wake_train_kit.convert` helpers land in the train-kit package.
+  - The training wizard renders the formats/quantization selectors and the
+    wake-phrase list from spec — no hard-coded UI (ADR-025).
+  - Follow-up implementation issues are tracked for: multi-word training
+    (labels + wakePhrases + phrase selector), formats/quantization train
+    params, and the module-owned convert stage.

--- a/docs/modules/kws-streaming.md
+++ b/docs/modules/kws-streaming.md
@@ -74,7 +74,10 @@ Why this module exists (and is not "just another backend"):
     list, and whether the speech feature extractor is inside the graph.
   - Label → posterior selection: pick the configured `wantedWord` column out of
     the multi-class softmax, so a 12-label Speech Commands model can act as a
-    single-wake-word detector.
+    single-wake-word detector. This is the reference driver for ADR-039's
+    "one model, many labels" contract — trained bundles carry a standard
+    `labels.json` (upstream `labels.txt` normalized) so the console can test
+    every wake word of the model (`docs/modules/training.md` §4.5).
   - The `spec.train` block wiring the **unpatched upstream**
     `kws_streaming/train/model_train_eval.py` (ADR-031) plus a
     `standardize-results` adapter for its run directory.

--- a/docs/modules/training.md
+++ b/docs/modules/training.md
@@ -169,6 +169,25 @@ stays byte-identical; WakeStudio wraps it.
   "adapterOptions": {                     // NEW: per-adapter config
     "modelRegex": "model\\.(onnx|tflite)$",  // find the model in the run dir
     "metricsParser": "openwakeword-json"       // how to parse metrics.json
+  },
+  // WHAT the wizard offers (capability-labeled, spec-driven — ADR-025, ADR-039):
+  "multiWord": true,                      // NEW (ADR-039): trains ONE model for
+                                           //   many wake words? true → the params
+                                           //   field is "wakePhrases" (array);
+                                           //   false (openwakeword) keeps
+                                           //   "wakePhrase" (string).
+  "formats": {                            // NEW (ADR-039): selectable output formats
+    "default": ["onnx"],
+    "options": ["onnx", "tflite", "tflite-int8"]
+  },
+  "quantization": {                       // NEW (ADR-039): selectable quant schemes
+    "options": ["none", "fp16", "int8-static"],
+    "default": "int8-static"
+  },
+  "convert": {                            // NEW (ADR-039): module-owned convert script
+    "entry": "convert.py",               //   callable at train time AND standalone
+    "from": ["tflite", "onnx"],          //   source formats it accepts
+    "to": ["onnx", "tflite-int8"]        //   target formats it can derive
   }
 }
 ```
@@ -220,6 +239,64 @@ with any language:
   `train-kit` package (`wake_train_kit.report`) provides the reporter so
   module-owned scripts get this for free.
 
+### 4.5 Multi-wake-word models — "one model, many labels" (ADR-039)
+
+A trained bundle is **one model + an ordered label list**, not "one model per
+phrase". A multi-class model (e.g. kws-streaming's 12-label Speech Commands)
+acts as a detector for every label in the list; a single-phrase model
+(openwakeword) carries a one-element list.
+
+- **Standard `labels.json` (new):** every Traditional train emits an ordered
+  label list that matches the model's class index. kws-streaming's `labels.txt`
+  becomes `labels.json`; openwakeword emits a one-element list. The importer
+  validates it; drivers select the score column by phrase — kws-streaming's
+  `wantedWord` selection is already exactly this.
+- **Spec-driven wizard input:** `spec.train.multiWord` declares whether the
+  module can train several wake words at once. Capable modules (kws-streaming)
+  render `wakePhrases` (array) in the wizard; single-word modules (openwakeword)
+  keep `wakePhrase` (string). No hard-coded UI (ADR-025).
+- **In-browser test:** after import, the KWS panel offers a phrase selector fed
+  from `labels.json`, so the user tests each wake word of the model.
+- **Separate-models-per-phrase backends** are second-class: prefer merging into
+  one multi-class model (shared features, one runtime session, one threshold to
+  manage). A bundle-level `models[]` array is a future escape hatch only if a
+  backend genuinely cannot merge.
+
+### 4.6 Formats, quantization & conversion (ADR-039)
+
+**Decision: formats and quantization are spec-driven train params; conversion
+is module-owned, like training — with a shared helper for the common
+transforms.**
+
+- **`spec.train.formats` / `spec.train.quantization`** are capability-labeled
+  selectors. The wizard renders them from the spec (ADR-025); the adapter
+  honors them; `metadata.json` records what was requested and what shipped.
+- **The canonical artifact is always kept.** Each module emits its
+  upstream-native format (openwakeword → onnx; kws-streaming → tflite); the
+  requested formats are **derived** from it. This makes train-time format
+  selection safe: a later target needs only re-conversion, not retraining.
+- **Convert is module-owned (`spec.train.convert`), callable in two modes:**
+  1. **At train time** (embedded in the adapter) — the natural place for int8
+     static PTQ, because the calibration data is sitting right there.
+  2. **Standalone on an already-trained canonical model** ("convert existing")
+     — re-run a job or invoke the convert script directly when the user later
+     targets a different device.
+- **A shared helper (`wake_train_kit.convert`)** provides the *specific*
+  well-defined transforms (tflite→onnx via tf2onnx; onnx→tflite + int8 static
+  PTQ via the TF converter; fp16 via onnxruntime) — the same composition style
+  as `wake_train_kit.report` / `.data_sources`. Each module's convert script
+  composes these helpers and declares its source→target pairs; the helper is
+  **not** a universal router, because onnx↔tflite is lossy and one-way-ish.
+- **In-browser testing requires onnx.** onnxruntime-web runs `.onnx` only, and
+  every Traditional driver in the console (openwakeword, kws-streaming) runs on
+  it. So a tflite-native trainer (kws-streaming) must also be able to emit a
+  derived `.onnx` for the in-browser test + the browser export row — onnx is a
+  required derived output, not just an option.
+- **Calibration for later standalone converts:** when PTQ runs at train time it
+  consumes the run's calibration data directly; a tiny `calibration/` set (a
+  few seconds of representative audio) is snapshotted into the bundle so a
+  later standalone convert can re-quantize without retraining.
+
 ## 6. Artifact bundle manifest (single retrieval contract)
 
 One manifest serves ALL backends - studio-backend, cloud, and Colab - so the PWA
@@ -227,13 +304,24 @@ has **one importer** that validates + imports any trained model:
 
 ```
 wake-studio-results/<job-id>/
-  model.onnx            (or model.tflite)
+  model.onnx            (or model.tflite)  canonical, always present
+  labels.json           (NEW, ADR-039: ordered, matches the class index;
+                         single-phrase bundles carry a one-element list)
+  calibration/          (NEW, optional, ADR-039: small representative audio
+                         set so a later standalone convert can re-quantize)
   metrics.json          (FAR/FRR, loss, epochs - for the quality report)
-  metadata.json         (params used, backend, provider, dates)
+  metadata.json         (params used, backend, provider, dates + requested &
+                         shipped formats/quantization)
   provenance.json       (license: user-owned / commercially clean; source data
                          attributions for the Phase 4 license gate)
   config.json           (AFE/KWS/Few-Shot config snapshot used for the training)
 ```
+
+`labels.json` (ADR-039) makes the label list a first-class part of the
+contract: the importer validates it, the KWS panel derives its phrase selector
+from it, and drivers pick the class index by phrase. `formats`/`quantization`
+in `metadata.json` tell the importer what the bundle actually contains and feed
+the Phase 4 export matrix.
 
 `metadata.json` shape:
 
@@ -244,6 +332,8 @@ wake-studio-results/<job-id>/
   "backend": "self-hosted" | "cloud" | "colab",
   "provider": "...",
   "params": { "...": "..." },
+  "formats": { "requested": ["onnx"], "shipped": ["onnx", "tflite-int8"] },  // NEW (ADR-039)
+  "labels": ["hey studio"],                                                    // NEW (ADR-039), from labels.json
   "trainedAtMs": 0
 }
 ```
@@ -414,6 +504,8 @@ for every provider. Capability labels: train-capable vs inference-only.
 | T-4 | **Where the bundle manifest lives in the PWA** | `packages/modules/training/core/manifest.ts` - the single importer used by all backends. |
 | T-5 | **Which modules have a `train/` target in v1** | kws drivers (sherpa: transduce model frozen, so NO train - it's inference-only per ADR-024 ASR-Decoding; openwakeword: traditional train in Phase 5; plix: encoder is frozen). Training targets land with docs/roadmap.md Phase 5 backends. |
 | T-6 | **Upstream-script adapters (§4): preserve scripts/notebooks as-is vs rewrite** | ✅ **RESOLVED (human, 2026-08-05): preserve.** WakeStudio adapts to the upstream artifact (declare invocation + normalize outputs), never rewrites it. Spec `train` gains `script`/`notebook` + `adapter`/`adapterOptions` fields. |
+| T-7 | **Multi wake words: one model per phrase vs one model + labels** | ✅ **RESOLVED (human, 2026-08-18): "one model, many labels" (ADR-039).** Standard `labels.json` in the bundle; `spec.train.multiWord` capability + `wakePhrases` (array) param; in-browser phrase selector fed from `labels.json` (§4.5). |
+| T-8 | **Formats (.onnx/.tflite) + quantization: at train time vs a convert API** | ✅ **RESOLVED (human, 2026-08-18): spec-driven train params + module-owned convert (ADR-039).** `spec.train.formats`/`quantization` are capability-labeled selectors; convert is a module-owned script (`spec.train.convert`) callable at train time AND standalone on the canonical model; shared `wake_train_kit.convert` helpers for the common transforms (§4.6). |
 
 > T-5 note: per ADR-024, ASR-Decoding (sherpa) is **inference-only** - it has no
 > train target. The training module's first real `train/` targets are the
@@ -423,6 +515,7 @@ for every provider. Capability labels: train-capable vs inference-only.
 
 | Date | Change | Author |
 |---|---|---|
+| 2026-08-18 | **ADR-039 — multi wake words + formats/quantization + module-owned convert (§4.1/§4.5/§4.6/§6, T-7/T-8):** design decision from discussion (human, 2026-08-18). Bundles are "one model + an ordered `labels.json`"; `wakePhrases` (array) + `multiWord` capability drive the wizard; `spec.train.formats`/`quantization` are spec-driven selectors; convert is module-owned (like train) via `spec.train.convert`, callable at train time and standalone on the canonical model, with a shared `wake_train_kit.convert` helper; in-browser testing requires onnx for all Traditional drivers. | agent |
 | 2026-08-05 | Initial draft (docs-first, §6.5 Step A). | agent |
 | 2026-08-05 | **§4 upstream-script adapters** (human decision: preserve upstream train.py/ipynb; adapt to them). Spec `train` gains `script`/`notebook`/`adapter` fields; `standardize-results` is the single importer. Sections renumbered. | agent |
 | 2026-08-13 | §7.2 Colab runtime tunnel (proposal, Q15 issue #106): collapse Colab into the self-hosted API shape. | agent |


### PR DESCRIPTION
## What

Records the training-contract design decision (ADR-039) from the 2026-08-18
discussion about **multi wake words** and **model formats/quantization**.

### Q1 — Multi wake words
Bundles become **one canonical model + an ordered `labels.json`** ("one model,
many labels"). `spec.train.multiWord` (capability) + `wakePhrases` (array param)
drive the wizard; the in-browser test gets a phrase selector fed from
`labels.json`. kws-streaming's `wantedWord` selection is the reference behaviour.

### Q2 — Formats (.onnx/.tflite) + quantization
Formats & quantization become **spec-driven train params**
(`spec.train.formats` / `spec.train.quantization`), capability-labeled so the
wizard renders from spec. Conversion is **module-owned, like training**
(`spec.train.convert`), callable at train time AND standalone on the canonical
model ("convert existing" — no retrain when the target changes), with a shared
`wake_train_kit.convert` helper. In-browser testing requires onnx for all
Traditional drivers; a tiny `calibration/` set is snapshotted into the bundle
for later standalone PTQ.

## Files
- `DECISIONS.md` — **ADR-039** (accepted, 2026-08-18)
- `docs/modules/training.md` — §4.1 spec fields, new §4.5/§4.6, §6 manifest +
  metadata, T-7/T-8 resolved, change log
- `docs/modules/kws-streaming.md` — cross-ref to the `labels.json` contract

## Notes
- Docs-only change; no code. Follow-up implementation issues are being filed.
- Resolves training-contract open questions **T-7** and **T-8**.

## Follow-up issues
Implementation is tracked as tasks (ADR-039), all in the WakeStudio Delivery project (Phase P5):
- #175 — multi wake words in training (labels.json + wakePhrases/multiWord + phrase selector)
- #176 — formats + quantization as spec-driven train params
- #177 — module-owned convert stage + shared wake_train_kit.convert helper