### PR TITLE
feat(training): ADR-039 implementation — multi wake words, formats/quantization, module-owned convert (WIP)

### DIFF
--- a/apps/studio-backend/registry.json
+++ b/apps/studio-backend/registry.json
@@ -10,6 +10,8 @@
    "WAKE_FALSE_ACTIVATION": "{params.falseActivationPenalty}",
    "WAKE_AUGMENT": "{params.augment}",
    "WAKE_QUANTIZE": "{params.quantize}",
+   "WAKE_FORMATS": "{params.formats}",
+   "WAKE_QUANTIZATION": "{params.quantization}",
    "WAKE_BACKEND": "self-hosted",
    "UPSTREAM_PYTHON": "{env.UPSTREAM_PYTHON}"
   }
@@ -37,6 +39,8 @@
    "STREAM_HOW_MANY_TRAINING_STEPS": "{params.howManyTrainingSteps}",
    "STREAM_LEARNING_RATE": "{params.learningRate}",
    "STREAM_SPLIT_DATA": "{params.splitData}",
+   "STREAM_FORMATS": "{params.formats}",
+   "STREAM_QUANTIZATION": "{params.quantization}",
    "STREAM_BACKEND": "self-hosted",
    "UPSTREAM_PYTHON": "{env.UPSTREAM_PYTHON}"
   },

--- a/apps/studio-backend/src/wake_train_kit/convert.py
+++ b/apps/studio-backend/src/wake_train_kit/convert.py
@@ -1,0 +1,152 @@
+"""wake_train_kit.convert - shared model-format transforms (ADR-039 §4.6).
+
+Each helper is a SPECIFIC, well-defined transform, not a universal router:
+onnx<->tflite is lossy and one-way-ish, so module convert scripts compose
+these and declare their source->target pairs in ``spec.train.convert``.
+
+Heavy toolchains (tf2onnx, the TF converter, onnxruntime) are imported /
+invoked lazily, so this module can be imported anywhere (including the
+studio-backend tests, which exercise the orchestration with fakes). A missing
+toolchain raises :class:`ConvertError` with a clear message, so callers can
+decide to fall back (e.g. skip a train-time derive and defer to the convert
+stage) instead of crashing.
+
+Conventions: every function returns the output :class:`pathlib.Path` and
+raises :class:`ConvertError` (never silently succeeding) on any failure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+__all__ = [
+    "ConvertError",
+    "tflite_to_onnx",
+    "onnx_fp16",
+    "snapshot_calibration",
+]
+
+
+class ConvertError(RuntimeError):
+    """A conversion failed (missing toolchain, bad input, converter error)."""
+
+
+def tflite_to_onnx(tflite: str | Path, onnx_out: str | Path, opset: int = 17) -> Path:
+    """TFLite -> ONNX via tf2onnx's TFLite front-end (``--tflite``).
+
+    The same transform the kws-streaming CI export uses
+    (``packages/modules/kws/streaming/scripts/export-kws-streaming-onnx.py``),
+    lifted here so any module can reuse it. Requires ``tf2onnx`` on
+    ``sys.executable``; when it is missing, :class:`ConvertError` is raised
+    with a hint to run the convert stage (which installs the toolchain).
+    """
+    tflite, onnx_out = Path(tflite), Path(onnx_out)
+    if not tflite.is_file():
+        raise ConvertError(f"tflite not found: {tflite}")
+    cmd = [
+        sys.executable,
+        "-m",
+        "tf2onnx.convert",
+        "--tflite",
+        str(tflite),
+        "--output",
+        str(onnx_out),
+        "--opset",
+        str(opset),
+        "--dequantize",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    except FileNotFoundError as exc:  # pragma: no cover - env without python
+        raise ConvertError(f"python not found: {sys.executable}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ConvertError(f"tf2onnx timed out for {tflite}") from exc
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-10:]
+        raise ConvertError(
+            f"tf2onnx failed ({proc.returncode}) for {tflite}: {' | '.join(tail)}"
+        )
+    if not onnx_out.is_file():
+        raise ConvertError(f"tf2onnx reported success but produced no {onnx_out}")
+    return onnx_out
+
+
+def onnx_fp16(onnx: str | Path, out: str | Path) -> Path:
+    """ONNX fp32 -> fp16 via onnxruntime quantization (lazy import)."""
+    onnx, out = Path(onnx), Path(out)
+    if not onnx.is_file():
+        raise ConvertError(f"onnx not found: {onnx}")
+    try:
+        from onnxruntime.quantization import quantize_dynamic  # type: ignore
+    except ImportError as exc:
+        raise ConvertError(
+            "onnxruntime is not installed; run the convert stage env "
+            "(onnxruntime>=1.16) to enable fp16"
+        ) from exc
+    quantize_dynamic(onnx.__str__(), out.__str__(), weight_type="FLOAT16")
+    if not out.is_file():
+        raise ConvertError(f"fp16 quantization produced no {out}")
+    return out
+
+
+def snapshot_calibration(
+    wav_paths: Iterable[str | Path],
+    out_dir: str | Path,
+    *,
+    max_seconds: float = 30.0,
+    sample_rate: int = 16000,
+) -> list[Path]:
+    """Copy a tiny representative audio set for later post-training
+    quantization (ADR-039 §4.6 / §6 ``calibration/``).
+
+    Copies up to ``max_seconds`` of 16 kHz wav data (a handful of clips) into
+    ``out_dir`` so a later standalone convert can run int8 static PTQ without
+    the training data. Callers pass their run's positive/negative wavs; a
+    best-effort selection is made (clip length is read from the 44-byte wav
+    header when present). Missing/invalid files are skipped.
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    copied: list[Path] = []
+    budget = max_seconds * sample_rate
+    used = 0
+    for src in wav_paths:
+        if used >= budget:
+            break
+        p = Path(src)
+        if not p.is_file():
+            continue
+        seconds = _wav_seconds(p)
+        if seconds is None or seconds <= 0:
+            continue
+        if used + seconds * sample_rate > budget:
+            # keep partial? take whole clip if we still have room for > 0
+            if used + seconds * sample_rate > budget and used > 0:
+                continue
+        dst = out / p.name
+        try:
+            dst.write_bytes(p.read_bytes())
+        except OSError:
+            continue
+        copied.append(dst)
+        used += seconds * sample_rate
+    return copied
+
+
+def _wav_seconds(path: Path) -> float | None:
+    """Best-effort duration from a 44-byte PCM wav header (bytes 28..31)."""
+    try:
+        with path.open("rb") as fh:
+            riff = fh.read(44)
+    except OSError:
+        return None
+    if len(riff) < 44 or riff[0:4] != b"RIFF" or riff[8:12] != b"WAVE":
+        return None
+    byte_rate = int.from_bytes(riff[28:32], "little")
+    data_size = int.from_bytes(riff[40:44], "little")
+    if byte_rate <= 0:
+        return None
+    return data_size / byte_rate

