### PR TITLE
docs(sdk): Phase 4 SDK contract draft + ADR-040 (Q13)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1376,3 +1376,74 @@ applied per this log and may be overridden._
   - Follow-up implementation issues are tracked for: multi-word training
     (labels + wakePhrases + phrase selector), formats/quantization train
     params, and the module-owned convert stage.
+
+---
+
+## ADR-040 — SDK core: C++17 with a C ABI, device code inside modules, link-time composition root, profile-driven builds, native-first CI
+
+- **Status:** Accepted (2026-08-19)
+- **Origin:** Phase 4 SDK design discussion (epic #31); human decisions on
+  language, module placement, registration, low-power vs high-performance
+  split, and first target sequencing. Resolves Q13 (#35) and Q-SDK-1
+  (`docs/modules/sdk.md` §4.1).
+- **Decision:**
+  1. **Core language: C++17 with a strict C ABI.** Public API is `extern "C"`
+     headers (`wake/kws_backend.h`, `wake/afe_graph.h`, …); the core compiles
+     freestanding-friendly (`-fno-exceptions -fno-rtti`, arena allocator, no
+     STL heap in hot paths). Rationale: every wrapped dependency is C/C++
+     (TFLite-Micro and micro-wake-word require C++; RNNoise/PocketSphinx are
+     C; onnxruntime/sherpa expose C APIs) while the C ABI binds to Python
+     (ctypes), Kotlin (JNI), Swift, and JS/WASM (emscripten). Rust/Zig were
+     considered and rejected: the ecosystem we wrap is C/C++, and Rust's
+     TFLite-Micro interop adds friction without benefit.
+  2. **Device code lives inside the module.** Each KWS backend / AFE stage
+     module owns `device/` (C/C++ driver + CMake target) next to its browser
+     driver, train adapter, assets, spec, and tests (ADR-025 extended; matches
+     the CONTRIBUTING layout `packages/modules/<category>/<name>/{core,web,
+     node,train,device,spec,tests}`). Top-level `device/` is the CMake
+     **aggregation tree** (core + selected module `device/` dirs + adapters),
+     not a mirrored tree. `packages/sdk` is the SDK's public binding package
+     (JS/WASM binding + bundle tooling + docs).
+  3. **Link-time registration via an explicit composition root** —
+     `wake_sdk_compose()` calls one registration entry per module
+     (`wake_register_kws_backend` / `wake_register_afe_stage`). This ports the
+     ADR-034 composition-root concept to C and preserves the ADR-024
+     decoupling rule on device: adding a backend/AFE stage = new module + one
+     line in the root; core never edited. Constructor attributes / linker
+     section magic are avoided (fragile on bare-metal).
+  4. **One core, two profiles — not forks.** `WAKE_SDK_PROFILE=mcu|app`
+     selects compile-time feature macros (linked module set, VAD, heap budget,
+     int16 vs float DSP, threading) and a runtime `wake_sdk_capabilities()`
+     query reports the build's reality (device twin of the browser registry's
+     `browserFeasible`). Bundle generation is data-driven end-to-end: export
+     UI picks (profile, backend, AFE mode) → generator emits the CMake target
+     list + composition root + defaults from `module.spec.json` (one schema,
+     two worlds).
+  5. **CI: native host first (Q13/#35 closed).** Native gcc/clang build +
+     unit tests + composition-root integration test on every PR; Cortex-M
+     `arm-none-eabi` cross-compile in the same job matrix; on-hardware
+     validation only for golden-path acceptance.
+  6. **First target sequencing:** (1) native test harness + CLI demo on the
+     dev host (macOS/Linux) validates the core; (2) Cortex-M cross-compile
+     build + tests (no hardware needed); (3) Raspberry Pi Python binding as
+     the app-class golden path; (4) one cheap STM32/Arduino board for final
+     MCU hardware validation; (5) Android/iOS/desktop bindings after the core
+     and one embedded target prove the abstractions. Android-first was
+     rejected: JNI + onnxruntime-android on an unvalidated core is the worst
+     place to debug the core.
+- **Rationale:** ADR-021 already committed to a layered C/C++ core; these
+  decisions pin the dialect/ABI, the module boundary (module-owned device
+  code keeps "a module is a thing you can fully add" true), the registration
+  mechanism that makes the ADR-024 rule hold on device, and the profile
+  mechanism that makes one core span Cortex-M to desktop without divergence.
+  Native-first CI matches the roadmap's Phase 4 risk mitigation ("validate
+  with one C unit-test harness + one golden-path target first").
+- **Consequences:**
+  - `docs/modules/sdk.md` upgraded from stub to Draft v2 (contract per §4–§12).
+  - New impl issues under epic #31 slice the epic into module-layout, core,
+    AFE, harness, CI, composition-root/profile, driver, and binding tasks
+    (see #31 scope).
+  - `packages/sdk` + `device/` gain their first code in the scaffolding task.
+  - Q-SDK-1 resolved (C op-struct mirrors the TS `KWSBackend`); Q-SDK-2 (iOS
+    CoreML vs onnxruntime) and Q-SDK-3 (ESP32 scope) remain open.
+  - #35 (Q13) closed by this ADR.

--- a/docs/modules/sdk.md
+++ b/docs/modules/sdk.md
@@ -1,121 +1,312 @@
-# Device-Side SDK - Module Specification
+# Device-Side SDK — Module Specification
 
-- **Status:** Draft (stub - to be filled at Phase 4 start, per the docs-first rule)
+- **Status:** Draft v2 (filled at Phase 4 start per the docs-first rule; ADR-040 records the core decisions)
 - **Owner:** WakeStudio team
-- **Plan phase:** Phase 4 (reshaped by ADR-021)
-- **Related ADRs:** ADR-019 (target matrix), ADR-020 (pluggable KWS backends),
-  ADR-021 (device-side SDK), ADR-003 (vendor vs portable AFE), ADR-016 (AFE
-  design)
-- **Depends on (modules):** KWS (KWSBackend interface), AFE (portable RNNoise/
-  WebRTC core), Export (bundle generation)
-- **Last updated:** 2026-07-27
+- **Plan phase:** Phase 4 (reshaped by ADR-021; epic #31)
+- **Related ADRs:** ADR-019 (target matrix), ADR-020 (pluggable KWS backends), ADR-021 (device-side SDK), ADR-003/016 (AFE), ADR-024 (KWS decoupling), ADR-025 (module platform), ADR-034 (composition roots), ADR-040 (core language / placement / profiles / CI)
+- **Depends on (modules):** KWS (`KWSBackend` interface), AFE (RNNoise/WebRTC cores), Export (bundle generation)
+- **Last updated:** 2026-08-19
 
 ## 1. Purpose
 
 WakeStudio develops a **layered portable device-side SDK**, and **every export
 workflow is built upon it** (ADR-021). The SDK is the shared substrate that lets
-WakeStudio emit application templates for the full target matrix (ADR-019) - Arm
-Cortex-M (STM32, Arduino), Raspberry Pi, Android, iOS, browsers, and desktop
-(Linux/macOS/Windows) - without maintaining N divergent codepaths. The in-browser
+WakeStudio emit application templates for the full target matrix (ADR-019) —
+Arm Cortex-M (STM32, Arduino), Raspberry Pi, Android, iOS, browsers, and desktop
+(Linux/macOS/Windows) — without maintaining N divergent codepaths. The in-browser
 PWA demo also consumes the same `KWSBackend` interface (via the JS/WASM binding)
 so the demo and the exports stay consistent.
 
-> This is a **stub**. The full contract is written just-in-time at Phase 4 start
-> (plan §11), reviewed, and then implemented. It is recorded now so ADR-021 has a
-> concrete document home and the Phase 4 reshaping is visible.
+**Module-ownership principle (ADR-025, extended):** every KWS backend and every
+AFE stage is a **self-contained module** that owns *everything about its
+component* — its spec, its browser driver, its training adapter, its
+**on-device run code**, its assets, and its tests. Adding a component (e.g. a new
+KWS backend or AFE stage) = new module + one line in the composition root; the
+SDK core is never edited (ADR-024 decoupling rule, now on device).
 
 ## 2. Scope & boundaries
 
 - **In scope:**
-  - A target-agnostic **Core (C/C++)**: the `KWSBackend` interface (ADR-020), a
-    portable AFE (RNNoise/WebRTC, per ADR-003/016), audio-I/O + threading + clock
-    abstractions, and VAD.
-  - **Target adapters**: per-platform implementations of the abstractions (audio
-    capture, model runtime, threading) for each target in ADR-019.
-  - **Language bindings**: JS/WASM (browsers), Kotlin (Android), Swift (iOS),
-    Python (Linux/macOS/Windows), C/TFLite-Micro (Cortex-M, ESP32).
+  - A target-agnostic **Core (C++17 with a strict C ABI)**: the `KWSBackend`
+    interface (ADR-020), the generic detection loop, a portable AFE graph,
+    audio-I/O + threading + clock + memory abstractions, VAD, config and
+    capabilities. See ADR-040 §1 for the language/ABI rationale.
+  - **Per-component modules** (one per KWS backend / AFE stage), each carrying
+    its `device/` implementation (C/C++ driver + CMake target).
+  - **Target adapters**: per-platform implementations of the abstractions
+    (audio capture, model runtime, threading) for each target in ADR-019.
+  - **Language bindings**: C API (universal), Python (Linux/macOS/Windows,
+    ctypes), Kotlin (Android, JNI), Swift (iOS), JS/WASM (browsers,
+    emscripten), C/TFLite-Micro (Cortex-M, ESP32).
   - The **bundle layout** every export emits: SDK adapter + model + AFE config +
     `demo/` + `README.md` + `LICENSES.md` + `test/` (FAR/FRR).
 - **Out of scope:**
-  - Training (owned by the Training module / Phase 5 + ADR-013 backends).
+  - Training (owned by the Training module / Phase 5 + ADR-013 backends) —
+    although each module *owns its train adapter*, the training *platform* is
+    shared (`train-kit`, job manager).
   - Audio-data sourcing (owned by the Data-Sources module / ADR-022).
   - The PWA UI itself (the Studio), which *uses* the JS/WASM binding but is not
     part of the exported SDK.
-- **Public surface:** the `KWSBackend` interface, the AFE/abstraction headers,
-  the per-target adapter entry points, and the bundle generator contract.
+- **Public surface:** the `KWSBackend` C API, the AFE/abstraction headers, the
+  per-target adapter entry points, and the bundle generator contract.
 
 ## 3. Dependencies
 
 - **Upstream (consumes from):** KWS module (`KWSBackend` interface + adapters:
-  openWakeWord, micro-wake-word, PLiX Few-Shot, PocketSphinx - ADR-020); AFE
-  module (portable NS/AEC cores).
+  openWakeWord, micro-wake-word, PLiX Few-Shot, PocketSphinx, sherpa-onnx —
+  ADR-020); AFE module (portable NS/AEC cores).
 - **Downstream (provides to):** Export module (Phase 4 bundle generation); the
   in-browser PWA demo (JS/WASM binding).
-- **External libraries / models:** onnxruntime (Apache-2.0), TFLite-Micro
-  (Apache-2.0), RNNoise (BSD-3), WebRTC audio_processing (BSD-3), PocketSphinx
-  (BSD). See `LICENSES.md`; per-target `LICENSES.md` applies because vendor/model
-  licenses differ.
+- **External libraries / models:** TFLite-Micro (Apache-2.0), onnxruntime
+  (Apache-2.0, C API), RNNoise (BSD-3), WebRTC audio_processing (BSD-3),
+  PocketSphinx (BSD), micro-wake-word (Apache-2.0). See `LICENSES.md`;
+  per-target `LICENSES.md` applies because vendor/model licenses differ.
 
 ## 4. Public API & types
 
-_To be specified at Phase 4 start._ The contract will define at minimum:
+### 4.1 The `KWSBackend` C interface (Q-SDK-1 resolved)
 
-- The `KWSBackend` interface (load, processFrame, reset, score/threshold
-  semantics) shared by the in-browser engine and every exported target.
-- The audio-I/O / threading / clock abstraction interface that target adapters
-  implement.
-- The bundle-generator interface (target -> zip layout).
+Mirrors the in-browser `KWSBackend` (TypeScript) one-to-one so the demo and the
+exports stay consistent (ADR-021). A single op-struct + handle:
 
-## 5. Data flow / sequence
+```c
+/* core/include/wake/kws_backend.h */
+typedef struct wake_kws_backend wake_kws_backend_t;   /* opaque handle */
 
-_To be specified at Phase 4 start._ High level: `audio capture -> AFE (core) ->
-KWSBackend (core) -> trigger`, with all three running on the device via the
-target adapter; the PWA demo follows the same path through the JS/WASM binding.
+typedef struct wake_kws_ops {
+    const char *id;                                    /* 'microwakeword' | 'plixkws' | ... */
+    const char *label;
+    /* Load the backend's models. Returns 0 on success. */
+    int (*load)(wake_kws_backend_t *self, const wake_model_urls_t *urls,
+                const wake_kws_config_t *cfg);
+    /* Process one AFE frame (160 samples / 10 ms @ 16 kHz). Returns raw
+       posterior [0,1], or -1 during warmup. */
+    float (*process_frame)(wake_kws_backend_t *self, const int16_t *samples);
+    void (*reset)(wake_kws_backend_t *self);
+    void (*dispose)(wake_kws_backend_t *self);
+} wake_kws_ops_t;
 
-## 6. Configuration & constants
+/* A backend instance is created by its module's registration entry. */
+int wake_register_kws_backend(wake_sdk_t *sdk, const wake_kws_ops_t *ops,
+                              void *(*create)(const wake_kws_config_t *cfg));
+```
 
-_To be specified._ Will be surfaced via `describeParameters()` (ADR-017),
-including per-target frame sizes, sample rate (16 kHz at the KWS boundary),
-latency budgets, and the selectable KWS backend + AFE mode per target.
+The generic **detection loop lives in the core** (never in a module): VAD gate →
+smoothed score (sliding-window max) → threshold + min-duration → cooldown —
+a direct port of `packages/modules/kws/engine/core/logic.ts` (pure math). The
+core owns threading/clocking; the backend owns model-specific inference and its
+own audio windowing/buffering — exactly the browser split (ADR-018).
+
+### 4.2 AFE stage interface
+
+```c
+/* core/include/wake/afe_graph.h */
+typedef struct wake_afe_stage wake_afe_stage_t;
+
+typedef struct wake_afe_stage_ops {
+    const char *id;              /* 'ns' | 'vad' | 'aec' | 'agc' | 'bss' */
+    int (*init)(wake_afe_stage_t *self, const wake_afe_config_t *cfg);
+    int (*process)(wake_afe_stage_t *self, int16_t *frames, size_t n);
+    void (*reset)(wake_afe_stage_t *self);
+} wake_afe_stage_ops_t;
+
+int wake_register_afe_stage(wake_sdk_t *sdk, const wake_afe_stage_ops_t *ops,
+                            void *(*create)(void));
+```
+
+Strict pipeline order is **AEC → BSS → NS → VAD → KWS** (ADR-001/016); AEC/BSS
+are passthrough for v1 (ADR-016) with vendor adapter slots (WebRTC/SpeexDSP).
+RNNoise NS + VAD are real modules ported from the C source the browser WASM
+already vendors.
+
+### 4.3 Capabilities & config
+
+- `wake_sdk_capabilities_t wake_sdk_capabilities(const wake_sdk_t *sdk)` —
+  returns the *build's* capabilities: registered backend ids, sample rates,
+  heap budget, `vad`, `threading`, `float_dsp`. This is the device twin of the
+  browser registry's `browserFeasible` (ADR-020): the bundle generator uses it
+  to pick what to ship, the demo uses it to show what works on *this* build.
+- Config is spec-driven: every module's tunables come from its
+  `module.spec.json` (`describeParameters()` on the web side, ADR-017/025). The
+  device side receives the same keys via the bundle's config file — **one
+  schema, two worlds**, no divergent config.
+
+## 5. Architecture & module layout
+
+### 5.1 Physical layout (ADR-040 §2: device code inside the module)
+
+The device implementation of a component lives **inside its module**, per the
+CONTRIBUTING layout (`packages/modules/<category>/<name>/{core,web,node,train,device,spec,tests}`):
+
+```
+packages/modules/kws/openwakeword/
+├── module.spec.json      ← single fact source: params, asset recipe, train contract, device config
+├── src/                  ← browser driver (JS/TS)
+├── train/                ← training adapter
+├── device/               ← C/C++ driver + CMakeLists.txt (on-device run code)
+├── assets/               ← ADR-027 fetch/build recipe (gitignored binaries)
+├── tests/                ← L1 unit + L2 boot tests (browser + device)
+└── LICENSES.md           ← module-owned license declarations
+```
+
+Top-level `device/` is the **CMake aggregation tree**, not a mirror of the
+modules:
+
+```
+device/
+├── CMakeLists.txt            # add_subdirectory over core + selected module device/ dirs + adapters
+├── core/                     # SDK core (C++17, C ABI headers in core/include/wake/)
+│   ├── kws_backend.h  afe_graph.h  config.h  capabilities.h
+│   ├── audio_io.h  clock.h  thread.h  alloc.h
+│   ├── detection.cxx          # port of engine/core/logic.ts
+│   └── CMakeLists.txt
+├── adapters/                 # per-target: cortex-m/, pi/, android/, ios/, desktop/, wasm/
+├── cmake/                    # toolchains, profile presets
+└── tests/                    # composition-root integration tests (native harness)
+```
+
+`packages/sdk` (npm package) holds the SDK's *public binding package*: the C API
+headers' language-facing side (JS/WASM binding for the PWA + bundle tooling that
+emits composition roots) and SDK docs. `device/` holds the C/C++ source itself.
+
+### 5.2 Registration: link-time composition root (ADR-040 §3)
+
+No dynamic import exists on device, so registration is **link-time**, via an
+explicit composition root — the ADR-034 concept ported to C. Each module exports
+a registration entry (`wake_register_kws_backend(...)`,
+`wake_register_afe_stage(...)`); the composition root is the **only** file that
+calls them:
+
+```c
+/* device/composition/<profile>_root.cxx — one line per module */
+void wake_sdk_compose(wake_sdk_t *sdk) {
+    wake_register_afe_stage(sdk, &afe_ns_ops, afe_ns_create);        /* afe/ns   */
+    wake_register_afe_stage(sdk, &afe_vad_ops, afe_vad_create);      /* afe/vad  */
+    wake_register_kws_backend(sdk, &kws_microwakeword_ops,
+                              kws_microwakeword_create);             /* kws/microwakeword */
+}
+```
+
+The root is hand-written or **generated by the bundle generator** from the
+selected modules' specs (see §9). `__attribute__((constructor))` and linker
+section tricks are avoided: fragile on bare-metal (linker scripts, startup
+code), nondeterministic. An explicit root is debuggable and testable.
+
+### 5.3 Low-power vs high-performance: profiles, not forks (ADR-040 §4)
+
+One core; the mcu/app distinction is **preset configurations**:
+
+- **Compile-time profile** (`WAKE_SDK_PROFILE=mcu|app`): selects feature macros
+  (which modules link, `WAKE_SDK_HAVE_VAD`, heap budget, int16 vs float DSP,
+  frame sizes, threading on/off). MCU build = static buffers, no threads,
+  single backend; app build = heap + threads + multi-backend.
+- **Runtime capabilities** (§4.3) report the profile's reality to demos and the
+  bundle generator.
+- Backend selection stays data-driven end-to-end: export UI picks
+  (profile, backend, AFE mode) → bundle generator emits the matching CMake
+  target list + composition root + defaults. MCU bundles register only
+  `microwakeword`; app bundles register plix/openwakeword/sherpa/pocketsphinx.
+
+## 6. Data flow / sequence
+
+One path for every target (mirrors the browser pipeline):
+
+```
+audio in → [adapter: capture] → [core: AFE graph 16 kHz, 10 ms frames]
+         → [core: KWSBackend.process_frame] → [core: detection loop]
+         → trigger → [adapter: notify/callback]
+```
+
+- Capture is adapter-owned (PCM16 frames at the device rate); the core
+  resamples to 16 kHz at the AFE boundary (sample-rate support is a capability).
+- The detection loop emits score/trigger events the same shape as the browser
+  `KWSScoreSample` / `KWSTriggerEvent` (capturedAtMs, rawScore, smoothedScore,
+  triggered, vadProbability).
 
 ## 7. Error model & failure modes
 
-_To be specified._ Will cover model-load failure, audio-device failure, and
-backend-incompatibility (e.g. a backend too large for a target) with graceful
-fallback to a lighter backend (ADR-020).
+- Model-load failure, audio-device failure, and backend-incompatibility
+  (e.g. a backend too large for a target) are distinct error codes; the demo and
+  bundles degrade gracefully by capability (`wake_sdk_capabilities`), falling
+  back to a lighter backend when available (ADR-020).
+- No exceptions on device builds (`-fno-exceptions`); errors are `int` codes
+  from the C API. Memory exhaustion fails allocation up front (arena), never
+  mid-inference.
 
 ## 8. Observability
 
-_To be specified._ Exposes score/VAD/latency telemetry for the in-app UI and a
-serial/log channel in exported demos.
+- The SDK exposes score/VAD/latency telemetry via a small callback/log seam, so
+  the in-app UI (JS/WASM binding) and exported demos (serial/log channel) render
+  the same per-frame data the browser shows today.
 
-## 9. Testing strategy
+## 9. Bundle generation contract
 
-_To be specified._ Per-target build smoke tests; FAR/FRR `test/` script in every
-bundle; on-hardware validation for golden-path targets.
+Every export is an SDK-based project: model(s) + `labels.json` + AFE config +
+SDK adapter + generated composition root + `demo/` + `README.md` + `LICENSES.md`
+(assembled from per-module declarations) + `test/` (FAR/FRR script). The
+generator is the consumer of `module.spec.json`: selected modules → CMake target
+list + composition root + defaults. A bundle is *buildable and runnable* on its
+target — this is the hard acceptance for #41.
 
-## 10. Security & privacy
+## 10. Testing strategy (ADR-026 applied to the device world)
+
+- **L1 unit tests per module** (native build): e.g. RNNoise NS on a synthetic
+  16 kHz clip; microwakeword with a tiny int8 model.
+- **Composition-root integration test** (native harness, macOS/Linux): assemble
+  core + selected AFE stages + one backend, feed a wav, assert a trigger — the
+  L2-style boot test for device; runs on the developer's host, zero hardware.
+- **Cross-compile builds** (Cortex-M `arm-none-eabi`) in CI: build + link +
+  unit tests, no hardware required.
+- **On-hardware validation**: final acceptance for golden paths only (Cortex-M
+  triggers on the wake word; Pi bundle runs and triggers).
+- **CI (Q13/#35, ADR-040 §5):** native gcc/clang build + tests on every PR
+  first; Cortex-M cross-compile in the same job matrix.
+
+## 11. Security & privacy
 
 - The SDK processes mic audio on-device; no audio leaves the device in exported
   deployments.
 - No credentials are bundled into exported artifacts (ADR-013 security note).
+- Licenses travel with every bundle: per-module declarations → generated
+  `LICENSES.md`; the Phase 4 gate (#42) blocks CC BY-NC-SA models from
+  commercial exports.
 
-## 11. Open questions
+## 12. Implementation sequence (ADR-040 §6)
 
-- `[Q-SDK-1]` Concrete `KWSBackend` C interface shape (resolved at Phase 4 start).
-- `[Q-SDK-2]` Whether iOS uses ONNX Runtime or Core ML for the PLiX/openWakeWord
-  path (resolved at Phase 4 start).
-- `[Q-SDK-3]` ESP32 (deferred target, ADR-019) adapter scope vs Cortex-M-first
-  sequencing.
+1. SDK `device/` layout + module `device/` convention + core skeleton + CMake
+   aggregation (scaffolding).
+2. Core: `KWSBackend` C API + detection loop + config/capabilities.
+3. Core: AFE graph + RNNoise NS + VAD device modules.
+4. **Native test harness + CLI demo** (macOS/Linux host, Q13 native-first).
+5. Device CI job (native build + unit tests, every PR).
+6. Composition root + profile system (mcu/app) + capabilities query.
+7. microwakeword device driver (TFLite-Micro) + Cortex-M cross-compile in CI.
+8. Raspberry Pi Python binding golden path.
+9. plix device driver (onnxruntime C API); openwakeword/sherpa reuse the
+   pattern as follow-ups.
+10. On-hardware MCU validation (buy one cheap STM32/Arduino board for the
+    golden-path acceptance).
+11. Android (JNI) / iOS (Swift) / desktop bindings; bundle generator consumes
+    specs (#39/#41).
 
-## 12. References
+## 13. Open questions
 
-- ADR-019 (target matrix), ADR-020 (pluggable KWS backends), ADR-021 (this SDK).
-- Plan §6 (target matrix), Phase 4 (reshaped).
-- `docs/modules/kws.md`, `docs/modules/afe.md`, `docs/modules/export.md`.
+- `[Q-SDK-2]` iOS: ONNX Runtime vs Core ML for the PLiX/openWakeWord path
+  (resolved at binding time).
+- `[Q-SDK-3]` ESP32 (deferred target, ADR-019): adapter scope vs
+  Cortex-M-first sequencing (stays deferred).
 
-## 13. Change log
+## 14. References
+
+- ADR-019 (target matrix), ADR-020 (pluggable KWS backends), ADR-021 (device
+  SDK), ADR-024 (decoupling), ADR-025 (module platform), ADR-034 (composition
+  roots), ADR-040 (core language / placement / profiles / CI).
+- `docs/architecture.md` §6 (export matrix), `docs/modules/kws.md`,
+  `docs/modules/afe.md`, `docs/modules/export.md`, `LICENSES.md`.
+
+## 15. Change log
 
 | Date | Change | Author |
 |---|---|---|
 | 2026-07-27 | Initial stub (ADR-021 recorded; full contract deferred to Phase 4 start). | WakeStudio team |
+| 2026-08-19 | Draft v2: module-ownership (device code inside modules, ADR-040 §2), KWSBackend C API + detection loop (Q-SDK-1 resolved), AFE stage interface, composition root, profiles + capabilities, bundle contract, testing, sequence. | WakeStudio team |


### PR DESCRIPTION
## Summary

Phase 4 SDK (epic #31) docs-first deliverables: the full device-side SDK contract and the ADR that pins the core design decisions from the 2026-08-19 design discussion.

## What's in this PR

- **`docs/modules/sdk.md`** — stub → Draft v2 contract:
  - `KWSBackend` C op-struct mirroring the browser interface (Q-SDK-1 resolved) + generic detection loop
  - AFE stage interface (AEC → BSS → NS → VAD → KWS, ADR-016 passthroughs)
  - Module ownership: device code lives inside each module (`packages/modules/<category>/<name>/device/`)
  - Link-time composition root (ADR-034 ported to C) — new backend = new module + one line, core never edited
  - mcu/app profiles via `WAKE_SDK_PROFILE` + runtime `wake_sdk_capabilities()` (device twin of `browserFeasible`)
  - Bundle generation contract, testing strategy, implementation sequence
- **`DECISIONS.md`** — **ADR-040**: C++17 core with a strict C ABI · device code inside modules · link-time composition root · one core, two profiles · native-first CI (Q13) · first-target sequencing (host harness → Cortex-M cross-compile → Pi golden path → hardware → mobile)

## Verification

- Docs only; no code. Branch builds nothing yet (scaffolding tasks #179–#189 will).
- Decision record consistent with the Phase 4 epic scope (#31) and roadmap §8 risk mitigation.

Closes #35 (Q13 — decision recorded as ADR-040)
Refs #31