--- a/apps/studio-backend/tests/test_convert.py
+++ b/apps/studio-backend/tests/test_convert.py
@@ -1,0 +1,141 @@
+"""Tests for wake_train_kit.convert (ADR-039 §4.6).
+
+The heavy toolchains (tf2onnx, onnxruntime) are exercised with fakes; the
+tests cover the orchestration, error paths, and file handling. Real conversion
+runs in the CI convert stage / the module convert env.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from wake_train_kit.convert import (
+    ConvertError,
+    tflite_to_onnx,
+    onnx_fp16,
+    snapshot_calibration,
+)
+
+WAV44 = (
+    b"RIFF" + b"\x24\x00\x00\x00" + b"WAVE"
+    + b"fmt " + b"\x10\x00\x00\x00\x01\x00\x01\x00"
+    + b"\x80\x3e\x00\x00\x00\x7d\x00\x00\x00\x02\x00\x10\x00"
+    + b"data" + b"\x00\x00\x00\x00"
+)
+
+
+# --- tflite_to_onnx ---------------------------------------------------------
+
+
+def test_tflite_to_onnx_calls_tf2onnx(tmp_path, monkeypatch):
+    tflite = tmp_path / "model.tflite"
+    tflite.write_bytes(b"tflite")
+    out = tmp_path / "model.onnx"
+
+    class R:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output=True, text=True, timeout=900):
+        assert cmd[0] == sys.executable
+        assert "-m" in cmd
+        assert "tf2onnx.convert" in cmd
+        assert "--tflite" in cmd
+        assert str(tflite) in cmd
+        assert str(out) in cmd
+        assert "--dequantize" in cmd
+        Path(str(out)).write_bytes(b"fake-onnx")
+        return R()
+
+    monkeypatch.setattr("wake_train_kit.convert.subprocess.run", fake_run)
+    result = tflite_to_onnx(tflite, out)
+    assert result == out
+    assert out.read_bytes() == b"fake-onnx"
+
+
+def test_tflite_to_onnx_missing_input(tmp_path):
+    with pytest.raises(ConvertError, match="tflite not found"):
+        tflite_to_onnx(tmp_path / "nope.tflite", tmp_path / "out.onnx")
+
+
+def test_tflite_to_onnx_propagates_tf2onnx_failure(tmp_path, monkeypatch):
+    tflite = tmp_path / "model.tflite"
+    tflite.write_bytes(b"tflite")
+
+    class R:
+        returncode = 1
+        stdout = ""
+        stderr = "boom"
+
+    monkeypatch.setattr(
+        "wake_train_kit.convert.subprocess.run", lambda *a, **k: R()
+    )
+    with pytest.raises(ConvertError, match="tf2onnx failed"):
+        tflite_to_onnx(tflite, tmp_path / "out.onnx")
+
+
+# --- onnx_fp16 --------------------------------------------------------------
+
+
+def test_onnx_fp16_uses_onnxruntime(tmp_path, monkeypatch):
+    onnx = tmp_path / "model.onnx"
+    onnx.write_bytes(b"onnx")
+    out = tmp_path / "model-fp16.onnx"
+
+    calls: list[dict] = []
+
+    def quantize_dynamic(model_input, model_output, weight_type):  # noqa: D102
+        calls.append({"input": model_input, "output": model_output, "weight_type": weight_type})
+        Path(model_output).write_bytes(b"fp16-onnx")
+
+    quant_mod = type("quantization", (), {"quantize_dynamic": staticmethod(quantize_dynamic)})
+    onnx_mod = type("onnxruntime", (), {"quantization": quant_mod})
+    monkeypatch.setitem(sys.modules, "onnxruntime", onnx_mod)
+    monkeypatch.setitem(sys.modules, "onnxruntime.quantization", quant_mod)
+
+    result = onnx_fp16(onnx, out)
+    assert result == out
+    assert calls[0]["weight_type"] == "FLOAT16"
+    assert Path(calls[0]["output"]).read_bytes() == b"fp16-onnx"
+
+
+def test_onnx_fp16_missing_onnxruntime(tmp_path, monkeypatch):
+    onnx = tmp_path / "model.onnx"
+    onnx.write_bytes(b"onnx")
+    real_import = __import__
+
+    def fake_import(mod, *a, **k):
+        if mod.startswith("onnxruntime"):
+            raise ImportError(mod)
+        return real_import(mod, *a, **k)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    with pytest.raises(ConvertError, match="onnxruntime is not installed"):
+        onnx_fp16(onnx, tmp_path / "out.onnx")
+
+
+def test_snapshot_calibration_copies_up_to_budget(tmp_path):
+    # two wavs: one 1s (byte_rate 8000 -> data_size 8000), one 2s
+    one_s = WAV44[:28] + (8000).to_bytes(4, "little") + WAV44[32:40] + (8000).to_bytes(4, "little")
+    two_s = WAV44[:28] + (8000).to_bytes(4, "little") + WAV44[32:40] + (16000).to_bytes(4, "little")
+    a = tmp_path / "a.wav"
+    b = tmp_path / "b.wav"
+    a.write_bytes(one_s)
+    b.write_bytes(two_s)
+    out = tmp_path / "cal"
+
+    copied = snapshot_calibration([a, b], out, max_seconds=2.5, sample_rate=8000)
+    assert len(copied) >= 1
+    assert (out / "a.wav").is_file()
+
+
+def test_snapshot_calibration_skips_invalid(tmp_path):
+    bad = tmp_path / "bad.wav"
+    bad.write_bytes(b"not a wav")
+    good = tmp_path / "good.wav"
+    good.write_bytes(WAV44[:28] + (8000).to_bytes(4, "little") + WAV44[32:40] + (8000).to_bytes(4, "little"))
+    out = tmp_path / "cal"
+    copied = snapshot_calibration([bad, good], out, max_seconds=5, sample_rate=8000)
+    assert copied == [out / "good.wav"]

--- a/apps/web/public/train-modules.json
+++ b/apps/web/public/train-modules.json
@@ -149,6 +149,15 @@
             "none",
             "int8-static"
           ]
+        },
+        "convert": {
+          "entry": "train/convert.py",
+          "from": [
+            "onnx"
+          ],
+          "to": [
+            "onnx-fp16"
+          ]
         }
       }
     },
@@ -340,6 +349,15 @@
           "default": "none",
           "options": [
             "none"
+          ]
+        },
+        "convert": {
+          "entry": "train/convert.py",
+          "from": [
+            "tflite"
+          ],
+          "to": [
+            "onnx"
           ]
         }
       }

--- a/apps/web/public/train-modules.json
+++ b/apps/web/public/train-modules.json
@@ -127,22 +127,29 @@
             "default": true,
             "description": "Background mixing + room impulse responses (notebook env WAKE_AUGMENT).",
             "env": "WAKE_AUGMENT"
-          },
-          {
-            "id": "quantize",
-            "label": "Quantize export",
-            "group": "advanced",
-            "type": "boolean",
-            "default": true,
-            "description": "Emit a TFLite model alongside the ONNX (best-effort, notebook env WAKE_QUANTIZE).",
-            "env": "WAKE_QUANTIZE"
           }
         ],
         "outputs": {
           "checkpoint": "out/model.onnx",
           "metrics": "out/metrics.json"
         },
-        "entry": "train/train_adapter.py"
+        "entry": "train/train_adapter.py",
+        "formats": {
+          "default": [
+            "onnx"
+          ],
+          "options": [
+            "onnx",
+            "tflite-int8"
+          ]
+        },
+        "quantization": {
+          "default": "none",
+          "options": [
+            "none",
+            "int8-static"
+          ]
+        }
       }
     },
     {
@@ -319,6 +326,21 @@
           "modelRegex": "stream_state_external\\.tflite$",
           "labelsFile": "labels.txt",
           "flagsFile": "flags.json"
+        },
+        "formats": {
+          "default": [
+            "tflite"
+          ],
+          "options": [
+            "tflite",
+            "onnx"
+          ]
+        },
+        "quantization": {
+          "default": "none",
+          "options": [
+            "none"
+          ]
         }
       }
     }

--- a/apps/web/public/train-modules.json
+++ b/apps/web/public/train-modules.json
@@ -68,6 +68,7 @@
       "maturity": "pilot",
       "train": {
         "notebookLocal": "packages/modules/kws/openwakeword/train/colab/train.ipynb",
+        "multiWord": false,
         "invocation": [
           "studio-backend",
           "colab"
@@ -174,6 +175,7 @@
           "studio-backend",
           "ci"
         ],
+        "multiWord": true,
         "params": [
           {
             "id": "model",

--- a/apps/web/public/train/kws-openwakeword/train_adapter.py
+++ b/apps/web/public/train/kws-openwakeword/train_adapter.py
@@ -56,6 +56,8 @@ DEFAULTS = {
     "falseActivationPenalty": 1500,
     "augment": True,
     "quantize": True,
+    "formats": "onnx",
+    "quantization": "int8-static",
 }
 
 STAGES: list[tuple[str, str]] = [
@@ -91,6 +93,7 @@ def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
         raw = env.get(name, "").lower()
         return default if raw == "" else raw in ("1", "true", "yes")
 
+    quantize = flag("WAKE_QUANTIZE", DEFAULTS["quantize"])
     return {
         "wakePhrase": _s("WAKE_PHRASE", DEFAULTS["wakePhrase"]),
         "target": _s("WAKE_TARGET", DEFAULTS["target"]),
@@ -101,7 +104,13 @@ def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
             "WAKE_FALSE_ACTIVATION", DEFAULTS["falseActivationPenalty"]
         ),
         "augment": flag("WAKE_AUGMENT", DEFAULTS["augment"]),
-        "quantize": flag("WAKE_QUANTIZE", DEFAULTS["quantize"]),
+        "quantize": quantize,
+        # ADR-039 §4.6: formats/quantization selectors. Defaults preserve the
+        # legacy quantize flag behaviour (a quantized tflite is produced).
+        "formats": _s("WAKE_FORMATS", DEFAULTS["formats"]),
+        "quantization": _s(
+            "WAKE_QUANTIZATION", "int8-static" if quantize else "none"
+        ),
         "jobId": _s("WAKE_JOB_ID", f"kws-openwakeword-{int(time.time() * 1000)}"),
         "backend": _s("WAKE_BACKEND", "colab"),
     }
@@ -210,8 +219,18 @@ def build_bundle(
     bundle_dir = Path(out_root) / params["jobId"]
     bundle_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(onnx_path, bundle_dir / "model.onnx")
-    if params["quantize"] and tflite_path.is_file():
+
+    # ADR-039 §4.6: requested formats (comma-separated select) vs what shipped.
+    requested = [f.strip() for f in params["formats"].split(",") if f.strip()] or ["onnx"]
+    want_tflite = any(f in ("tflite", "tflite-int8") for f in requested)
+    shipped = ["onnx"]
+    if tflite_path.is_file() and (want_tflite or params["quantize"]):
         shutil.copy(tflite_path, bundle_dir / "model.tflite")
+        shipped.append("tflite-int8" if "tflite-int8" in requested else "tflite")
+
+    # Standard ordered label list (ADR-039 §4.5): single-phrase classifier.
+    labels = [params["wakePhrase"]]
+    (bundle_dir / "labels.json").write_text(json.dumps(labels), encoding="utf-8")
 
     metrics = parse_metrics(log_text)
     metrics["steps"] = params["steps"]
@@ -230,6 +249,8 @@ def build_bundle(
             "augment": str(params["augment"]).lower(),
             "quantize": str(params["quantize"]).lower(),
         },
+        "formats": {"requested": requested, "shipped": shipped},
+        "labels": labels,
         "trainedAtMs": int(time.time() * 1000),
     }
     (bundle_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
@@ -263,8 +284,8 @@ def build_bundle(
 
     zip_path = bundle_dir / "wake-studio-results.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name in ("model.onnx", "model.tflite", "metrics.json", "metadata.json",
-                     "provenance.json", "config.json"):
+        for name in ("model.onnx", "model.tflite", "labels.json", "metrics.json",
+                     "metadata.json", "provenance.json", "config.json"):
             p = bundle_dir / name
             if p.is_file():
                 zf.write(p, arcname=f"{params['jobId']}/{name}")

--- a/apps/web/public/train/kws-streaming/train_adapter.py
+++ b/apps/web/public/train/kws-streaming/train_adapter.py
@@ -372,8 +372,16 @@ def build_bundle(
     sources: list[dict[str, Any]],
     log_text: str,
     reporter: Reporter,
+    data_dir: str | None = None,
 ) -> Path:
-    """Normalize the upstream run dir into the standard bundle (§6) and zip it."""
+    """Normalize the upstream run dir into the standard bundle (§6) and zip it.
+
+    ``data_dir`` (when available) is the prepared ``label/*.wav`` tree: used
+    to snapshot a tiny ``calibration/`` set (ADR-039 §4.6/§6) and, when the
+    requested formats include onnx, to attempt a train-time tflite→onnx derive
+    (opportunistic — tf2onnx lives in the CI convert stage, not the train env,
+    so a missing toolchain logs and ships the canonical tflite only).
+    """
     model_src = train_dir / "tflite_stream_state_external" / "stream_state_external.tflite"
     if not model_src.is_file():
         raise FileNotFoundError(
@@ -384,6 +392,25 @@ def build_bundle(
     bundle_dir = Path(out_root) / params["jobId"]
     bundle_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(model_src, bundle_dir / "model.tflite")
+    shipped = ["tflite"]
+
+    # ADR-039 §4.6: train-time onnx derive (opportunistic). tf2onnx is a
+    # convert-stage tool, not a train-env dep, so a missing toolchain is not
+    # fatal — the standalone convert.py covers the full derive.
+    requested = [f.strip() for f in params["formats"].split(",") if f.strip()]
+    if "onnx" in requested:
+        try:
+            from wake_train_kit.convert import tflite_to_onnx
+
+            tflite_to_onnx(bundle_dir / "model.tflite", bundle_dir / "model.onnx")
+            shipped.append("onnx")
+            reporter.emit("log", level="info", message="derived model.onnx (tflite→onnx)")
+        except Exception as exc:  # noqa: BLE001 - toolchain missing/failed
+            reporter.emit(
+                "log", level="info",
+                message=f"train-time onnx derive skipped: {exc}",
+            )
+
     for name in ("labels.txt", "flags.json"):
         p = train_dir / name
         if p.is_file():
@@ -420,11 +447,12 @@ def build_bundle(
             "learningRate": params["learningRate"],
         },
         # ADR-039 §4.6: requested formats vs shipped. The derived .onnx for the
-        # browser lands with the module-owned convert stage (#177).
+        # browser is attempted at train time (opportunistic; see build_bundle)
+        # and always available via the module-owned convert stage (#177).
         "formats": {
             "requested": [f.strip() for f in params["formats"].split(",") if f.strip()]
             or ["tflite"],
-            "shipped": ["tflite"],
+            "shipped": shipped,
         },
         "labels": labels or None,
         "trainedAtMs": int(time.time() * 1000),
@@ -457,14 +485,30 @@ def build_bundle(
     }
     (bundle_dir / "config.json").write_text(json.dumps(config_snapshot, indent=2), encoding="utf-8")
 
+    # ADR-039 §6: tiny calibration/ set for later standalone int8 PTQ. Snapshotted
+    # from the prepared label/*.wav tree (best-effort; skipped when absent).
+    calibration: list[Path] = []
+    if data_dir:
+        try:
+            from wake_train_kit.convert import snapshot_calibration
+
+            wavs = sorted(Path(data_dir).rglob("*.wav"))
+            calibration = snapshot_calibration(
+                wavs, bundle_dir / "calibration", max_seconds=30.0, sample_rate=16000
+            )
+        except Exception as exc:  # noqa: BLE001
+            reporter.emit("log", level="info", message=f"calibration snapshot skipped: {exc}")
+
     zip_path = bundle_dir / "wake-studio-results.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name in ("model.tflite", "labels.txt", "labels.json", "flags.json",
-                     "metrics.json", "metadata.json", "provenance.json",
-                     "config.json"):
+        for name in ("model.tflite", "model.onnx", "labels.txt", "labels.json",
+                     "flags.json", "metrics.json", "metadata.json",
+                     "provenance.json", "config.json"):
             p = bundle_dir / name
             if p.is_file():
                 zf.write(p, arcname=f"{params['jobId']}/{name}")
+        for cal in calibration:
+            zf.write(cal, arcname=f"{params['jobId']}/calibration/{cal.name}")
     reporter.emit("log", level="info", message=f"bundle ready: {zip_path}")
     return zip_path
 
@@ -625,6 +669,7 @@ def main(argv: list[str] | None = None) -> int:
         bundle_zip = build_bundle(
             params, wanted, train_dir, out_root, sources,
             "\n".join(log_lines), reporter,
+            data_dir=data_dir,
         )
     except Exception as exc:  # noqa: BLE001
         reporter.emit("error", message=f"bundle error: {exc}")

--- a/apps/web/public/train/kws-streaming/train_adapter.py
+++ b/apps/web/public/train/kws-streaming/train_adapter.py
@@ -85,6 +85,8 @@ DEFAULTS: dict[str, Any] = {
     "backgroundFrequency": 0.8,
     "silencePercentage": 10.0,
     "unknownPercentage": 10.0,
+    "formats": "tflite",
+    "quantization": "none",
     "jobId": None,
     "backend": "colab",
 }
@@ -109,6 +111,8 @@ ENV_MAP: dict[str, str] = {
     "STREAM_BACKGROUND_FREQUENCY": "backgroundFrequency",
     "STREAM_SILENCE_PERCENTAGE": "silencePercentage",
     "STREAM_UNKNOWN_PERCENTAGE": "unknownPercentage",
+    "STREAM_FORMATS": "formats",
+    "STREAM_QUANTIZATION": "quantization",
     "STREAM_JOB_ID": "jobId",
     "STREAM_BACKEND": "backend",
 }
@@ -385,6 +389,18 @@ def build_bundle(
         if p.is_file():
             shutil.copy(p, bundle_dir / name)
 
+    # Standard ordered label list (ADR-039 §4.5): upstream labels.txt (one
+    # label per line, class-index order) becomes the standard labels.json.
+    labels: list[str] = []
+    labels_txt = train_dir / "labels.txt"
+    if labels_txt.is_file():
+        labels = [
+            ln.strip() for ln in labels_txt.read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+    if labels:
+        (bundle_dir / "labels.json").write_text(json.dumps(labels), encoding="utf-8")
+
     metrics = parse_metrics(train_dir, log_text)
     metrics["training_steps"] = params["howManyTrainingSteps"]
     (bundle_dir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
@@ -403,6 +419,14 @@ def build_bundle(
             "trainingSteps": params["howManyTrainingSteps"],
             "learningRate": params["learningRate"],
         },
+        # ADR-039 §4.6: requested formats vs shipped. The derived .onnx for the
+        # browser lands with the module-owned convert stage (#177).
+        "formats": {
+            "requested": [f.strip() for f in params["formats"].split(",") if f.strip()]
+            or ["tflite"],
+            "shipped": ["tflite"],
+        },
+        "labels": labels or None,
         "trainedAtMs": int(time.time() * 1000),
     }
     (bundle_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
@@ -435,8 +459,9 @@ def build_bundle(
 
     zip_path = bundle_dir / "wake-studio-results.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name in ("model.tflite", "labels.txt", "flags.json", "metrics.json",
-                     "metadata.json", "provenance.json", "config.json"):
+        for name in ("model.tflite", "labels.txt", "labels.json", "flags.json",
+                     "metrics.json", "metadata.json", "provenance.json",
+                     "config.json"):
             p = bundle_dir / name
             if p.is_file():
                 zf.write(p, arcname=f"{params['jobId']}/{name}")

--- a/apps/web/src/components/KWSPanel.tsx
+++ b/apps/web/src/components/KWSPanel.tsx
@@ -39,6 +39,7 @@ import {
   modelSourcesForRole,
 } from '../workspace/kws-config'
 import { ParamRows, type ParamValue } from './UnifiedConfigPanel'
+import { UiMultiselect } from '@wake-studio/module-kit'
 import { drawScoreCurve } from './viz/ScoreCurve'
 import { useProjectStageConfig } from '../projects'
 import { useLiveKws } from '../workspace/live'
@@ -144,6 +145,10 @@ export const KWSPanel = memo(function KWSPanel({
     'wasm',
   )
   const [lastKeyword, setLastKeyword] = useState('')
+  // Available wake-word options for the multi-word selector (ADR-039): the
+  // loaded kws-streaming model's labels (sherpa keywords ride the driver
+  // params). Empty for single-word backends (no selector shown).
+  const [wordOptions, setWordOptions] = useState<string[]>([])
 
   // --- plixkws enrollment state (Few-Shot, Phase 3) ---
   const fsEngineRef = useRef<FewShotEngine | null>(null)
@@ -192,7 +197,7 @@ export const KWSPanel = memo(function KWSPanel({
   const [savedPrototypes, setSavedPrototypes] = useState<UserArtifact[]>([])
   const [savedSampleCount, setSavedSampleCount] = useState(0)
 
-  const { historyRef, setThreshold, setLastScore } = useLiveKws()
+  const { historyRef, setThreshold, setLastScore, setWords } = useLiveKws()
 
   // Report a compact config summary for the tab node's core preview (the
   // few-shot flag is resolved below; backend + status are enough here).
@@ -408,6 +413,23 @@ export const KWSPanel = memo(function KWSPanel({
       setStatus(engine.status)
       setExecutionProvider(engine.executionProvider)
       logInfo('kws', `Models loaded (backend: ${config.backend})`)
+      // ADR-039: expose the multi-word selector options from the loaded model.
+      // kws-streaming carries a sidecar manifest with its label list; other
+      // backends are single-word (or, for sherpa, ride the driver keywords).
+      const ks = (urls as { kwsStreaming?: { manifest?: string } }).kwsStreaming
+      if (ks?.manifest) {
+        try {
+          const res = await fetch(ks.manifest)
+          if (res.ok) {
+            const manifest = (await res.json()) as { labels?: string[] }
+            setWordOptions(manifest.labels ?? [])
+          }
+        } catch {
+          /* word options are a nicety; ignore a fetch failure */
+        }
+      } else {
+        setWordOptions([])
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
       setStatus('error')
@@ -863,6 +885,22 @@ export const KWSPanel = memo(function KWSPanel({
     persist(patch)
   }, [persist])
 
+  // ADR-039: keep the shared live words (multi-word score curve) in sync with
+  // the panel's config.words.
+  useEffect(() => {
+    setWords(config.words ?? [])
+  }, [config.words, setWords])
+
+  // Default the multi-word selection once the loaded model's labels are known
+  // (kws-streaming), skipping the reserved upstream columns (_silence_/_unknown_).
+  useEffect(() => {
+    if (wordOptions.length === 0) return
+    const nonReserved = wordOptions.filter((l) => !l.startsWith('_'))
+    if ((config.words?.length ?? 0) === 0 && nonReserved.length > 0) {
+      updateConfig({ words: nonReserved })
+    }
+  }, [wordOptions, config.words, updateConfig])
+
   // Keep the shared Phase 2 score curve in sync with the detection
   // threshold (epic #53 P7).
   useEffect(() => {
@@ -963,6 +1001,21 @@ export const KWSPanel = memo(function KWSPanel({
 
         {error && <span className="text-sm text-danger">{error}</span>}
       </div>
+
+      {/* Wake words - multi-word selector (ADR-039): one score curve per
+          selected word. Options come from the loaded model's labels; hidden
+          for single-word backends. Shared threshold across words. */}
+      {wordOptions.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="text-ink-2">Wake words</span>
+          <UiMultiselect
+            value={(config.words ?? []).join(',')}
+            options={wordOptions.map((w) => ({ value: w, label: w }))}
+            onChange={(v) => updateConfig({ words: v.split(',').filter(Boolean) })}
+            disabled={running || status === 'loading'}
+          />
+        </div>
+      )}
 
       {/* Engine card - the primary action area: resource loading (per-backend)
           + detection start/stop. Kept separate from backend selection so

--- a/apps/web/src/components/MiniScoreCurve.tsx
+++ b/apps/web/src/components/MiniScoreCurve.tsx
@@ -12,7 +12,7 @@ import { drawScoreCurve } from './viz/ScoreCurve'
 import { useLiveKws } from '../workspace/live'
 
 export function MiniScoreCurve() {
-  const { historyRef, threshold } = useLiveKws()
+  const { historyRef, threshold, words } = useLiveKws()
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -21,13 +21,13 @@ export function MiniScoreCurve() {
       const canvas = canvasRef.current
       if (canvas) {
         const ctx = canvas.getContext('2d')
-        if (ctx) drawScoreCurve(ctx, canvas, historyRef.current, threshold)
+        if (ctx) drawScoreCurve(ctx, canvas, historyRef.current, threshold, words)
       }
       rafId = requestAnimationFrame(render)
     }
     rafId = requestAnimationFrame(render)
     return () => cancelAnimationFrame(rafId)
-  }, [historyRef, threshold])
+  }, [historyRef, threshold, words])
 
   return (
     <canvas

--- a/apps/web/src/components/ScoreCurvePanel.tsx
+++ b/apps/web/src/components/ScoreCurvePanel.tsx
@@ -11,7 +11,7 @@ import { drawScoreCurve } from './viz/ScoreCurve'
 import { useLiveKws } from '../workspace/live'
 
 export function ScoreCurvePanel({ running }: { running: boolean }) {
-  const { historyRef, threshold } = useLiveKws()
+  const { historyRef, threshold, words } = useLiveKws()
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -22,14 +22,14 @@ export function ScoreCurvePanel({ running }: { running: boolean }) {
       const canvas = canvasRef.current
       if (canvas) {
         const ctx = canvas.getContext('2d')
-        if (ctx) drawScoreCurve(ctx, canvas, historyRef.current, threshold)
+        if (ctx) drawScoreCurve(ctx, canvas, historyRef.current, threshold, words)
       }
       rafId = requestAnimationFrame(render)
     }
 
     rafId = requestAnimationFrame(render)
     return () => cancelAnimationFrame(rafId)
-  }, [running, threshold, historyRef])
+  }, [running, threshold, historyRef, words])
 
   const last = historyRef.current.length > 0
     ? historyRef.current[historyRef.current.length - 1]

--- a/apps/web/src/components/viz/ScoreCurve.ts
+++ b/apps/web/src/components/viz/ScoreCurve.ts
@@ -8,12 +8,29 @@
 
 import type { KWSScoreSample } from '@wake-studio/module-kws-engine'
 
-/** Draw the scrolling score curve with threshold line. */
+/** Line colors for per-word curves (ADR-039 multi-word). */
+const WORD_COLORS = [
+  '#38bdf8',
+  '#34d399',
+  '#f472b6',
+  '#fbbf24',
+  '#a78bfa',
+  '#f87171',
+  '#2dd4bf',
+]
+
+/**
+ * Draw the scrolling score curve with threshold line.
+ *
+ * When `words` is set and the samples carry `wordScores` (ADR-039), draw one
+ * raw line per word; otherwise fall back to the single raw/smoothed pair.
+ */
 export function drawScoreCurve(
   ctx: CanvasRenderingContext2D,
   canvas: HTMLCanvasElement,
   history: KWSScoreSample[],
   threshold: number,
+  words?: string[],
 ): void {
   const w = canvas.width
   const h = canvas.height
@@ -34,31 +51,47 @@ export function drawScoreCurve(
 
   const xStep = w / (HISTORY_MAX - 1)
 
-  // Raw score (faint).
-  ctx.strokeStyle = 'rgba(129,140,248,0.4)'
-  ctx.lineWidth = 1
-  ctx.beginPath()
-  for (let i = 0; i < history.length; i++) {
-    const x = i * xStep
-    const y = h - history[i].rawScore * h
-    if (i === 0) ctx.moveTo(x, y)
-    else ctx.lineTo(x, y)
+  const drawLine = (
+    getY: (s: KWSScoreSample) => number,
+    color: string,
+    width: number,
+  ) => {
+    ctx.strokeStyle = color
+    ctx.lineWidth = width
+    ctx.beginPath()
+    for (let i = 0; i < history.length; i++) {
+      const x = i * xStep
+      const y = h - getY(history[i]) * h
+      if (i === 0) ctx.moveTo(x, y)
+      else ctx.lineTo(x, y)
+    }
+    ctx.stroke()
   }
-  ctx.stroke()
 
-  // Smoothed score (bright).
-  ctx.strokeStyle = '#38bdf8'
-  ctx.lineWidth = 1.5
-  ctx.beginPath()
-  for (let i = 0; i < history.length; i++) {
-    const x = i * xStep
-    const y = h - history[i].smoothedScore * h
-    if (i === 0) ctx.moveTo(x, y)
-    else ctx.lineTo(x, y)
+  // Multi-word mode: one raw line per configured word.
+  if (words && words.length > 0 && history[0].wordScores) {
+    words.forEach((word, idx) => {
+      const color = WORD_COLORS[idx % WORD_COLORS.length]
+      drawLine((s) => s.wordScores?.[word] ?? 0, color, 1.5)
+    })
+    // Highlight triggered regions (shared by both modes).
+    highlightTriggered(ctx, history, xStep, h)
+    return
   }
-  ctx.stroke()
 
-  // Highlight triggered regions.
+  // Single-word mode: raw score (faint) + smoothed score (bright).
+  drawLine((s) => s.rawScore, 'rgba(129,140,248,0.4)', 1)
+  drawLine((s) => s.smoothedScore, '#38bdf8', 1.5)
+  highlightTriggered(ctx, history, xStep, h)
+}
+
+/** Shade frames where the trigger condition was met. */
+function highlightTriggered(
+  ctx: CanvasRenderingContext2D,
+  history: KWSScoreSample[],
+  xStep: number,
+  h: number,
+): void {
   ctx.fillStyle = 'rgba(52,211,153,0.1)'
   for (let i = 0; i < history.length; i++) {
     if (history[i].triggered) {

--- a/apps/web/src/training/__tests__/colab-import.test.ts
+++ b/apps/web/src/training/__tests__/colab-import.test.ts
@@ -144,6 +144,16 @@ describe('registerColabBundle (issue #97)', () => {
     expect(result.bundle.files.provenance.license).toBe('user-owned')
     expect(result.bundle.files.metrics?.accuracy).toBe(0.8)
   })
+
+  it('uses the standard ADR-039 labels list for the phrase (metadata.labels)', async () => {
+    const bundle = colabBundle()
+    bundle.files.metadata.labels = ['hey studio', 'good morning']
+    const result = await registerColabBundle(bundle)
+    // Assert the exact artifact this call created (listProvisionArtifacts is
+    // newest-first but Date.now() ties across tests, so [0] is unreliable).
+    expect(result.artifact.name).toContain('hey studio, good morning')
+    expect(result.bundle.files.metadata.labels).toEqual(['hey studio', 'good morning'])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/training/colab-import.ts
+++ b/apps/web/src/training/colab-import.ts
@@ -55,12 +55,16 @@ export async function registerColabBundle(
     type: 'application/octet-stream',
   })
 
-  // The wake phrase key varies by producer: the Colab notebook writes
-  // `wakePhrase`, the studio-backend kws-streaming runner writes
-  // `wakePhrases` (and the wizard may record it under either).
+  // The canonical wake-word source is now the standard ADR-039 labels list
+  // (metadata.labels from labels.json). Fall back to the legacy param keys
+  // (the Colab notebook writes `wakePhrase`, the studio-backend kws-streaming
+  // runner writes `wakePhrases`) for bundles produced before ADR-039.
   const metaParams = bundle.files.metadata.params ?? {}
+  const labels = bundle.files.metadata.labels ?? []
   const phrase =
-    String(metaParams.wakePhrase ?? metaParams.wakePhrases ?? '')
+    labels.length > 0
+      ? labels.join(', ')
+      : String(metaParams.wakePhrase ?? metaParams.wakePhrases ?? '')
   const jobId = bundle.jobId
   const license = bundle.files.provenance.license
 

--- a/apps/web/src/training/console/NewTrainWizard.tsx
+++ b/apps/web/src/training/console/NewTrainWizard.tsx
@@ -116,6 +116,9 @@ export function NewTrainWizard({
             category: module.category,
             license: module.license,
             params: module.train.params,
+            // ADR-039 §4.6: formats/quantization selectors render spec-driven.
+            formats: module.train.formats,
+            quantization: module.train.quantization,
           })
         : null,
     [module],

--- a/apps/web/src/training/train-modules.ts
+++ b/apps/web/src/training/train-modules.ts
@@ -28,6 +28,14 @@ export interface TrainableModuleTrain {
   python?: string
   invocation?: string[]
   outputs?: { checkpoint?: string; metrics?: string }
+  /** ADR-039 §4.5: multi-wake-word capability. */
+  multiWord?: boolean
+  /** ADR-039 §4.6: selectable output formats. */
+  formats?: { default: string[]; options: string[] }
+  /** ADR-039 §4.6: selectable quantization schemes. */
+  quantization?: { default?: string; options: string[] }
+  /** ADR-039 §4.6: module-owned convert script declaration. */
+  convert?: { entry: string; from?: string[]; to?: string[] }
 }
 
 export interface TrainableModule {

--- a/apps/web/src/workspace/kws-config.ts
+++ b/apps/web/src/workspace/kws-config.ts
@@ -40,7 +40,9 @@ function descriptorFromParam(param: ModuleParam): ParameterDescriptor {
         ? 'select'
         : param.type === 'secret'
           ? 'string'
-          : param.type
+          : param.type === 'multiselect'
+            ? 'select' // training-only type (formats selector); KWS driver params never use it
+            : param.type
   return {
     id: param.id,
     label: param.label,

--- a/apps/web/src/workspace/live.tsx
+++ b/apps/web/src/workspace/live.tsx
@@ -105,6 +105,10 @@ interface LiveKwsValue {
   /** Latest smoothed score (top-bar mini bar wake indicator). */
   lastScore: number
   setLastScore: (s: number) => void
+  /** Configured wake words (ADR-039) — the score curve draws one line per
+   *  word. Shared across all KWS surfaces. */
+  words: string[]
+  setWords: (w: string[]) => void
 }
 
 const LiveKwsContext = React.createContext<LiveKwsValue | null>(null)
@@ -114,11 +118,13 @@ export function LiveKwsProvider({ children }: { children: React.ReactNode }) {
   const [threshold, setThreshold] = React.useState(0.5)
   const [kwsRunning, setKwsRunningState] = React.useState(false)
   const [lastScore, setLastScoreState] = React.useState(0)
+  const [words, setWordsState] = React.useState<string[]>([])
   const setKwsRunning = React.useCallback((r: boolean) => setKwsRunningState(r), [])
   const setLastScore = React.useCallback((s: number) => setLastScoreState(s), [])
+  const setWords = React.useCallback((w: string[]) => setWordsState(w), [])
   const value = React.useMemo(
-    () => ({ historyRef, threshold, setThreshold, kwsRunning, setKwsRunning, lastScore, setLastScore }),
-    [threshold, kwsRunning, setKwsRunning, lastScore, setLastScore],
+    () => ({ historyRef, threshold, setThreshold, kwsRunning, setKwsRunning, lastScore, setLastScore, words, setWords }),
+    [threshold, kwsRunning, setKwsRunning, lastScore, setLastScore, words, setWords],
   )
   return <LiveKwsContext.Provider value={value}>{children}</LiveKwsContext.Provider>
 }

--- a/packages/contracts/src/module-spec.schema.json
+++ b/packages/contracts/src/module-spec.schema.json
@@ -105,7 +105,8 @@
               "enum",
               "slider",
               "secret",
-              "string"
+              "string",
+              "multiselect"
             ]
           },
           "default": {},

--- a/packages/contracts/src/module-spec.schema.json
+++ b/packages/contracts/src/module-spec.schema.json
@@ -436,7 +436,7 @@
               },
               "env": {
                 "type": "string",
-                "description": "Notebook env var this train param maps to (issue #105) \u2014 the app bakes the user's value into the downloaded notebook by replacing the default in os.environ.get(\"ENV\", \"default\")."
+                "description": "Notebook env var this train param maps to (issue #105) — the app bakes the user's value into the downloaded notebook by replacing the default in os.environ.get(\"ENV\", \"default\")."
               }
             }
           }
@@ -520,6 +520,64 @@
         },
         "adapterOptions": {
           "type": "object"
+        },
+        "multiWord": {
+          "type": "boolean",
+          "description": "Multi-wake-word capability (ADR-039 §4.5): true -> the module trains ONE model for many wake words and the canonical input is wakePhrases (array); false -> single-phrase (wakePhrase)."
+        },
+        "formats": {
+          "type": "object",
+          "description": "Selectable output formats (ADR-039 §4.6); the canonical upstream-native artifact is always kept, others are derived.",
+          "properties": {
+            "default": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "quantization": {
+          "type": "object",
+          "description": "Selectable quantization schemes (ADR-039 §4.6).",
+          "properties": {
+            "default": {
+              "type": "string"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "convert": {
+          "type": "object",
+          "description": "Module-owned convert script (ADR-039 §4.6): callable at train time AND standalone on an already-trained canonical model.",
+          "properties": {
+            "entry": {
+              "type": "string"
+            },
+            "from": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/packages/contracts/src/module-spec.ts
+++ b/packages/contracts/src/module-spec.ts
@@ -148,6 +148,32 @@ export interface ModuleTrain {
     metricsParser?: string
     [key: string]: unknown
   }
+  /**
+   * Multi-wake-word capability (ADR-039 §4.5): true → the module trains ONE
+   * model for many wake words, and the canonical wake-word input is
+   * `wakePhrases` (array). false → single-phrase (param `wakePhrase`).
+   */
+  multiWord?: boolean
+  /** Selectable output formats (ADR-039 §4.6): the wizard renders the options;
+   *  the canonical upstream-native artifact is always kept, others are derived. */
+  formats?: {
+    default: string[]
+    options: string[]
+  }
+  /** Selectable quantization schemes (ADR-039 §4.6). */
+  quantization?: {
+    default?: string
+    options: string[]
+  }
+  /** Module-owned convert script (ADR-039 §4.6): callable at train time AND
+   *  standalone on an already-trained canonical model. */
+  convert?: {
+    entry: string
+    /** Source formats it accepts. */
+    from?: string[]
+    /** Target formats it can derive. */
+    to?: string[]
+  }
 }
 
 /** A build input for the generic build workflow (workflow_dispatch input). */

--- a/packages/contracts/src/module-spec.ts
+++ b/packages/contracts/src/module-spec.ts
@@ -9,7 +9,7 @@
  */
 
 /** Param control kinds (ADR-017 leaf; panel generator maps 1:1). */
-export type ParamType = 'number' | 'boolean' | 'select' | 'enum' | 'slider' | 'secret' | 'string'
+export type ParamType = 'number' | 'boolean' | 'select' | 'enum' | 'slider' | 'secret' | 'string' | 'multiselect'
 
 export interface ParamValidation {
   required?: boolean

--- a/packages/module-kit/src/ui/controls.tsx
+++ b/packages/module-kit/src/ui/controls.tsx
@@ -148,6 +148,59 @@ export function UiSelect({ value, options, onChange, disabled, placeholder = 'Se
 }
 
 // ---------------------------------------------------------------------------
+// Multiselect (param type: multiselect)
+// ---------------------------------------------------------------------------
+
+/** A toggle-chip group for a param type: multiselect (ADR-039 §4.6).
+ *  The value is a comma-joined string ("onnx,tflite-int8") so the job-params
+ *  contract stays string-valued across the wizard, registry and adapters. */
+export function UiMultiselect({
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  value: string
+  options: ReadonlyArray<UiSelectOption>
+  onChange: (value: string) => void
+  disabled?: boolean
+}) {
+  const selected = new Set(value ? value.split(',').map((s) => s.trim()).filter(Boolean) : [])
+  const toggle = (v: string) => {
+    const next = new Set(selected)
+    if (next.has(v)) next.delete(v)
+    else next.add(v)
+    onChange([...next].join(','))
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {options.map((opt) => {
+        const on = selected.has(opt.value)
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            aria-pressed={on}
+            disabled={disabled}
+            onClick={() => toggle(opt.value)}
+            className={cn(
+              'rounded-full border px-2.5 py-1 text-xs transition-colors',
+              on
+                ? 'border-brand-9 bg-brand-9/15 text-brand-11'
+                : 'border-line bg-surface-3 text-ink-2 hover:border-ink-4',
+              disabled && 'opacity-40',
+            )}
+          >
+            {on ? '✓ ' : ''}
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Toggle (param type: boolean)
 // ---------------------------------------------------------------------------
 

--- a/packages/module-kit/src/ui/index.ts
+++ b/packages/module-kit/src/ui/index.ts
@@ -10,6 +10,7 @@ export {
   UiSlider,
   UiNumber,
   UiSelect,
+  UiMultiselect,
   UiToggle,
   UiButton,
   UiProgress,

--- a/packages/module-kit/src/ui/mapper.tsx
+++ b/packages/module-kit/src/ui/mapper.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { ModuleParam, ModuleAction } from '@wake-studio/contracts'
-import { UiSlider, UiNumber, UiSelect, UiToggle, UiParamRow } from './controls'
+import { UiSlider, UiNumber, UiSelect, UiToggle, UiMultiselect, UiParamRow } from './controls'
 
 export interface ParamControlProps {
   param: ModuleParam
@@ -78,6 +78,19 @@ export function renderParamControl({ param, value, onChange, disabled }: ParamCo
       const options = normalizeSelectOptions(param.options)
       return (
         <UiSelect
+          value={typeof value === 'string' ? value : String(param.default ?? '')}
+          options={options}
+          onChange={(v) => onChange(v)}
+          disabled={disabled}
+        />
+      )
+    }
+    case 'multiselect': {
+      // Comma-joined string value ("a,b") so the job-params contract stays
+      // string-valued end-to-end (ADR-039 §4.6 formats selector).
+      const options = normalizeSelectOptions(param.options)
+      return (
+        <UiMultiselect
           value={typeof value === 'string' ? value : String(param.default ?? '')}
           options={options}
           onChange={(v) => onChange(v)}

--- a/packages/module-kit/tests/multiselect.test.tsx
+++ b/packages/module-kit/tests/multiselect.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * module-kit - multiselect control (param type: multiselect, ADR-039 §4.6).
+ *
+ * The training wizard's "Output format(s)" selector lets the user pick several
+ * target formats to zip. The value stays a comma-joined string so the
+ * job-params contract is string-valued end-to-end.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { UiMultiselect } from '../src/ui/controls'
+
+const OPTIONS = [
+  { value: 'onnx', label: 'onnx' },
+  { value: 'tflite', label: 'tflite' },
+  { value: 'tflite-int8', label: 'tflite-int8' },
+]
+
+function html(value: string) {
+  return renderToStaticMarkup(
+    <UiMultiselect value={value} options={OPTIONS} onChange={() => {}} />,
+  )
+}
+
+describe('UiMultiselect', () => {
+  it('marks the selected options as pressed (aria-pressed)', () => {
+    const markup = html('onnx,tflite-int8')
+    expect(markup).toContain('aria-pressed="true"')
+    // two selected -> exactly two pressed chips
+    expect(markup.match(/aria-pressed="true"/g)).toHaveLength(2)
+    expect(markup.match(/aria-pressed="false"/g)).toHaveLength(1)
+  })
+
+  it('renders nothing selected for an empty value', () => {
+    const markup = html('')
+    expect(markup.match(/aria-pressed="true"/g)).toBeNull()
+    expect(markup.match(/aria-pressed="false"/g)).toHaveLength(3)
+  })
+
+  it('labels the chips from the option labels', () => {
+    const markup = html('onnx')
+    expect(markup).toContain('onnx')
+    expect(markup).toContain('tflite-int8')
+  })
+})

--- a/packages/modules/kws/engine/core/KWSEngine.ts
+++ b/packages/modules/kws/engine/core/KWSEngine.ts
@@ -376,6 +376,7 @@ export class KWSEngine {
         smoothedScore: smoothed,
         triggered: triggerEvent !== null,
         vadProbability,
+        wordScores: (backend as KWSBackend).wordScores ?? undefined,
       }),
     )
     if (triggerEvent) {

--- a/packages/modules/kws/engine/core/types.ts
+++ b/packages/modules/kws/engine/core/types.ts
@@ -50,6 +50,12 @@ export interface KWSScoreSample {
   triggered: boolean
   /** VAD probability [0,1] (from the AFE's RNNoise VAD, ADR-018). */
   vadProbability: number
+  /**
+   * Raw per-word scores (label -> [0,1]) for the last frame (ADR-039).
+   * Present when the active backend can provide per-word posteriors (e.g.
+   * a multi-class kws-streaming model); absent for single-word backends.
+   */
+  wordScores?: Record<string, number>
 }
 
 /** A wake-word trigger event. */
@@ -78,6 +84,13 @@ export interface KWSConfig {
    * {@link DEFAULT_MODEL_RUNTIME} ('onnx').
    */
   runtime?: ModelRuntime
+  /**
+   * Configured wake words (ADR-039): the host's multi-word selector. Each
+   * word the user enables is shown as its own score curve (when the backend
+   * provides {@link KWSScoreSample.wordScores}). Shared threshold/smoothing
+   * across words (human decision 2026-08-18).
+   */
+  words?: string[]
 }
 
 /** Descriptor for one tunable parameter (shared with AFE, ADR-017). */
@@ -111,6 +124,19 @@ export interface KWSBackend {
    * posterior [0,1], or null during warmup (not enough audio accumulated).
    */
   processFrame(samples: Float32Array): Promise<number | null>
+  /**
+   * Optional (ADR-039): per-word raw scores (label -> [0,1]) for the last
+   * processed frame, or null when the backend is single-word. The engine
+   * threads these into {@link KWSScoreSample.wordScores} so hosts can draw a
+   * score curve per wake word. Optional, so existing backends are untouched.
+   */
+  readonly wordScores?: Record<string, number> | null
+  /**
+   * Optional (ADR-039): the wake-word labels this backend can detect — the
+   * options for the host's multi-word selector (e.g. a multi-class model's
+   * labels, an ASR keyword list). Optional; single-word backends omit it.
+   */
+  readonly labels?: string[]
   /** Reset internal state (e.g. on stop). */
   reset(): void
   /** Release model resources. */

--- a/packages/modules/kws/engine/web/worker.ts
+++ b/packages/modules/kws/engine/web/worker.ts
@@ -63,6 +63,8 @@ let smoother = new ScoreSmoother(config.smoothingWindowFrames)
  * continuous so the min-duration trigger can actually accumulate.
  */
 let lastScore: number | null = null
+/** Last per-word scores from the backend (sample-and-hold, ADR-039). */
+let lastWordScores: Record<string, number> | null = null
 const trigger = new TriggerDetector(
   config.threshold,
   config.minDurationMs,
@@ -271,6 +273,7 @@ function handleConfig(newConfig: KWSConfig): void {
   if (newConfig.smoothingWindowFrames !== oldWindow) {
     smoother = new ScoreSmoother(newConfig.smoothingWindowFrames)
     lastScore = null
+    lastWordScores = null
   }
   trigger.configure(
     newConfig.threshold,
@@ -348,6 +351,7 @@ async function handleAudio(
     score = lastScore
   } else {
     lastScore = score
+    lastWordScores = backend.wordScores ?? null
   }
 
   const smoothed = smoother.push(score)
@@ -365,6 +369,7 @@ async function handleAudio(
       smoothedScore: smoothed,
       triggered: triggerEvent !== null,
       vadProbability,
+      wordScores: lastWordScores ?? undefined,
     },
   })
 
@@ -440,6 +445,7 @@ self.onmessage = async (e: MessageEvent<KWSWorkerMessage>) => {
         // Drop the held score too, or the next session would start by holding a
         // stale (possibly above-threshold) value from the previous run.
         lastScore = null
+        lastWordScores = null
         break
     }
   } catch (err) {

--- a/packages/modules/kws/openwakeword/spec/module.spec.json
+++ b/packages/modules/kws/openwakeword/spec/module.spec.json
@@ -108,22 +108,29 @@
         "default": true,
         "description": "Background mixing + room impulse responses (notebook env WAKE_AUGMENT).",
         "env": "WAKE_AUGMENT"
-      },
-      {
-        "id": "quantize",
-        "label": "Quantize export",
-        "group": "advanced",
-        "type": "boolean",
-        "default": true,
-        "description": "Emit a TFLite model alongside the ONNX (best-effort, notebook env WAKE_QUANTIZE).",
-        "env": "WAKE_QUANTIZE"
       }
     ],
     "outputs": {
       "checkpoint": "out/model.onnx",
       "metrics": "out/metrics.json"
     },
-    "entry": "train/train_adapter.py"
+    "entry": "train/train_adapter.py",
+    "formats": {
+      "default": [
+        "onnx"
+      ],
+      "options": [
+        "onnx",
+        "tflite-int8"
+      ]
+    },
+    "quantization": {
+      "default": "none",
+      "options": [
+        "none",
+        "int8-static"
+      ]
+    }
   },
   "build": {
     "recipe": "none",

--- a/packages/modules/kws/openwakeword/spec/module.spec.json
+++ b/packages/modules/kws/openwakeword/spec/module.spec.json
@@ -49,6 +49,7 @@
   },
   "train": {
     "notebookLocal": "packages/modules/kws/openwakeword/train/colab/train.ipynb",
+    "multiWord": false,
     "invocation": [
       "studio-backend",
       "colab"

--- a/packages/modules/kws/openwakeword/spec/module.spec.json
+++ b/packages/modules/kws/openwakeword/spec/module.spec.json
@@ -130,6 +130,15 @@
         "none",
         "int8-static"
       ]
+    },
+    "convert": {
+      "entry": "train/convert.py",
+      "from": [
+        "onnx"
+      ],
+      "to": [
+        "onnx-fp16"
+      ]
     }
   },
   "build": {

--- a/packages/modules/kws/openwakeword/train/convert.py
+++ b/packages/modules/kws/openwakeword/train/convert.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""openwakeword module convert script (ADR-039 §4.6, spec.train.convert).
+
+Standalone counterpart to the train-time bundle: given an already-trained
+canonical ``model.onnx``, derive the additional target formats the module
+declares in ``spec.train.convert`` (today: an fp16 variant via onnxruntime).
+
+The quantized ``tflite-int8`` is produced by the upstream train itself (the
+canonical artifact is onnx + upstream tflite), so this script only derives
+what is NOT already produced upstream:
+
+    python convert.py path/to/model.onnx --output path/to/model-fp16.onnx
+
+Requires ``onnxruntime`` (a convert-stage dependency, not a train-env one).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from wake_train_kit.convert import ConvertError, onnx_fp16
+
+DESCRIPTION = "Derive an fp16 ONNX from a trained openwakeword model (ADR-039 §4.6)."
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("onnx", type=Path, help="canonical model.onnx (from a bundle)")
+    parser.add_argument("--output", "-o", type=Path, default=None, help="output fp16 .onnx path")
+    args = parser.parse_args(argv)
+
+    out = args.output or args.onnx.with_name(f"{args.onnx.stem}-fp16.onnx")
+    try:
+        result = onnx_fp16(args.onnx, out)
+    except ConvertError as exc:
+        print(f"[openwakeword convert] ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"[openwakeword convert] ok: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/modules/kws/openwakeword/train/tests/test_train_adapter.py
+++ b/packages/modules/kws/openwakeword/train/tests/test_train_adapter.py
@@ -143,6 +143,8 @@ def test_end_to_end_adapter(tmp_path):
     assert metadata["moduleId"] == "kws-openwakeword"
     assert metadata["params"]["wakePhrase"] == "hey studio"
     assert metadata["backend"] == "colab"
+    assert metadata["labels"] == ["hey studio"], "metadata.labels is the ADR-039 label list"
+    assert json.loads((bundle / "labels.json").read_text()) == ["hey studio"]
     provenance = json.loads((bundle / "provenance.json").read_text())
     assert provenance["license"] == "user-owned"
 
@@ -152,6 +154,7 @@ def test_end_to_end_adapter(tmp_path):
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
     assert any(n.endswith("model.onnx") for n in names)
+    assert any(n.endswith("labels.json") for n in names)
     assert any(n.endswith("metadata.json") for n in names)
 
 

--- a/packages/modules/kws/openwakeword/train/tests/test_train_adapter.py
+++ b/packages/modules/kws/openwakeword/train/tests/test_train_adapter.py
@@ -145,6 +145,8 @@ def test_end_to_end_adapter(tmp_path):
     assert metadata["backend"] == "colab"
     assert metadata["labels"] == ["hey studio"], "metadata.labels is the ADR-039 label list"
     assert json.loads((bundle / "labels.json").read_text()) == ["hey studio"]
+    assert metadata["formats"]["requested"] == ["onnx"], "requested formats (ADR-039 §4.6)"
+    assert metadata["formats"]["shipped"] == ["onnx"], "fake upstream produces only onnx"
     provenance = json.loads((bundle / "provenance.json").read_text())
     assert provenance["license"] == "user-owned"
 

--- a/packages/modules/kws/openwakeword/train/train_adapter.py
+++ b/packages/modules/kws/openwakeword/train/train_adapter.py
@@ -56,6 +56,8 @@ DEFAULTS = {
     "falseActivationPenalty": 1500,
     "augment": True,
     "quantize": True,
+    "formats": "onnx",
+    "quantization": "int8-static",
 }
 
 STAGES: list[tuple[str, str]] = [
@@ -91,6 +93,7 @@ def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
         raw = env.get(name, "").lower()
         return default if raw == "" else raw in ("1", "true", "yes")
 
+    quantize = flag("WAKE_QUANTIZE", DEFAULTS["quantize"])
     return {
         "wakePhrase": _s("WAKE_PHRASE", DEFAULTS["wakePhrase"]),
         "target": _s("WAKE_TARGET", DEFAULTS["target"]),
@@ -101,7 +104,13 @@ def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
             "WAKE_FALSE_ACTIVATION", DEFAULTS["falseActivationPenalty"]
         ),
         "augment": flag("WAKE_AUGMENT", DEFAULTS["augment"]),
-        "quantize": flag("WAKE_QUANTIZE", DEFAULTS["quantize"]),
+        "quantize": quantize,
+        # ADR-039 §4.6: formats/quantization selectors. Defaults preserve the
+        # legacy quantize flag behaviour (a quantized tflite is produced).
+        "formats": _s("WAKE_FORMATS", DEFAULTS["formats"]),
+        "quantization": _s(
+            "WAKE_QUANTIZATION", "int8-static" if quantize else "none"
+        ),
         "jobId": _s("WAKE_JOB_ID", f"kws-openwakeword-{int(time.time() * 1000)}"),
         "backend": _s("WAKE_BACKEND", "colab"),
     }
@@ -210,8 +219,14 @@ def build_bundle(
     bundle_dir = Path(out_root) / params["jobId"]
     bundle_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(onnx_path, bundle_dir / "model.onnx")
-    if params["quantize"] and tflite_path.is_file():
+
+    # ADR-039 §4.6: requested formats (comma-separated select) vs what shipped.
+    requested = [f.strip() for f in params["formats"].split(",") if f.strip()] or ["onnx"]
+    want_tflite = any(f in ("tflite", "tflite-int8") for f in requested)
+    shipped = ["onnx"]
+    if tflite_path.is_file() and (want_tflite or params["quantize"]):
         shutil.copy(tflite_path, bundle_dir / "model.tflite")
+        shipped.append("tflite-int8" if "tflite-int8" in requested else "tflite")
 
     # Standard ordered label list (ADR-039 §4.5): single-phrase classifier.
     labels = [params["wakePhrase"]]
@@ -234,6 +249,7 @@ def build_bundle(
             "augment": str(params["augment"]).lower(),
             "quantize": str(params["quantize"]).lower(),
         },
+        "formats": {"requested": requested, "shipped": shipped},
         "labels": labels,
         "trainedAtMs": int(time.time() * 1000),
     }

--- a/packages/modules/kws/openwakeword/train/train_adapter.py
+++ b/packages/modules/kws/openwakeword/train/train_adapter.py
@@ -213,6 +213,10 @@ def build_bundle(
     if params["quantize"] and tflite_path.is_file():
         shutil.copy(tflite_path, bundle_dir / "model.tflite")
 
+    # Standard ordered label list (ADR-039 §4.5): single-phrase classifier.
+    labels = [params["wakePhrase"]]
+    (bundle_dir / "labels.json").write_text(json.dumps(labels), encoding="utf-8")
+
     metrics = parse_metrics(log_text)
     metrics["steps"] = params["steps"]
     metrics["epochs"] = params["steps"]  # upstream trains for `steps` optimizer steps
@@ -230,6 +234,7 @@ def build_bundle(
             "augment": str(params["augment"]).lower(),
             "quantize": str(params["quantize"]).lower(),
         },
+        "labels": labels,
         "trainedAtMs": int(time.time() * 1000),
     }
     (bundle_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
@@ -263,8 +268,8 @@ def build_bundle(
 
     zip_path = bundle_dir / "wake-studio-results.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name in ("model.onnx", "model.tflite", "metrics.json", "metadata.json",
-                     "provenance.json", "config.json"):
+        for name in ("model.onnx", "model.tflite", "labels.json", "metrics.json",
+                     "metadata.json", "provenance.json", "config.json"):
             p = bundle_dir / name
             if p.is_file():
                 zf.write(p, arcname=f"{params['jobId']}/{name}")

--- a/packages/modules/kws/sherpa/core/backend.ts
+++ b/packages/modules/kws/sherpa/core/backend.ts
@@ -291,6 +291,24 @@ export class SherpaOnnxKwsBackend implements KWSBackend {
     return this._lastKeyword
   }
 
+  /** Optional (ADR-039): the configured keyword list — the options for the
+   *  host's multi-word selector (sherpa takes a comma-separated wake-word
+   *  list). */
+  get labels(): string[] | undefined {
+    const kws = this._cfg.keywords ?? DEFAULT_KEYWORDS
+    return kws.split(',').map((k) => k.trim()).filter(Boolean)
+  }
+
+  /** Optional (ADR-039): per-word raw scores. sherpa is hit-based, not a
+   *  per-frame posterior, so while a keyword is held we report {keyword: 1}
+   *  (the host draws that word's curve at its peak); otherwise null. */
+  get wordScores(): Record<string, number> | null {
+    if (this._holdFrames > 0 && this._lastKeyword) {
+      return { [this._lastKeyword]: 1 }
+    }
+    return null
+  }
+
   reset(): void {
     if (this._spotter && this._stream) {
       try {

--- a/packages/modules/kws/sherpa/tests/backend.test.ts
+++ b/packages/modules/kws/sherpa/tests/backend.test.ts
@@ -69,6 +69,7 @@ interface TestBackend {
   _stream: FakeStream
   _holdFrames: number
   lastPartialText: string
+  configure(cfg: Partial<Record<string, unknown>>): void
   processFrame(samples: Float32Array): Promise<number | null>
 }
 
@@ -135,5 +136,22 @@ describe('SherpaOnnxKwsBackend.processFrame', () => {
     expect(held).toBe(1)
     expect(stream.acceptWaveform).toHaveBeenCalledTimes(2)
     expect(spotter.decodeCalls).toBe(1)
+  })
+
+  it('exposes the configured keyword list as multi-word labels + hit scores (ADR-039)', async () => {
+    const spotter = new FakeSpotter()
+    spotter.readyTicks = 1
+    spotter.results = [{ keyword: 'okay' }]
+    const backend = makeBackend(spotter)
+    backend.configure({ keywords: 'hey, studio, okay' })
+
+    // The multi-word selector options come from the comma-separated list.
+    const labels = (backend as unknown as { labels: string[] }).labels
+    expect(labels).toEqual(['hey', 'studio', 'okay'])
+
+    // Before a hit there is no per-word score; after a hit, {keyword: 1}.
+    expect((backend as unknown as { wordScores: Record<string, number> | null }).wordScores).toBeNull()
+    await backend.processFrame(FRAME)
+    expect((backend as unknown as { wordScores: Record<string, number> | null }).wordScores).toEqual({ okay: 1 })
   })
 })

--- a/packages/modules/kws/streaming/core/backend.ts
+++ b/packages/modules/kws/streaming/core/backend.ts
@@ -33,6 +33,7 @@ import {
   createStateBag,
   resetStateBag,
   selectLabelScore,
+  softmax,
   stateBagBytes,
 } from './streaming'
 
@@ -104,6 +105,30 @@ export class KWSStreamingBackend implements KWSBackend {
    */
   get lastLabelScores(): Float32Array | null {
     return this._lastLabelScores
+  }
+
+  /** Optional (ADR-039): per-word raw scores (label -> [0,1]) for the last
+   *  frame — the full softmax over the model's labels. Null before the first
+   *  frame. The engine threads this into KWSScoreSample.wordScores so the
+   *  host can draw a score curve per wake word. */
+  get wordScores(): Record<string, number> | null {
+    const manifest = this._manifest
+    const raw = this._lastLabelScores
+    if (!manifest || !raw) return null
+    const probs = manifest.softmaxed ? raw : softmax(raw)
+    const out: Record<string, number> = {}
+    for (let i = 0; i < manifest.labels.length; i++) {
+      const s = probs[i]
+      out[manifest.labels[i]] = Number.isFinite(s)
+        ? Math.max(0, Math.min(1, s))
+        : 0
+    }
+    return out
+  }
+
+  /** Optional (ADR-039): available wake-word labels for the host selector. */
+  get labels(): string[] | undefined {
+    return this._manifest?.labels
   }
 
   configure(patch: Partial<KwsStreamingConfig>): void {

--- a/packages/modules/kws/streaming/spec/module.spec.json
+++ b/packages/modules/kws/streaming/spec/module.spec.json
@@ -298,6 +298,15 @@
       "options": [
         "none"
       ]
+    },
+    "convert": {
+      "entry": "train/convert.py",
+      "from": [
+        "tflite"
+      ],
+      "to": [
+        "onnx"
+      ]
     }
   },
   "build": {

--- a/packages/modules/kws/streaming/spec/module.spec.json
+++ b/packages/modules/kws/streaming/spec/module.spec.json
@@ -139,6 +139,7 @@
       "studio-backend",
       "ci"
     ],
+    "multiWord": true,
     "params": [
       {
         "id": "model",

--- a/packages/modules/kws/streaming/spec/module.spec.json
+++ b/packages/modules/kws/streaming/spec/module.spec.json
@@ -283,6 +283,21 @@
       "modelRegex": "stream_state_external\\.tflite$",
       "labelsFile": "labels.txt",
       "flagsFile": "flags.json"
+    },
+    "formats": {
+      "default": [
+        "tflite"
+      ],
+      "options": [
+        "tflite",
+        "onnx"
+      ]
+    },
+    "quantization": {
+      "default": "none",
+      "options": [
+        "none"
+      ]
     }
   },
   "build": {

--- a/packages/modules/kws/streaming/tests/streaming-state.test.ts
+++ b/packages/modules/kws/streaming/tests/streaming-state.test.ts
@@ -29,6 +29,7 @@ import {
   softmax,
   stateBagBytes,
 } from '../core/streaming'
+import { KWSStreamingBackend } from '../core/backend'
 
 /** A minimal well-formed streaming manifest (ds_tc_resnet-shaped). */
 function baseManifest(): Record<string, unknown> {
@@ -476,5 +477,36 @@ describe('SlidingWindow (non-streamable topologies)', () => {
     expect(() => new SlidingWindow(0, 1)).toThrow()
     expect(() => new SlidingWindow(4, 0)).toThrow()
     expect(() => new SlidingWindow(4, 8)).toThrow(/exceeds/)
+  })
+})
+
+describe('KWSStreamingBackend.wordScores + labels (ADR-039 multi-word)', () => {
+  it('maps the last label posteriors to label -> score', () => {
+    const backend = new KWSStreamingBackend()
+    const b = backend as unknown as {
+      _manifest: KwsStreamingManifest
+      _lastLabelScores: Float32Array
+    }
+    b._manifest = validateManifest(baseManifest())
+    // logits favor 'up' over 'down'; wordScores softmaxes when not softmaxed.
+    b._lastLabelScores = new Float32Array([0.1, 0.2, 0.6, 0.1])
+
+    const labels = (backend as unknown as { labels: string[] }).labels
+    expect(labels).toEqual(['silence', 'unknown', 'up', 'down'])
+
+    const ws = (backend as unknown as { wordScores: Record<string, number> | null }).wordScores
+    expect(ws).not.toBeNull()
+    expect(ws!['up']).toBeGreaterThan(ws!['down'])
+    expect(ws!['up']).toBeGreaterThan(0)
+    expect(ws!['up']).toBeLessThanOrEqual(1)
+    // All manifest labels are present.
+    expect(Object.keys(ws!)).toEqual(['silence', 'unknown', 'up', 'down'])
+  })
+
+  it('returns null wordScores before the first frame', () => {
+    const backend = new KWSStreamingBackend()
+    const b = backend as unknown as { _manifest: KwsStreamingManifest | null }
+    b._manifest = validateManifest(baseManifest())
+    expect((backend as unknown as { wordScores: Record<string, number> | null }).wordScores).toBeNull()
   })
 })

--- a/packages/modules/kws/streaming/train/convert.py
+++ b/packages/modules/kws/streaming/train/convert.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""kws-streaming module convert script (ADR-039 §4.6, spec.train.convert).
+
+Standalone counterpart to the train-time derive: given an already-trained
+canonical ``model.tflite`` (from a bundle or an upstream run dir), derive the
+target formats the module declares in ``spec.train.convert`` (tflite -> onnx
+for the in-browser test + browser export row).
+
+Reuses the shared ``wake_train_kit.convert.tflite_to_onnx`` transform (the
+same one the CI export path uses). Run it in an env that has tf2onnx:
+
+    python convert.py path/to/model.tflite --output path/to/model.onnx
+
+When tf2onnx is missing, a :class:`ConvertError` is raised with a clear
+message — run the convert stage env instead of the train env.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from wake_train_kit.convert import ConvertError, tflite_to_onnx
+
+DESCRIPTION = "Derive ONNX from a trained kws-streaming TFLite model (ADR-039 §4.6)."
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("tflite", type=Path, help="canonical model.tflite (from a bundle)")
+    parser.add_argument("--output", "-o", type=Path, default=None, help="output .onnx path")
+    parser.add_argument("--opset", type=int, default=17, help="ONNX opset (default 17)")
+    args = parser.parse_args(argv)
+
+    out = args.output or args.tflite.with_suffix(".onnx")
+    try:
+        result = tflite_to_onnx(args.tflite, out, opset=args.opset)
+    except ConvertError as exc:
+        print(f"[kws-streaming convert] ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"[kws-streaming convert] ok: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/modules/kws/streaming/train/tests/test_train_adapter.py
+++ b/packages/modules/kws/streaming/train/tests/test_train_adapter.py
@@ -222,6 +222,8 @@ def test_end_to_end_adapter(tmp_path):
     assert metadata["params"]["model"] == "ds_tc_resnet"
     assert metadata["backend"] == "self-hosted"
     assert metadata["labels"] == ["_silence_", "_unknown_", "yes"]
+    assert metadata["formats"]["requested"] == ["tflite"], "requested formats (ADR-039 §4.6)"
+    assert metadata["formats"]["shipped"] == ["tflite"], "onnx derivation lands with #177"
 
     provenance = json.loads((bundle / "provenance.json").read_text())
     assert provenance["license"] == "user-owned"

--- a/packages/modules/kws/streaming/train/tests/test_train_adapter.py
+++ b/packages/modules/kws/streaming/train/tests/test_train_adapter.py
@@ -210,6 +210,8 @@ def test_end_to_end_adapter(tmp_path):
     assert (bundle / "flags.json").is_file()
     labels = (bundle / "labels.txt").read_text().splitlines()
     assert labels == ["_silence_", "_unknown_", "yes"]
+    assert json.loads((bundle / "labels.json").read_text()) == ["_silence_", "_unknown_", "yes"], \
+        "labels.json is the standard ADR-039 label list (from upstream labels.txt)"
 
     metrics = json.loads((bundle / "metrics.json").read_text())
     assert metrics["streaming_accuracy_reset0"] == 0.98
@@ -219,6 +221,7 @@ def test_end_to_end_adapter(tmp_path):
     assert metadata["moduleId"] == "kws-streaming"
     assert metadata["params"]["model"] == "ds_tc_resnet"
     assert metadata["backend"] == "self-hosted"
+    assert metadata["labels"] == ["_silence_", "_unknown_", "yes"]
 
     provenance = json.loads((bundle / "provenance.json").read_text())
     assert provenance["license"] == "user-owned"
@@ -226,6 +229,7 @@ def test_end_to_end_adapter(tmp_path):
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
     assert any(n.endswith("model.tflite") for n in names)
+    assert any(n.endswith("labels.json") for n in names)
     assert any(n.endswith("metadata.json") for n in names)
 
 

--- a/packages/modules/kws/streaming/train/train_adapter.py
+++ b/packages/modules/kws/streaming/train/train_adapter.py
@@ -385,6 +385,18 @@ def build_bundle(
         if p.is_file():
             shutil.copy(p, bundle_dir / name)
 
+    # Standard ordered label list (ADR-039 §4.5): upstream labels.txt (one
+    # label per line, class-index order) becomes the standard labels.json.
+    labels: list[str] = []
+    labels_txt = train_dir / "labels.txt"
+    if labels_txt.is_file():
+        labels = [
+            ln.strip() for ln in labels_txt.read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+    if labels:
+        (bundle_dir / "labels.json").write_text(json.dumps(labels), encoding="utf-8")
+
     metrics = parse_metrics(train_dir, log_text)
     metrics["training_steps"] = params["howManyTrainingSteps"]
     (bundle_dir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
@@ -403,6 +415,7 @@ def build_bundle(
             "trainingSteps": params["howManyTrainingSteps"],
             "learningRate": params["learningRate"],
         },
+        "labels": labels or None,
         "trainedAtMs": int(time.time() * 1000),
     }
     (bundle_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
@@ -435,8 +448,9 @@ def build_bundle(
 
     zip_path = bundle_dir / "wake-studio-results.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name in ("model.tflite", "labels.txt", "flags.json", "metrics.json",
-                     "metadata.json", "provenance.json", "config.json"):
+        for name in ("model.tflite", "labels.txt", "labels.json", "flags.json",
+                     "metrics.json", "metadata.json", "provenance.json",
+                     "config.json"):
             p = bundle_dir / name
             if p.is_file():
                 zf.write(p, arcname=f"{params['jobId']}/{name}")

--- a/packages/modules/kws/streaming/train/train_adapter.py
+++ b/packages/modules/kws/streaming/train/train_adapter.py
@@ -85,6 +85,8 @@ DEFAULTS: dict[str, Any] = {
     "backgroundFrequency": 0.8,
     "silencePercentage": 10.0,
     "unknownPercentage": 10.0,
+    "formats": "tflite",
+    "quantization": "none",
     "jobId": None,
     "backend": "colab",
 }
@@ -109,6 +111,8 @@ ENV_MAP: dict[str, str] = {
     "STREAM_BACKGROUND_FREQUENCY": "backgroundFrequency",
     "STREAM_SILENCE_PERCENTAGE": "silencePercentage",
     "STREAM_UNKNOWN_PERCENTAGE": "unknownPercentage",
+    "STREAM_FORMATS": "formats",
+    "STREAM_QUANTIZATION": "quantization",
     "STREAM_JOB_ID": "jobId",
     "STREAM_BACKEND": "backend",
 }
@@ -414,6 +418,13 @@ def build_bundle(
             "dataSource": params["dataSource"],
             "trainingSteps": params["howManyTrainingSteps"],
             "learningRate": params["learningRate"],
+        },
+        # ADR-039 §4.6: requested formats vs shipped. The derived .onnx for the
+        # browser lands with the module-owned convert stage (#177).
+        "formats": {
+            "requested": [f.strip() for f in params["formats"].split(",") if f.strip()]
+            or ["tflite"],
+            "shipped": ["tflite"],
         },
         "labels": labels or None,
         "trainedAtMs": int(time.time() * 1000),

--- a/packages/modules/kws/streaming/train/train_adapter.py
+++ b/packages/modules/kws/streaming/train/train_adapter.py
@@ -372,8 +372,16 @@ def build_bundle(
     sources: list[dict[str, Any]],
     log_text: str,
     reporter: Reporter,
+    data_dir: str | None = None,
 ) -> Path:
-    """Normalize the upstream run dir into the standard bundle (§6) and zip it."""
+    """Normalize the upstream run dir into the standard bundle (§6) and zip it.
+
+    ``data_dir`` (when available) is the prepared ``label/*.wav`` tree: used
+    to snapshot a tiny ``calibration/`` set (ADR-039 §4.6/§6) and, when the
+    requested formats include onnx, to attempt a train-time tflite→onnx derive
+    (opportunistic — tf2onnx lives in the CI convert stage, not the train env,
+    so a missing toolchain logs and ships the canonical tflite only).
+    """
     model_src = train_dir / "tflite_stream_state_external" / "stream_state_external.tflite"
     if not model_src.is_file():
         raise FileNotFoundError(
@@ -384,6 +392,25 @@ def build_bundle(
     bundle_dir = Path(out_root) / params["jobId"]
     bundle_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(model_src, bundle_dir / "model.tflite")
+    shipped = ["tflite"]
+
+    # ADR-039 §4.6: train-time onnx derive (opportunistic). tf2onnx is a
+    # convert-stage tool, not a train-env dep, so a missing toolchain is not
+    # fatal — the standalone convert.py covers the full derive.
+    requested = [f.strip() for f in params["formats"].split(",") if f.strip()]
+    if "onnx" in requested:
+        try:
+            from wake_train_kit.convert import tflite_to_onnx
+
+            tflite_to_onnx(bundle_dir / "model.tflite", bundle_dir / "model.onnx")
+            shipped.append("onnx")
+            reporter.emit("log", level="info", message="derived model.onnx (tflite→onnx)")
+        except Exception as exc:  # noqa: BLE001 - toolchain missing/failed
+            reporter.emit(
+                "log", level="info",
+                message=f"train-time onnx derive skipped: {exc}",
+            )
+
     for name in ("labels.txt", "flags.json"):
         p = train_dir / name
         if p.is_file():
@@ -420,11 +447,12 @@ def build_bundle(
             "learningRate": params["learningRate"],
         },
         # ADR-039 §4.6: requested formats vs shipped. The derived .onnx for the
-        # browser lands with the module-owned convert stage (#177).
+        # browser is attempted at train time (opportunistic; see build_bundle)
+        # and always available via the module-owned convert stage (#177).
         "formats": {
             "requested": [f.strip() for f in params["formats"].split(",") if f.strip()]
             or ["tflite"],
-            "shipped": ["tflite"],
+            "shipped": shipped,
         },
         "labels": labels or None,
         "trainedAtMs": int(time.time() * 1000),
@@ -457,14 +485,30 @@ def build_bundle(
     }
     (bundle_dir / "config.json").write_text(json.dumps(config_snapshot, indent=2), encoding="utf-8")
 
+    # ADR-039 §6: tiny calibration/ set for later standalone int8 PTQ. Snapshotted
+    # from the prepared label/*.wav tree (best-effort; skipped when absent).
+    calibration: list[Path] = []
+    if data_dir:
+        try:
+            from wake_train_kit.convert import snapshot_calibration
+
+            wavs = sorted(Path(data_dir).rglob("*.wav"))
+            calibration = snapshot_calibration(
+                wavs, bundle_dir / "calibration", max_seconds=30.0, sample_rate=16000
+            )
+        except Exception as exc:  # noqa: BLE001
+            reporter.emit("log", level="info", message=f"calibration snapshot skipped: {exc}")
+
     zip_path = bundle_dir / "wake-studio-results.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name in ("model.tflite", "labels.txt", "labels.json", "flags.json",
-                     "metrics.json", "metadata.json", "provenance.json",
-                     "config.json"):
+        for name in ("model.tflite", "model.onnx", "labels.txt", "labels.json",
+                     "flags.json", "metrics.json", "metadata.json",
+                     "provenance.json", "config.json"):
             p = bundle_dir / name
             if p.is_file():
                 zf.write(p, arcname=f"{params['jobId']}/{name}")
+        for cal in calibration:
+            zf.write(cal, arcname=f"{params['jobId']}/calibration/{cal.name}")
     reporter.emit("log", level="info", message=f"bundle ready: {zip_path}")
     return zip_path
 
@@ -625,6 +669,7 @@ def main(argv: list[str] | None = None) -> int:
         bundle_zip = build_bundle(
             params, wanted, train_dir, out_root, sources,
             "\n".join(log_lines), reporter,
+            data_dir=data_dir,
         )
     except Exception as exc:  # noqa: BLE001
         reporter.emit("error", message=f"bundle error: {exc}")

--- a/packages/modules/training/core/manifest.ts
+++ b/packages/modules/training/core/manifest.ts
@@ -18,6 +18,8 @@ export interface ArtifactBundleMetadata {
   backend: TrainingJobBackend
   provider?: string
   params: Record<string, string>
+  /** Ordered wake-word labels matching the model class index (ADR-039 §4.5). */
+  labels?: string[]
   trainedAtMs: number
 }
 
@@ -37,6 +39,9 @@ export interface ArtifactBundle {
   files: {
     /** model.onnx | model.tflite */
     model?: Uint8Array
+    /** Standard ordered label list (labels.json, ADR-039 §4.5): matches the
+     *  model class index, so a multi-class model can be tested per phrase. */
+    labels?: string[]
     metrics?: Record<string, number>
     metadata: ArtifactBundleMetadata
     provenance: ArtifactProvenance
@@ -123,6 +128,7 @@ export type BundleImportErrorCode =
   | 'missing-provenance'
   | 'invalid-metadata'
   | 'invalid-provenance'
+  | 'invalid-labels'
   | 'missing-model'
 
 /** Messages shown to the user for each {@link BundleImportErrorCode}. */
@@ -135,6 +141,8 @@ export const BUNDLE_IMPORT_ERROR_MESSAGES: Record<BundleImportErrorCode, string>
     'metadata.json is invalid — it must declare jobId, moduleId and a known backend (colab, self-hosted or cloud).',
   'invalid-provenance':
     'provenance.json is invalid — it must declare a license (e.g. “user-owned”).',
+  'invalid-labels':
+    'labels.json is invalid — it must be a non-empty array of non-empty strings matching the model class index (ADR-039).',
   'missing-model': 'No model found — the zip should contain model.onnx or model.tflite.',
 }
 
@@ -152,6 +160,7 @@ export const BUNDLE_IMPORT_ERROR_MESSAGES: Record<BundleImportErrorCode, string>
  *
  * ```
  * model.onnx | model.tflite
+ * labels.json   (optional, ADR-039: ordered, matches the class index)
  * metrics.json
  * metadata.json   (jobId, moduleId, backend: colab|self-hosted|cloud, params, trainedAtMs)
  * provenance.json (license: user-owned → Phase 4 export gate)
@@ -236,11 +245,29 @@ export async function importColabBundle(
   const metrics = readJson('metrics.json') as Record<string, number> | undefined
   const config = readJson('config.json') as Record<string, unknown> | undefined
 
+  // Standard ordered label list (ADR-039 §4.5). Optional for back-compat with
+  // pre-ADR bundles, but when present it must be a non-empty array of
+  // non-empty strings (the model class index contract).
+  const labels = readJson('labels.json') as unknown
+  if (labels !== undefined) {
+    const isLabels =
+      Array.isArray(labels) &&
+      labels.length > 0 &&
+      labels.every((l) => typeof l === 'string' && l.trim().length > 0)
+    if (!isLabels) {
+      throw new BundleImportError('invalid-labels', BUNDLE_IMPORT_ERROR_MESSAGES['invalid-labels'])
+    }
+  }
+  const labelsList: string[] | undefined = Array.isArray(labels)
+    ? (labels as string[])
+    : undefined
+
   const bundle: ArtifactBundle = {
     jobId,
     modelFormat: modelOnnx ? 'onnx' : 'tflite',
     files: {
       model,
+      labels: labelsList,
       metrics,
       metadata: {
         jobId,
@@ -248,6 +275,7 @@ export async function importColabBundle(
         backend,
         provider: metadata.provider,
         params: metadata.params ?? {},
+        labels: labelsList,
         trainedAtMs: metadata.trainedAtMs ?? 0,
       },
       provenance: {

--- a/packages/modules/training/core/train-spec.ts
+++ b/packages/modules/training/core/train-spec.ts
@@ -18,6 +18,10 @@ export interface TrainableModuleLike {
   license: string
   /** The module's own train params (spec.train.params). */
   params?: ModuleParam[]
+  /** Selectable output formats (spec.train.formats, ADR-039 §4.6). */
+  formats?: { default: string[]; options: string[] }
+  /** Selectable quantization schemes (spec.train.quantization, ADR-039 §4.6). */
+  quantization?: { default?: string; options: string[] }
 }
 
 export type TrainPanelSpec = Pick<
@@ -31,7 +35,34 @@ export type TrainPanelSpec = Pick<
  * (no actions/status), so the wizard shows exactly the module's train knobs.
  */
 export function trainPanelSpec(module: TrainableModuleLike): TrainPanelSpec {
-  const params = module.params ?? []
+  const params = [...(module.params ?? [])]
+
+  // ADR-039 §4.6: formats + quantization are capability-labeled selectors
+  // declared in spec.train — inject them as spec-driven params so the wizard
+  // renders them without any hard-coded format UI here.
+  if (module.formats?.options?.length) {
+    params.push({
+      id: 'formats',
+      label: 'Output format(s)',
+      group: 'primary',
+      type: 'select',
+      default: module.formats.default?.[0] ?? module.formats.options[0],
+      options: module.formats.options,
+      description: 'Target model format(s) to derive from the canonical artifact (ADR-039 §4.6).',
+    })
+  }
+  if (module.quantization?.options?.length) {
+    params.push({
+      id: 'quantization',
+      label: 'Quantization',
+      group: 'advanced',
+      type: 'select',
+      default: module.quantization.default ?? module.quantization.options[0],
+      options: module.quantization.options,
+      description: 'Quantization scheme applied to the requested formats (ADR-039 §4.6).',
+    })
+  }
+
   return {
     meta: {
       id: module.id,

--- a/packages/modules/training/core/train-spec.ts
+++ b/packages/modules/training/core/train-spec.ts
@@ -45,10 +45,10 @@ export function trainPanelSpec(module: TrainableModuleLike): TrainPanelSpec {
       id: 'formats',
       label: 'Output format(s)',
       group: 'primary',
-      type: 'select',
-      default: module.formats.default?.[0] ?? module.formats.options[0],
+      type: 'multiselect',
+      default: (module.formats.default ?? []).join(','),
       options: module.formats.options,
-      description: 'Target model format(s) to derive from the canonical artifact (ADR-039 §4.6).',
+      description: 'Target model format(s) to derive from the canonical artifact; pick several to zip them all (ADR-039 §4.6).',
     })
   }
   if (module.quantization?.options?.length) {

--- a/packages/modules/training/tests/manifest.test.ts
+++ b/packages/modules/training/tests/manifest.test.ts
@@ -96,6 +96,7 @@ function colabZip(opts: {
   withProvenance?: boolean
   withMetadata?: boolean
   prefix?: boolean
+  labels?: string[] | unknown
 } = {}): Uint8Array {
   const {
     jobId = 'kws-openwakeword-123',
@@ -105,6 +106,7 @@ function colabZip(opts: {
     withProvenance = true,
     withMetadata = true,
     prefix = true,
+    labels,
   } = opts
   const files: Record<string, Uint8Array> = {}
   const put = (name: string, obj: unknown) => {
@@ -134,6 +136,9 @@ function colabZip(opts: {
   }
   put('metrics.json', { recall: 0.9, accuracy: 0.8, steps: 10000 })
   put('config.json', { wakePhrase: 'hey studio', target: 'app-class' })
+  if (labels !== undefined) {
+    put('labels.json', labels)
+  }
   return zipSync(files, { level: 0 })
 }
 
@@ -152,6 +157,35 @@ describe('importColabBundle (the PWA Colab-results importer)', () => {
     expect(bundle.files.metrics?.accuracy).toBe(0.8)
     expect(bundle.files.configSnapshot?.target).toBe('app-class')
     expect(bundle.files.model?.byteLength).toBe('fake-onnx-bytes'.length)
+  })
+
+  it('imports labels.json into bundle.files.labels + metadata.labels (ADR-039)', async () => {
+    const zip = colabZip({ labels: ['yes', 'no'] })
+    const bundle = await importColabBundle(zip)
+    expect(bundle.files.labels).toEqual(['yes', 'no'])
+    expect(bundle.files.metadata.labels).toEqual(['yes', 'no'])
+  })
+
+  it('still imports a bundle without labels.json (back-compat, pre-ADR-039)', async () => {
+    const zip = colabZip()
+    const bundle = await importColabBundle(zip)
+    expect(bundle.files.labels).toBeUndefined()
+    expect(bundle.files.metadata.labels).toBeUndefined()
+  })
+
+  it('rejects an empty labels.json (invalid-labels)', async () => {
+    const zip = colabZip({ labels: [] })
+    await expect(importColabBundle(zip)).rejects.toMatchObject({ code: 'invalid-labels' })
+  })
+
+  it('rejects labels.json with a non-string entry (invalid-labels)', async () => {
+    const zip = colabZip({ labels: ['yes', 42] })
+    await expect(importColabBundle(zip)).rejects.toMatchObject({ code: 'invalid-labels' })
+  })
+
+  it('rejects labels.json whose entries are blank strings (invalid-labels)', async () => {
+    const zip = colabZip({ labels: ['yes', '   '] })
+    await expect(importColabBundle(zip)).rejects.toMatchObject({ code: 'invalid-labels' })
   })
 
   it('tolerates entries NOT prefixed by the job id (flat layout)', async () => {

--- a/packages/modules/training/tests/train-spec.test.ts
+++ b/packages/modules/training/tests/train-spec.test.ts
@@ -69,4 +69,30 @@ describe('trainPanelSpec', () => {
     expect(a.params.map((p) => p.id)).toEqual(['x'])
     expect(b.params).toEqual([])
   })
+
+  it('injects formats + quantization selectors from spec.train (ADR-039 §4.6)', () => {
+    const spec = trainPanelSpec({
+      id: 'kws-openwakeword',
+      name: 'OpenWakeWord',
+      category: 'kws',
+      license: 'Apache-2.0',
+      formats: { default: ['onnx'], options: ['onnx', 'tflite-int8'] },
+      quantization: { default: 'int8-static', options: ['none', 'int8-static'] },
+    })
+    const formats = spec.params.find((p) => p.id === 'formats')
+    const quant = spec.params.find((p) => p.id === 'quantization')
+    expect(formats).toMatchObject({ type: 'select', default: 'onnx', options: ['onnx', 'tflite-int8'] })
+    expect(quant).toMatchObject({ type: 'select', default: 'int8-static', options: ['none', 'int8-static'] })
+    expect(spec.params.map((p) => p.id)).toEqual(['formats', 'quantization'])
+  })
+
+  it('renders no formats/quantization selectors when the module declares none', () => {
+    const spec = trainPanelSpec({
+      id: 'rnnoise',
+      name: 'RNNoise',
+      category: 'afe',
+      license: 'BSD-3-Clause',
+    })
+    expect(spec.params.map((p) => p.id)).toEqual([])
+  })
 })

--- a/packages/modules/training/tests/train-spec.test.ts
+++ b/packages/modules/training/tests/train-spec.test.ts
@@ -76,12 +76,16 @@ describe('trainPanelSpec', () => {
       name: 'OpenWakeWord',
       category: 'kws',
       license: 'Apache-2.0',
-      formats: { default: ['onnx'], options: ['onnx', 'tflite-int8'] },
+      formats: { default: ['onnx', 'tflite-int8'], options: ['onnx', 'tflite-int8'] },
       quantization: { default: 'int8-static', options: ['none', 'int8-static'] },
     })
     const formats = spec.params.find((p) => p.id === 'formats')
     const quant = spec.params.find((p) => p.id === 'quantization')
-    expect(formats).toMatchObject({ type: 'select', default: 'onnx', options: ['onnx', 'tflite-int8'] })
+    expect(formats).toMatchObject({
+      type: 'multiselect',
+      default: 'onnx,tflite-int8',
+      options: ['onnx', 'tflite-int8'],
+    })
     expect(quant).toMatchObject({ type: 'select', default: 'int8-static', options: ['none', 'int8-static'] })
     expect(spec.params.map((p) => p.id)).toEqual(['formats', 'quantization'])
   })


### PR DESCRIPTION
## WIP — ADR-039 implementation tracker

Implements the three ADR-039 follow-up tasks on one branch; each task lands as
its own commit(s) and is ticked off here as it completes. **Do not merge** until
all three are done and CI is green.

- [x] **#175 — multi wake words in training**: standard `labels.json` in the
      bundle, `spec.train.multiWord` capability + `wakePhrases` (array) param,
      importer validation, in-browser phrase selector, `metadata.labels`.
      → landed so far: bundle/importer contract + validation + `multiWord`
      capability (commit 1); adapters emit `labels.json` + phrase selector TBD.
- [x] **#176 — formats + quantization as spec-driven train params**:
      `spec.train.formats` / `spec.train.quantization`, wizard selectors,
      adapters honor them, `metadata.formats` = {requested, shipped}.
- [x] **#177 — module-owned convert stage + shared `wake_train_kit.convert`**:
      `spec.train.convert`, per-module convert scripts (train-time + standalone),
      shared transforms (tflite→onnx, onnx→tflite + int8 PTQ, fp16),
      `calibration/` snapshot.

Design: ADR-039 · `docs/modules/training.md` §4.5/§4.6/§6

## Status (2026-08-18)
- ✅ #175 — bundle/importer contract + `labels.json` + `multiWord` capability +
  adapters emit labels + `metadata.labels`-fed registration. REMAINING: the
  in-browser phrase selector fed from `labels.json` (app-layer; the kws-streaming
  `wantedWord` select is static today — needs dynamic options from the imported
  bundle, tracked as a follow-up).
- ✅ #176 — `formats`/`quantization` spec-driven train params, wizard selectors
  (trainPanelSpec injection), adapters honor them, `metadata.formats` = {requested, shipped}.
- ✅ #177 — `wake_train_kit.convert` shared transforms + per-module `convert.py`
  (tflite→onnx, onnx→fp16) + `calibration/` snapshot + opportunistic train-time
  onnx derive. REMAINING: wiring the standalone `convert.py` into a studio-backend
  "convert existing" job/API + int8 PTQ on `calibration/` (deferred — needs a
  dependency decision).

## Status (2026-08-18, round 2)
- ✅ #175 multi-word workspace KWS now lands: engine wordScores (additive contract),
  kws-streaming full per-label scores + sherpa keyword-list/hit scores, Wake-words
  multi-select fed from the loaded model labels, ScoreCurve draws one line per word,
  shared threshold. REMAINING follow-up: PLiX multi-prototype enrollment (backend
  holds one prototype today) + sherpa continuous per-word scores (it is hit-based).