### PR TITLE
feat(sdk): openwakeword device driver — onnxruntime C API (#192)

### DIFF
--- a/.github/workflows/device.yml
+++ b/.github/workflows/device.yml
@@ -59,6 +59,48 @@ jobs:
           python3 packages/sdk/python/wake-sdk-demo.py tone.wav && echo "python tone: OK"
           ! python3 packages/sdk/python/wake-sdk-demo.py silence.wav && echo "python silence: OK"
 
+  app-runtime:
+    name: App profile + onnxruntime (openwakeword driver, #192)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Pinned onnxruntime prebuilt (ADR-031, issue #192): the openwakeword
+      # driver links it and the L1 test runs the real onnx pipeline. The
+      # tarball is fetched + sha256-verified by the script, never committed.
+      - name: Fetch onnxruntime (pinned 1.21.0)
+        run: node scripts/fetch-onnxruntime.mjs
+
+      # The three onnx models (melspectrogram / embedding / hey-buddy
+      # classifier) from the models-openwakeword-v1 release (ADR-027).
+      - name: Fetch openwakeword model assets
+        run: node scripts/fetch-artifact.mjs kws-openwakeword || echo "openwakeword assets fetch failed; L1 runtime test will skip"
+
+      # Stage the models under the names the driver declares (ADR-040 §4.1):
+      # melspectrogram.onnx / embedding_model.onnx / classifier.onnx.
+      - name: Stage driver model dir
+        run: |
+          mkdir -p models
+          cp packages/modules/kws/openwakeword/assets/openWakeWord/melspectrogram.onnx models/
+          cp packages/modules/kws/openwakeword/assets/openWakeWord/embedding_model.onnx models/
+          cp packages/modules/kws/openwakeword/assets/hey-buddy/models/hey-buddy.onnx models/classifier.onnx
+
+      - name: Configure (runtime ON)
+        run: cmake -S device -B build -DCMAKE_BUILD_TYPE=Debug -DWAKE_SDK_PROFILE=app \
+          -DWAKE_SDK_OPENWAKEWORD_HAS_RUNTIME=ON \
+          -DWAKE_OPENWAKEWORD_MODEL_DIR=$PWD/models
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run tests (real onnx pipeline L1, ADR-026)
+        run: ctest --test-dir build --output-on-failure
+
   cross-mcu:
     name: Cross-compile (Cortex-M4, arm-none-eabi)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,12 @@ packages/modules/*/*/train/*.egg-info/
 # onnxruntime-web wasm runtime (copied from node_modules at build, P0-4)
 apps/web/public/ort/
 
+# Fetched prebuilt runtimes (ADR-031 pin, issue #192): downloaded by
+# scripts/fetch-onnxruntime.mjs, never committed (ADR-027 spirit).
+third_party/onnxruntime/linux-x64/
+third_party/onnxruntime/linux-aarch64/
+third_party/onnxruntime/osx-universal2/
+
 # studio-backend runtime state (ADR-036): SQLite store + artifacts
 apps/studio-backend/.venv/
 apps/studio-backend/data/

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -76,6 +76,12 @@ Every model or component that enters an **export bundle** is classified:
 | Web Audio API + AudioWorklet | W3C standard | Royalty-free | Yes | ✅ | W3C RF policy. |
 | fft.js (DSP FFT core, `@wake-studio/dsp` ADR-032) | `indutny/fft.js` | MIT | Yes | ✅ | MIT license (see npm). |
 
+## Device-side runtimes (Phase 4 SDK, ADR-040)
+
+| Component | Source | License | Commercial? | Class | How verified |
+|---|---|---|---|---|---|
+| onnxruntime (native C API, pinned **1.21.0**) | `microsoft/onnxruntime` | Apache-2.0 | Yes | ✅ | Release tarball `LICENSE` (Apache-2.0). Fetched prebuilt at `third_party/onnxruntime/<host>` (ADR-031 pin, never committed; issue #192 — shared app-class runtime, kws-streaming #194 reuses it). |
+
 ## TTS for synthetic training data (Phase 5) — ⚠️ license change
 
 | Component | Source | License | Commercial? | Class | How verified |

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -33,6 +33,10 @@ add_subdirectory(
   ${CMAKE_BINARY_DIR}/modules/kws/microwakeword
 )
 add_subdirectory(
+  ../packages/modules/kws/openwakeword/device
+  ${CMAKE_BINARY_DIR}/modules/kws/openwakeword
+)
+add_subdirectory(
   ../packages/modules/afe/rnnoise/device
   ${CMAKE_BINARY_DIR}/modules/afe/rnnoise
 )

--- a/device/tests/unit/CMakeLists.txt
+++ b/device/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(sdk_unit_tests
   afe_graph.test.cxx
   rnnoise.test.cxx
   microwakeword.test.cxx
+  openwakeword.test.cxx
 )
 target_link_libraries(sdk_unit_tests PRIVATE
   wake_sdk_core
@@ -13,6 +14,20 @@ target_link_libraries(sdk_unit_tests PRIVATE
   wake_afe_aec
   wake_afe_bss
   wake_kws_microwakeword
+  wake_kws_openwakeword
 )
+# The openwakeword L1 test (issue #192) has two faces: the no-runtime
+# contract test and, when the onnxruntime is linked, a real-inference test
+# over the three onnx models. The compile-time gate + model dir must match
+# the module's own configuration.
+if(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  target_compile_definitions(sdk_unit_tests PRIVATE WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME=1)
+  set(WAKE_OPENWAKEWORD_MODEL_DIR "" CACHE PATH
+      "Directory holding the openwakeword onnx models (L1 runtime test)")
+  if(WAKE_OPENWAKEWORD_MODEL_DIR)
+    target_compile_definitions(sdk_unit_tests PRIVATE
+      WAKE_OPENWAKEWORD_MODEL_DIR="${WAKE_OPENWAKEWORD_MODEL_DIR}")
+  endif()
+endif()
 target_include_directories(sdk_unit_tests PRIVATE ${WAKE_REPO_ROOT}/third_party)
 add_test(NAME sdk_unit COMMAND sdk_unit_tests)

--- a/device/tests/unit/openwakeword.test.cxx
+++ b/device/tests/unit/openwakeword.test.cxx
@@ -1,0 +1,120 @@
+/*
+ * L1 tests for the openwakeword driver contract (issue #192).
+ *
+ * Without WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME the driver must still create and
+ * register, load() must fail loudly (runtime not linked), and
+ * process_frame() must stay in warmup (-1) — never crash, never fabricate a
+ * score.
+ *
+ * With the runtime + a model dir (WAKE_OPENWAKEWORD_MODEL_DIR, set by CI):
+ * the real mel -> embedding -> classifier pipeline runs over synthetic 16 kHz
+ * audio — warmup first, then finite [0,1] posteriors; score semantics mirror
+ * the browser driver (packages/modules/kws/openwakeword/core/backend.ts).
+ */
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "doctest/doctest.h"
+#include "wake/kws_backend.h"
+
+extern "C" const wake_kws_backend_ops_t wake_kws_openwakeword_ops;
+
+/* 10 ms @ 16 kHz — the SDK's AFE frame size (docs/modules/sdk.md §6). */
+static const size_t kFrame = 160;
+static const double kPi = 3.14159265358979323846;
+
+static void fill_sine(int16_t *frame, size_t n, double phase) {
+  for (size_t i = 0; i < n; ++i) {
+    double t = phase + (double)i / 16000.0;
+    frame[i] = (int16_t)(0.3 * 32767.0 * std::sin(2.0 * kPi * 440.0 * t));
+  }
+}
+
+#if !defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+
+TEST_CASE("openwakeword driver: creates, load fails without runtime, warmup") {
+  wake_kws_config_t cfg = WAKE_KWS_CONFIG_DEFAULT;
+  const wake_kws_backend_ops_t *ops = &wake_kws_openwakeword_ops;
+  CHECK(std::string(ops->id) == "openwakeword");
+
+  void *impl = ops->create(&cfg);
+  REQUIRE(impl != nullptr);
+
+  /* no runtime in this build (default) -> load must fail loudly */
+  wake_model_bundle_t models;
+  models.model_dir = "/nonexistent";
+  CHECK(ops->load(impl, &models, &cfg) != 0);
+
+  /* warmup: -1, never a fabricated score */
+  int16_t frame[kFrame] = {0};
+  CHECK(ops->process_frame(impl, frame, kFrame) == -1.0f);
+
+  ops->reset(impl);
+  ops->destroy(impl);
+}
+
+#else /* runtime linked */
+
+TEST_CASE("openwakeword driver: real pipeline over the onnx models") {
+  const char *dir = std::getenv("WAKE_OPENWAKEWORD_MODEL_DIR");
+#if defined(WAKE_OPENWAKEWORD_MODEL_DIR)
+  if (dir == nullptr || *dir == '\0') {
+    dir = WAKE_OPENWAKEWORD_MODEL_DIR;
+  }
+#endif
+  if (dir == nullptr || *dir == '\0') {
+    MESSAGE("WAKE_OPENWAKEWORD_MODEL_DIR unset - skipping real-inference "
+            "assertions (CI sets it from the fetched kws-openwakeword assets)");
+    return;
+  }
+
+  wake_kws_config_t cfg = WAKE_KWS_CONFIG_DEFAULT;
+  const wake_kws_backend_ops_t *ops = &wake_kws_openwakeword_ops;
+
+  void *impl = ops->create(&cfg);
+  REQUIRE(impl != nullptr);
+
+  wake_model_bundle_t models;
+  models.model_dir = dir;
+  REQUIRE(ops->load(impl, &models, &cfg) == 0);
+
+  /* 3 s of 440 Hz sine (48 000 samples). Warmup (~1.3 s of mel/embedding
+   * accumulation) yields -1; after the classifier's receptive field fills,
+   * every chunk produces a finite posterior in [0,1] (browser parity). */
+  int16_t frame[kFrame];
+  double phase = 0.0;
+  int saw_score = 0;
+  for (size_t t = 0; t < 48000 / kFrame; ++t) {
+    fill_sine(frame, kFrame, phase);
+    phase += (double)kFrame / 16000.0;
+    const float s = ops->process_frame(impl, frame, kFrame);
+    if (s >= 0.0f) {
+      saw_score = 1;
+      CHECK(std::isfinite(s));
+      CHECK(s >= 0.0f);
+      CHECK(s <= 1.0f);
+    }
+  }
+  CHECK(saw_score == 1); /* the pipeline must produce scores, not just warmup */
+
+  /* A trailing silence second must stay finite too (no NaN creep). */
+  int16_t quiet[kFrame] = {0};
+  for (size_t t = 0; t < 16000 / kFrame; ++t) {
+    const float s = ops->process_frame(impl, quiet, kFrame);
+    if (s >= 0.0f) {
+      CHECK(std::isfinite(s));
+      CHECK(s >= 0.0f);
+      CHECK(s <= 1.0f);
+    }
+  }
+
+  /* reset() clears streaming state; the next frame is warmup again. */
+  ops->reset(impl);
+  CHECK(ops->process_frame(impl, frame, kFrame) == -1.0f);
+
+  ops->destroy(impl);
+}
+
+#endif /* runtime linked */

--- a/docs/modules/sdk.md
+++ b/docs/modules/sdk.md
@@ -210,6 +210,29 @@ selected modules' specs (see §9). `__attribute__((constructor))` and linker
 section tricks are avoided: fragile on bare-metal (linker scripts, startup
 code), nondeterministic. An explicit root is debuggable and testable.
 
+### 5.4 Device drivers (per-backend `device/` targets)
+
+Each driver is a self-contained module target — `wake_kws_<id>` — behind the
+same C `KWSBackend` op-struct, **runtime-gated** by a CMake option so the
+module always compiles/registers and only links its runtime when the build
+asks for it. A driver without its runtime still appears in capabilities;
+`load()` fails loudly ("runtime not linked") and `process_frame()` stays in
+warmup (`-1`). The bundle generator picks the runtime-ON configuration.
+
+| Driver (issue) | Module `device/` | Runtime | Gate option |
+|---|---|---|---|
+| microwakeword (#185) | `kws/microwakeword/device/` | TFLite-Micro (pinned, `third_party/tflite-micro`) | `WAKE_SDK_MICROWAKEWORD_HAS_RUNTIME` |
+| openwakeword (#192) | `kws/openwakeword/device/` | onnxruntime C API (pinned 1.21.0, `third_party/onnxruntime`, fetched prebuilt) | `WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME` |
+
+**onnxruntime (shared app-class runtime).** The openwakeword driver is a
+byte-for-byte port of the browser pipeline (`core/backend.ts`): 1280-sample
+chunks + 480-overlap → `melspectrogram.onnx` → last 76 frames →
+`embedding_model.onnx` (96-dim) → 16-embedding ring → `classifier.onnx`
+(sigmoid'd [0,1]). Model files are read from the bundle `model_dir` with the
+names the driver declares (`melspectrogram.onnx`, `embedding_model.onnx`,
+`classifier.onnx`) — no URL bag on device (ADR-040 §4.1). The same pinned
+onnxruntime dependency serves kws-streaming (#194).
+
 ### 5.3 Low-power vs high-performance: profiles, not forks (ADR-040 §4)
 
 One core; the mcu/app distinction is **preset configurations**:
@@ -313,8 +336,8 @@ target — this is the hard acceptance for #41.
 6. Composition root + profile system (mcu/app) + capabilities query.
 7. microwakeword device driver (TFLite-Micro) + Cortex-M cross-compile in CI.
 8. Raspberry Pi Python binding golden path.
-9. plix device driver (onnxruntime C API); openwakeword/sherpa reuse the
-   pattern as follow-ups.
+9. openwakeword device driver (onnxruntime C API, shared runtime) shipped;
+   plix/sherpa reuse the pattern as follow-ups.
 10. On-hardware MCU validation (buy one cheap STM32/Arduino board for the
     golden-path acceptance).
 11. Android (JNI) / iOS (Swift) / desktop bindings; bundle generator consumes

--- a/packages/modules/kws/openwakeword/device/CMakeLists.txt
+++ b/packages/modules/kws/openwakeword/device/CMakeLists.txt
@@ -1,0 +1,44 @@
+# openwakeword module — device target (ADR-021/040 §2, issue #192).
+
+# Optional onnxruntime C API runtime: -DWAKE_SDK_OPENWAKEWORD_HAS_RUNTIME=ON.
+# Default OFF — the driver compiles and registers without it; load() reports
+# "runtime not linked" and process_frame() stays in warmup. The prebuilt
+# onnxruntime (pinned release, ADR-031 style) is fetched into
+# third_party/onnxruntime/<host> by scripts/fetch-onnxruntime.mjs (issue #192;
+# kws-streaming #194 shares the same dependency).
+option(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME "Link the onnxruntime C API runtime" OFF)
+
+add_library(wake_kws_openwakeword STATIC src/openwakeword_driver.c)
+target_link_libraries(wake_kws_openwakeword PUBLIC wake_sdk_core)
+
+if(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  set(WAKE_SDK_ONNXRUNTIME_DIR "${WAKE_REPO_ROOT}/third_party/onnxruntime"
+      CACHE PATH "onnxruntime prebuilt root (fetched; never committed)")
+  if(APPLE)
+    set(_ort_host osx-universal2)
+    set(_ort_lib "libonnxruntime.dylib")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    set(_ort_host linux-aarch64)
+    set(_ort_lib "libonnxruntime.so")
+  else()
+    set(_ort_host linux-x64)
+    set(_ort_lib "libonnxruntime.so")
+  endif()
+  set(_ort_root "${WAKE_SDK_ONNXRUNTIME_DIR}/${_ort_host}")
+
+  if(NOT EXISTS "${_ort_root}/include/onnxruntime_c_api.h")
+    message(FATAL_ERROR
+      "onnxruntime not found at ${_ort_root} — run: "
+      "node scripts/fetch-onnxruntime.mjs")
+  endif()
+
+  target_compile_definitions(wake_kws_openwakeword
+    PRIVATE WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME=1)
+  target_include_directories(wake_kws_openwakeword
+    PUBLIC "${_ort_root}/include")
+  target_link_libraries(wake_kws_openwakeword
+    PUBLIC "${_ort_root}/lib/${_ort_lib}")
+  # Consumers (test binaries, bundles) must find the runtime at load time.
+  target_link_options(wake_kws_openwakeword
+    INTERFACE "-Wl,-rpath,${_ort_root}/lib")
+endif()

--- a/packages/modules/kws/openwakeword/device/README.md
+++ b/packages/modules/kws/openwakeword/device/README.md
@@ -1,0 +1,65 @@
+# openwakeword module — device target
+
+`openWakeWord` (Apache-2.0) is the **app-class Traditional backend**
+(ADR-019/020/024): melspectrogram → speech_embedding → classifier, three onnx
+models run through the **onnxruntime C API** — the shared app-class runtime
+(kws-streaming #194 reuses the same pinned dependency).
+
+The browser driver (`core/backend.ts`) is the reference for pipeline order +
+streaming windowing; this C driver is a byte-for-byte port of its semantics:
+1280-sample chunks + 480-sample overlap → mel frames → last 76 frames →
+96-dim embedding → 16-embedding ring → classifier score.
+
+## Current state
+
+The full C `KWSBackend` adapter ships (`wake_kws_openwakeword_ops`):
+create / load(model_dir) / process_frame / reset / destroy, plus the CMake
+target and the runtime-gating option `WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME`
+(default OFF).
+
+Without the runtime the module still compiles, registers, and appears in
+capabilities; `load()` returns a clear "runtime not linked" error and
+`process_frame()` stays in warmup (`-1`).
+
+## Runtime (onnxruntime C API)
+
+Pinned release **1.21.0** (ADR-031 style; live upstream — ADR-037 Tier 1-2,
+no source vendoring). Fetched per host into `third_party/onnxruntime/<host>`
+(gitignored):
+
+```bash
+node scripts/fetch-onnxruntime.mjs          # linux-x64 | osx-universal2
+cmake -S device -B build -DCMAKE_BUILD_TYPE=Debug -DWAKE_SDK_PROFILE=app \
+  -DWAKE_SDK_OPENWAKEWORD_HAS_RUNTIME=ON
+cmake --build build -j
+ctest --test-dir build --output-on-failure
+```
+
+The L1 test exercises the real pipeline when a model dir is supplied:
+
+```bash
+cmake -S device -B build ... -DWAKE_SDK_OPENWAKEWORD_HAS_RUNTIME=ON \
+  -DWAKE_OPENWAKEWORD_MODEL_DIR=<dir-with-the-3-onnx>
+```
+
+## Model files (driver-declared names, ADR-040 §4.1)
+
+The driver reads these names from the bundle's `model_dir`:
+
+| File | Model | I/O |
+|---|---|---|
+| `melspectrogram.onnx` | openWakeWord log-Mel front-end (Apache-2.0) | `[1, samples]` → `[1, 1, time, 32]` |
+| `embedding_model.onnx` | Google speech_embedding backbone re-impl (Apache-2.0) | `[1, 76, 32, 1]` → `[1, 1, 1, 96]` |
+| `classifier.onnx` | per-wake-word classifier (e.g. hey-buddy, CC-BY-4.0) | `[1, 16, 96]` → `[1, 1]` |
+
+Fetched via `node scripts/fetch-artifact.mjs kws-openwakeword` (ADR-027,
+`models-openwakeword-v1` release). The `hey-buddy` classifier is
+**commercially clean (CC-BY-4.0)**; CC BY-NC-SA demo models (e.g. `alexa`,
+`hey_jarvis`) must never enter commercial bundles (license gate #42).
+
+## Why C, not C++
+
+The onnxruntime C API is a plain C interface; the driver holds no C++ objects
+and keeps the module linkable into any profile/ABI without a C++ runtime
+story (consistent with the other drivers; the SDK core is C++17 behind the C
+ABI per ADR-040 §1).

--- a/packages/modules/kws/openwakeword/device/src/openwakeword_driver.c
+++ b/packages/modules/kws/openwakeword/device/src/openwakeword_driver.c
@@ -1,0 +1,536 @@
+/*
+ * openwakeword_driver.c — openWakeWord device driver (issue #192).
+ *
+ * C KWSBackend adapter for the app-class backend (ADR-020): the
+ * melspectrogram -> speech_embedding -> classifier pipeline (ADR-024
+ * Traditional category), identical to the browser driver
+ * (packages/modules/kws/openwakeword/core/backend.ts). The three onnx models
+ * run through the onnxruntime C API (shared app-class runtime; kws-streaming
+ * #194 reuses the same dependency).
+ *
+ * Model files are read from the bundle's model_dir with the names this
+ * driver declares (ADR-040 §4.1: the driver reads the names it declared):
+ *   <model_dir>/melspectrogram.onnx   [1, samples]   -> [1, 1, time, 32]
+ *   <model_dir>/embedding_model.onnx  [1,76,32,1]    -> [1, 1, 1, 96]
+ *   <model_dir>/classifier.onnx       [1,16,96]      -> [1, 1] (sigmoid'd)
+ *
+ * Streaming (browser parity, backend.ts): each 1280-sample chunk (80 ms) plus
+ * the 480-sample overlap (openWakeWord's 160*3) feeds the mel model (~8-9
+ * mel frames per chunk); mel frames accumulate in a sliding buffer; the last
+ * 76 frames produce one 96-dim embedding per chunk; 16 embeddings fill the
+ * classifier's receptive field (~1.3 s), after which one score per chunk.
+ * process_frame() consumes 160-sample AFE frames (10 ms @ 16 kHz) and
+ * returns the raw posterior [0,1], or -1 during warmup.
+ *
+ * Runtime gating: WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME (CMake option, default
+ * OFF). Without the runtime, load() reports "runtime not linked" and
+ * process_frame() stays in warmup (-1) — the module still compiles and
+ * registers, so the composition root and capabilities work end-to-end.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "wake/kws_backend.h"
+
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+#include "onnxruntime_c_api.h"
+#endif
+
+/* openWakeWord streaming constants (backend.ts, verified against utils.py). */
+#define MEL_WINDOW_SIZE 1280  /* samples per chunk (80 ms @ 16 kHz) */
+#define MEL_OVERLAP 480       /* samples carried between chunks (160*3) */
+#define MEL_CHUNK_INPUT (MEL_WINDOW_SIZE + MEL_OVERLAP) /* 1760 */
+#define MEL_MAX_FRAMES 100    /* sliding mel-frame buffer (~1 s at 100 Hz) */
+#define MEL_BINS 32           /* melspectrogram output bins */
+#define EMBEDDING_WINDOW 76   /* mel frames the embedding model consumes */
+#define EMBEDDING_DIM 96      /* speech_embedding output dim */
+#define CLASSIFIER_STEPS 16   /* classifier receptive field */
+#define AUDIO_RING_CAP 2048   /* rolling audio buffer (>= 1760 + margin) */
+
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+typedef struct ort_session {
+  OrtSession *session;
+  char input_name[64];
+  char output_name[64];
+} ort_session_t;
+#endif
+
+typedef struct openwakeword_impl {
+  int loaded; /* load() succeeded and streaming state is live */
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  const OrtApi *api;
+  OrtEnv *env;
+  ort_session_t mel;
+  ort_session_t embed;
+  ort_session_t cls;
+
+  /* Rolling audio buffer (float; int16 in, ONNX graph expects int16 range —
+   * the browser scales float [-1,1] by 32768; device samples are int16
+   * already, so the values pass through unchanged). */
+  float audio_ring[AUDIO_RING_CAP];
+  size_t audio_len;
+  size_t new_samples; /* samples not yet consumed by a 1280-chunk */
+
+  /* Sliding mel-frame buffer: MEL_MAX_FRAMES rows of MEL_BINS. */
+  float mel_frames[MEL_MAX_FRAMES * MEL_BINS];
+  size_t mel_count;
+
+  /* Embedding ring buffer: CLASSIFIER_STEPS rows of EMBEDDING_DIM. */
+  float embed_ring[CLASSIFIER_STEPS * EMBEDDING_DIM];
+  size_t embed_index;
+  int embed_filled;
+
+  /* Scratch buffers (one chunk's worth, no per-frame allocation). */
+  float mel_input[MEL_CHUNK_INPUT];
+  float embed_input[EMBEDDING_WINDOW * MEL_BINS];
+  float classifier_input[CLASSIFIER_STEPS * EMBEDDING_DIM];
+#endif
+} openwakeword_impl_t;
+
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+
+/* Read a whole model file into memory (models are ~0.1-2 MB). */
+static int read_file(const char *path, void **out_data, size_t *out_size) {
+  FILE *f = fopen(path, "rb");
+  if (f == NULL) {
+    return 1;
+  }
+  if (fseek(f, 0, SEEK_END) != 0) {
+    fclose(f);
+    return 1;
+  }
+  long size = ftell(f);
+  if (size <= 0) {
+    fclose(f);
+    return 1;
+  }
+  rewind(f);
+  void *data = malloc((size_t)size);
+  if (data == NULL) {
+    fclose(f);
+    return 1;
+  }
+  if (fread(data, 1, (size_t)size, f) != (size_t)size) {
+    free(data);
+    fclose(f);
+    return 1;
+  }
+  fclose(f);
+  *out_data = data;
+  *out_size = (size_t)size;
+  return 0;
+}
+
+/* Create one ORT session from a model file; capture input/output names. */
+static int load_session(openwakeword_impl_t *impl, const char *path,
+                        ort_session_t *sess) {
+  const OrtApi *api = impl->api;
+  OrtStatus *st = NULL;
+  OrtSessionOptions *opts = NULL;
+
+  void *data = NULL;
+  size_t size = 0;
+  if (read_file(path, &data, &size) != 0) {
+    fprintf(stderr, "[openwakeword] cannot read model %s\n", path);
+    return 1;
+  }
+
+  st = api->CreateSessionOptions(&opts);
+  if (st == NULL) {
+    st = api->SetSessionGraphOptimizationLevel(opts, ORT_ENABLE_ALL);
+  }
+  if (st == NULL) {
+    st = api->CreateSessionFromArray(impl->env, data, size, opts,
+                                     &sess->session);
+  }
+  if (opts != NULL) {
+    api->ReleaseSessionOptions(opts);
+  }
+  free(data);
+  if (st != NULL) {
+    fprintf(stderr, "[openwakeword] CreateSessionFromArray(%s): %s\n", path,
+            api->GetErrorMessage(st));
+    api->ReleaseStatus(st);
+    return 1;
+  }
+
+  /* Input/output names are model-owned; the driver reads them (the browser
+   * uses inputNames[0]/outputNames[0] — same contract). */
+  OrtAllocator *alloc = NULL;
+  st = api->GetAllocatorWithDefaultOptions(&alloc);
+  if (st != NULL) {
+    api->ReleaseStatus(st);
+    return 1;
+  }
+  char *name = NULL;
+  st = api->SessionGetInputName(sess->session, 0, alloc, &name);
+  if (st == NULL && name != NULL) {
+    snprintf(sess->input_name, sizeof(sess->input_name), "%s", name);
+  } else {
+    fprintf(stderr, "[openwakeword] input name query on %s failed\n", path);
+    if (st != NULL) {
+      api->ReleaseStatus(st);
+    }
+    if (name != NULL) {
+      alloc->Free(alloc, name);
+    }
+    return 1;
+  }
+  alloc->Free(alloc, name);
+  name = NULL;
+
+  st = api->SessionGetOutputName(sess->session, 0, alloc, &name);
+  if (st == NULL && name != NULL) {
+    snprintf(sess->output_name, sizeof(sess->output_name), "%s", name);
+  } else {
+    fprintf(stderr, "[openwakeword] output name query on %s failed\n", path);
+    if (st != NULL) {
+      api->ReleaseStatus(st);
+    }
+    if (name != NULL) {
+      alloc->Free(alloc, name);
+    }
+    return 1;
+  }
+  alloc->Free(alloc, name);
+  return 0;
+}
+
+static void release_session(const OrtApi *api, ort_session_t *sess) {
+  if (sess->session != NULL) {
+    api->ReleaseSession(sess->session);
+    sess->session = NULL;
+  }
+}
+
+/* Run a one-input/one-output float32 session. Copies the output tensor into
+ * `output` (its byte count is written to *out_bytes); `out_dims` receives the
+ * output shape (up to out_dims_cap entries). Returns 0 on success. */
+static int run_float32(openwakeword_impl_t *impl, ort_session_t *sess,
+                       const float *input, const int64_t *input_dims,
+                       size_t input_ndims, float *output, size_t *out_bytes,
+                       int64_t *out_dims, size_t out_dims_cap) {
+  const OrtApi *api = impl->api;
+  OrtStatus *st = NULL;
+  const char *errmsg = NULL;
+  OrtMemoryInfo *meminfo = NULL;
+  OrtValue *in_val = NULL;
+  OrtValue *out_vals[1] = {NULL};
+  OrtTensorTypeAndShapeInfo *shape = NULL;
+
+  size_t in_bytes = sizeof(float);
+  for (size_t i = 0; i < input_ndims; ++i) {
+    in_bytes *= (size_t)input_dims[i];
+  }
+
+  st = api->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &meminfo);
+  if (st != NULL) goto fail;
+  st = api->CreateTensorWithDataAsOrtValue(
+      meminfo, (void *)input, in_bytes, input_dims, input_ndims,
+      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &in_val);
+  if (st != NULL) goto fail;
+
+  const char *input_names[1] = {sess->input_name};
+  const char *output_names[1] = {sess->output_name};
+  st = api->Run(sess->session, NULL, input_names, (const OrtValue *const *)&in_val,
+                1, output_names, 1, out_vals);
+  if (st != NULL) goto fail;
+  if (out_vals[0] == NULL) {
+    errmsg = "unexpected output count";
+    goto fail_clean;
+  }
+
+  /* Copy the output tensor out of the session-owned value. */
+  size_t ndims = 0;
+  st = api->GetTensorTypeAndShape(out_vals[0], &shape);
+  if (st != NULL) goto fail;
+  st = api->GetDimensionsCount(shape, &ndims);
+  if (st != NULL) goto fail;
+  if (ndims > out_dims_cap) ndims = out_dims_cap;
+  st = api->GetDimensions(shape, out_dims, ndims);
+  if (st != NULL) goto fail;
+
+  size_t elems = 1;
+  for (size_t i = 0; i < ndims; ++i) {
+    elems *= (size_t)out_dims[i];
+  }
+  void *raw = NULL;
+  st = api->GetTensorMutableData(out_vals[0], &raw);
+  if (st != NULL) goto fail;
+  memcpy(output, raw, elems * sizeof(float));
+  *out_bytes = elems * sizeof(float);
+
+  api->ReleaseTensorTypeAndShapeInfo(shape);
+  api->ReleaseValue(out_vals[0]);
+  api->ReleaseValue(in_val);
+  api->ReleaseMemoryInfo(meminfo);
+  return 0;
+
+fail:
+  errmsg = api->GetErrorMessage(st);
+fail_clean:
+  fprintf(stderr, "[openwakeword] inference on '%s' failed: %s\n",
+          sess->input_name, errmsg != NULL ? errmsg : "unknown error");
+  if (st != NULL) {
+    api->ReleaseStatus(st);
+  }
+  if (shape != NULL) {
+    api->ReleaseTensorTypeAndShapeInfo(shape);
+  }
+  if (out_vals[0] != NULL) {
+    api->ReleaseValue(out_vals[0]);
+  }
+  if (in_val != NULL) {
+    api->ReleaseValue(in_val);
+  }
+  if (meminfo != NULL) {
+    api->ReleaseMemoryInfo(meminfo);
+  }
+  return 1;
+}
+
+/* Feed the audio ring into mel -> embedding -> classifier; returns a score
+ * [0,1] or -1 while warming up (browser _processChunk, backend.ts). */
+static float process_chunk(openwakeword_impl_t *impl) {
+  /* Take the last min(audio_len, 1760) samples: the 1280-window plus the
+   * 480-sample overlap between consecutive chunks. */
+  size_t input_len = impl->audio_len < MEL_CHUNK_INPUT ? impl->audio_len
+                                                       : MEL_CHUNK_INPUT;
+  const float *mel_audio = impl->audio_ring + (impl->audio_len - input_len);
+
+  /* Step 1: melspectrogram [1, input_len] -> [1, 1, time, 32]. */
+  int64_t mel_dims_in[2] = {1, (int64_t)input_len};
+  float mel_out[MEL_MAX_FRAMES * MEL_BINS];
+  size_t mel_bytes = 0;
+  int64_t mel_dims[4] = {0, 0, 0, 0};
+  if (run_float32(impl, &impl->mel, mel_audio, mel_dims_in, 2, mel_out,
+                  &mel_bytes, mel_dims, 4) != 0) {
+    return -1.0f;
+  }
+  const int64_t mel_time = mel_dims[2];
+  const int64_t mel_bins = mel_dims[3];
+  if (mel_bins != MEL_BINS) {
+    /* Model mismatch; stay in warmup rather than fabricate scores. */
+    return -1.0f;
+  }
+
+  /* openWakeWord melspec_transform: x/10 + 2 (utils.py). Push frames into the
+   * sliding window, trimming the oldest when it exceeds MEL_MAX_FRAMES. */
+  for (int64_t t = 0; t < mel_time; ++t) {
+    if (impl->mel_count == MEL_MAX_FRAMES) {
+      memmove(impl->mel_frames, impl->mel_frames + MEL_BINS,
+              (MEL_MAX_FRAMES - 1) * MEL_BINS * sizeof(float));
+      impl->mel_count = MEL_MAX_FRAMES - 1;
+    }
+    float *dst = impl->mel_frames + impl->mel_count * MEL_BINS;
+    const float *src = mel_out + (size_t)t * MEL_BINS;
+    for (int64_t b = 0; b < mel_bins; ++b) {
+      dst[(size_t)b] = src[(size_t)b] / 10.0f + 2.0f;
+    }
+    impl->mel_count += 1;
+  }
+
+  /* Not enough mel frames for one embedding window yet (warmup). */
+  if (impl->mel_count < EMBEDDING_WINDOW) {
+    return -1.0f;
+  }
+
+  /* Step 2: speech_embedding [1, 76, 32, 1] -> [1, 1, 1, 96]. */
+  size_t start = impl->mel_count - EMBEDDING_WINDOW;
+  memcpy(impl->embed_input, impl->mel_frames + start * MEL_BINS,
+         EMBEDDING_WINDOW * MEL_BINS * sizeof(float));
+  int64_t embed_dims_in[4] = {1, EMBEDDING_WINDOW, MEL_BINS, 1};
+  float embed_out[EMBEDDING_DIM];
+  size_t embed_bytes = 0;
+  int64_t embed_dims[4] = {0, 0, 0, 0};
+  if (run_float32(impl, &impl->embed, impl->embed_input, embed_dims_in, 4,
+                  embed_out, &embed_bytes, embed_dims, 4) != 0) {
+    return -1.0f;
+  }
+  if (embed_bytes < EMBEDDING_DIM * sizeof(float)) {
+    return -1.0f;
+  }
+
+  memcpy(impl->embed_ring + impl->embed_index * EMBEDDING_DIM, embed_out,
+         EMBEDDING_DIM * sizeof(float));
+  impl->embed_index = (impl->embed_index + 1) % CLASSIFIER_STEPS;
+  if (impl->embed_index == 0) {
+    impl->embed_filled = 1;
+  }
+
+  /* Not enough embeddings for the classifier yet (warmup). */
+  if (!impl->embed_filled) {
+    return -1.0f;
+  }
+
+  /* Step 3: classifier — unroll the ring oldest -> newest [1, 16, 96]. */
+  for (size_t i = 0; i < CLASSIFIER_STEPS; ++i) {
+    size_t src = ((impl->embed_index + i) % CLASSIFIER_STEPS) * EMBEDDING_DIM;
+    memcpy(impl->classifier_input + i * EMBEDDING_DIM,
+           impl->embed_ring + src, EMBEDDING_DIM * sizeof(float));
+  }
+  int64_t cls_dims_in[3] = {1, CLASSIFIER_STEPS, EMBEDDING_DIM};
+  float cls_out[1];
+  size_t cls_bytes = 0;
+  int64_t cls_dims[2] = {0, 0};
+  if (run_float32(impl, &impl->cls, impl->classifier_input, cls_dims_in, 3,
+                  cls_out, &cls_bytes, cls_dims, 2) != 0) {
+    return -1.0f;
+  }
+  if (cls_bytes != sizeof(float)) {
+    return -1.0f;
+  }
+
+  /* The classifier's output node is Sigmoid (verified in the ONNX graph), so
+   * the value is already a probability; clamp for floating-point safety. */
+  float score = cls_out[0];
+  if (score < 0.0f) score = 0.0f;
+  if (score > 1.0f) score = 1.0f;
+  return score;
+}
+
+#endif /* WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME */
+
+static void *openwakeword_create(const wake_kws_config_t *cfg) {
+  (void)cfg;
+  return calloc(1, sizeof(openwakeword_impl_t));
+}
+
+static void openwakeword_destroy(void *v) {
+  openwakeword_impl_t *impl = (openwakeword_impl_t *)v;
+  if (impl == NULL) {
+    return;
+  }
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  const OrtApi *api = impl->api;
+  if (api != NULL) {
+    release_session(api, &impl->cls);
+    release_session(api, &impl->embed);
+    release_session(api, &impl->mel);
+    if (impl->env != NULL) {
+      api->ReleaseEnv(impl->env);
+      impl->env = NULL;
+    }
+  }
+#endif
+  free(impl);
+}
+
+static int openwakeword_load(void *v, const wake_model_bundle_t *models,
+                             const wake_kws_config_t *cfg) {
+  (void)cfg;
+  openwakeword_impl_t *impl = (openwakeword_impl_t *)v;
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  if (models == NULL || models->model_dir == NULL) {
+    return 1;
+  }
+
+  /* Create the ORT environment + sessions. The driver reads the model names
+   * it declared from the bundle dir (ADR-040 §4.1). */
+  const OrtApi *api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+  impl->api = api;
+  OrtStatus *st = api->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "wake-openwakeword",
+                                 &impl->env);
+  if (st != NULL) {
+    fprintf(stderr, "[openwakeword] CreateEnv: %s\n", api->GetErrorMessage(st));
+    api->ReleaseStatus(st);
+    return 1;
+  }
+
+  char path[1024];
+  snprintf(path, sizeof(path), "%s/melspectrogram.onnx", models->model_dir);
+  if (load_session(impl, path, &impl->mel) != 0) {
+    goto fail;
+  }
+  snprintf(path, sizeof(path), "%s/embedding_model.onnx", models->model_dir);
+  if (load_session(impl, path, &impl->embed) != 0) {
+    goto fail;
+  }
+  snprintf(path, sizeof(path), "%s/classifier.onnx", models->model_dir);
+  if (load_session(impl, path, &impl->cls) != 0) {
+    goto fail;
+  }
+
+  impl->loaded = 1;
+  return 0;
+
+fail:
+  release_session(api, &impl->cls);
+  release_session(api, &impl->embed);
+  release_session(api, &impl->mel);
+  api->ReleaseEnv(impl->env);
+  impl->env = NULL;
+  return 1;
+#else
+  (void)impl;
+  (void)models;
+  return 1; /* onnxruntime C API not linked in this build */
+#endif
+}
+
+static float openwakeword_process_frame(void *v, const int16_t *samples,
+                                        size_t n) {
+  openwakeword_impl_t *impl = (openwakeword_impl_t *)v;
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  if (!impl->loaded || samples == NULL) {
+    return -1.0f; /* warmup */
+  }
+
+  /* Append to the rolling audio buffer, evicting the oldest samples when the
+   * ring fills (browser _pushAudio parity: keep the most recent context). */
+  if (impl->audio_len + n > AUDIO_RING_CAP) {
+    size_t keep = AUDIO_RING_CAP - n;
+    if (keep > 0) {
+      memmove(impl->audio_ring, impl->audio_ring + (impl->audio_len - keep),
+              keep * sizeof(float));
+    }
+    impl->audio_len = keep;
+  }
+  for (size_t i = 0; i < n; ++i) {
+    impl->audio_ring[impl->audio_len + i] = (float)samples[i];
+  }
+  impl->audio_len += n;
+  impl->new_samples += n;
+
+  /* Consume 1280-sample chunks; keep the last score produced in this frame. */
+  float score = -1.0f;
+  while (impl->new_samples >= MEL_WINDOW_SIZE) {
+    impl->new_samples -= MEL_WINDOW_SIZE;
+    float s = process_chunk(impl);
+    if (s >= 0.0f) {
+      score = s;
+    }
+  }
+  return score;
+#else
+  (void)impl;
+  (void)samples;
+  (void)n;
+  return -1.0f; /* warmup — onnxruntime not linked */
+#endif
+}
+
+static void openwakeword_reset(void *v) {
+  openwakeword_impl_t *impl = (openwakeword_impl_t *)v;
+#if defined(WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME)
+  /* Clear the streaming state; models stay loaded (browser reset parity). */
+  impl->audio_len = 0;
+  impl->new_samples = 0;
+  impl->mel_count = 0;
+  impl->embed_index = 0;
+  impl->embed_filled = 0;
+  memset(impl->audio_ring, 0, sizeof(impl->audio_ring));
+  memset(impl->mel_frames, 0, sizeof(impl->mel_frames));
+  memset(impl->embed_ring, 0, sizeof(impl->embed_ring));
+#else
+  (void)impl;
+#endif
+}
+
+const wake_kws_backend_ops_t wake_kws_openwakeword_ops = {
+    "openwakeword",
+    "OpenWakeWord (mel -> embedding -> classifier, onnxruntime)",
+    openwakeword_create, openwakeword_destroy, openwakeword_load,
+    openwakeword_process_frame, openwakeword_reset};

--- a/scripts/fetch-onnxruntime.mjs
+++ b/scripts/fetch-onnxruntime.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Fetch the pinned onnxruntime prebuilt C API (issue #192; shared app-class
+ * runtime for the openwakeword driver now and kws-streaming #194 later).
+ *
+ * onnxruntime is a live upstream project (ADR-037 Tier 1-2): we pin a release
+ * (ADR-031 style) instead of vendoring source. The official release tarballs
+ * ship the C API headers + shared library; this script downloads the platform
+ * tarball for the current host, verifies its sha256, and extracts it to
+ * third_party/onnxruntime/<host> (gitignored — built by the fetch, never
+ * committed; ADR-027 SOP spirit).
+ *
+ * Usage:
+ *   node scripts/fetch-onnxruntime.mjs            # detect host
+ *   node scripts/fetch-onnxruntime.mjs --force    # re-fetch even if present
+ *
+ * Pinned: ONNXRUNTIME_VERSION + per-platform sha256 below. When bumping,
+ * update both (sha256sum of the release tarball).
+ */
+import { createHash } from 'node:crypto'
+import { createWriteStream, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const VERSION = '1.21.0'
+const BASE = `https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}`
+
+const PLATFORMS = {
+  'linux-x64': {
+    tarball: `onnxruntime-linux-x64-${VERSION}.tgz`,
+    sha256: '7485c7e7aac6501b27e353dcbe068e45c61ab51fbaf598d13970dfae669d20bf',
+  },
+  'osx-universal2': {
+    tarball: `onnxruntime-osx-universal2-${VERSION}.tgz`,
+    sha256: '3c3cfc71e538e592192c14d9bad88ec5d5d8d5d698ebc2c6b3119be8c90b4670',
+  },
+  'linux-aarch64': {
+    tarball: `onnxruntime-linux-aarch64-${VERSION}.tgz`,
+    sha256: null, // not verified yet — add when first used
+  },
+}
+
+function die(msg) {
+  console.error(`[fetch-onnxruntime] ${msg}`)
+  process.exit(1)
+}
+
+function detectHost() {
+  const { platform, arch } = process
+  if (platform === 'darwin') return 'osx-universal2'
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  if (platform === 'linux' && (arch === 'arm64' || arch === 'aarch64')) {
+    return 'linux-aarch64'
+  }
+  die(`unsupported host ${platform}/${arch} (supported: linux-x64, linux-aarch64, osx-universal2)`)
+}
+
+function main() {
+  const force = process.argv.includes('--force')
+  const host = detectHost()
+  const cfg = PLATFORMS[host]
+  const ortDir = resolve(import.meta.dirname, '..', 'third_party', 'onnxruntime')
+  const dest = join(ortDir, host)
+  const marker = join(dest, 'include', 'onnxruntime_c_api.h')
+
+  if (!force && existsSync(marker)) {
+    console.log(`[fetch-onnxruntime] ${host} already fetched at ${dest}`)
+    return
+  }
+
+  const url = `${BASE}/${cfg.tarball}`
+  const tmpTgz = join(ortDir, `.${host}.${VERSION}.tgz`)
+  mkdirSync(ortDir, { recursive: true })
+
+  console.log(`[fetch-onnxruntime] downloading ${url}`)
+  const res = await fetch(url)
+  if (!res.ok) {
+    die(`download failed: HTTP ${res.status} ${res.statusText}`)
+  }
+
+  const hash = createHash('sha256')
+  await new Promise((resolveStream, rejectStream) => {
+    const file = createWriteStream(tmpTgz)
+    res.body.on('error', rejectStream)
+    file.on('error', rejectStream)
+    file.on('finish', resolveStream)
+    res.body.pipe(hash).pipe(file)
+  })
+  const got = hash.digest('hex')
+
+  if (cfg.sha256 && got !== cfg.sha256) {
+    rmSync(tmpTgz, { force: true })
+    die(`sha256 mismatch for ${cfg.tarball}:\n  expected ${cfg.sha256}\n  got      ${got}`)
+  }
+  console.log(`[fetch-onnxruntime] sha256 ok (${got})`)
+
+  rmSync(dest, { recursive: true, force: true })
+  mkdirSync(dest, { recursive: true })
+  const tar = spawnSync('tar', ['xzf', tmpTgz, '-C', dest, '--strip-components=1'], {
+    stdio: 'inherit',
+  })
+  rmSync(tmpTgz, { force: true })
+  if (tar.status !== 0) {
+    die(`extraction failed (tar exit ${tar.status})`)
+  }
+  console.log(`[fetch-onnxruntime] ${host} -> ${dest} (onnxruntime ${VERSION})`)
+}
+
+main().catch((e) => {
+  console.error('[fetch-onnxruntime]', e)
+  process.exit(1)
+})

--- a/scripts/fetch-onnxruntime.mjs
+++ b/scripts/fetch-onnxruntime.mjs
@@ -55,7 +55,7 @@ function detectHost() {
   die(`unsupported host ${platform}/${arch} (supported: linux-x64, linux-aarch64, osx-universal2)`)
 }
 
-function main() {
+async function main() {
   const force = process.argv.includes('--force')
   const host = detectHost()
   const cfg = PLATFORMS[host]

--- a/scripts/fetch-onnxruntime.mjs
+++ b/scripts/fetch-onnxruntime.mjs
@@ -18,7 +18,7 @@
  * update both (sha256sum of the release tarball).
  */
 import { createHash } from 'node:crypto'
-import { createWriteStream, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
@@ -69,37 +69,28 @@ async function main() {
   }
 
   const url = `${BASE}/${cfg.tarball}`
-  const tmpTgz = join(ortDir, `.${host}.${VERSION}.tgz`)
   mkdirSync(ortDir, { recursive: true })
-
   console.log(`[fetch-onnxruntime] downloading ${url}`)
   const res = await fetch(url)
   if (!res.ok) {
     die(`download failed: HTTP ${res.status} ${res.statusText}`)
   }
 
-  const hash = createHash('sha256')
-  await new Promise((resolveStream, rejectStream) => {
-    const file = createWriteStream(tmpTgz)
-    res.body.on('error', rejectStream)
-    file.on('error', rejectStream)
-    file.on('finish', resolveStream)
-    res.body.pipe(hash).pipe(file)
-  })
-  const got = hash.digest('hex')
-
+  const buf = Buffer.from(await res.arrayBuffer())
+  const got = createHash('sha256').update(buf).digest('hex')
   if (cfg.sha256 && got !== cfg.sha256) {
-    rmSync(tmpTgz, { force: true })
     die(`sha256 mismatch for ${cfg.tarball}:\n  expected ${cfg.sha256}\n  got      ${got}`)
   }
   console.log(`[fetch-onnxruntime] sha256 ok (${got})`)
 
   rmSync(dest, { recursive: true, force: true })
   mkdirSync(dest, { recursive: true })
-  const tar = spawnSync('tar', ['xzf', tmpTgz, '-C', dest, '--strip-components=1'], {
+  const tmpTgzPath = join(ortDir, `.${host}.${VERSION}.tgz`)
+  writeFileSync(tmpTgzPath, buf)
+  const tar = spawnSync('tar', ['xzf', tmpTgzPath, '-C', dest, '--strip-components=1'], {
     stdio: 'inherit',
   })
-  rmSync(tmpTgz, { force: true })
+  rmSync(tmpTgzPath, { force: true })
   if (tar.status !== 0) {
     die(`extraction failed (tar exit ${tar.status})`)
   }

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -26,6 +26,14 @@ on the record instead of pointing at a moving (or frozen) remote.
 |---|---|---|---|---|
 | `kws_streaming/` | `google-research/google-research` subtree `kws_streaming` | `cf61877d4c0021ff40ec3ecc0334aaa3937a1fcb` (2026-07-22, last commit touching the subtree) | Apache-2.0 | Archived upstream (project-level ARCHIVED); consumed unmodified by the kws-streaming train adapter (ADR-031; #156) |
 
+## Fetched prebuilt runtimes (not vendored source)
+
+`onnxruntime/` holds **fetched prebuilt binaries** (gitignored), not source:
+live upstream (ADR-037 Tier 1-2), pinned release **1.21.0** (ADR-031 style)
+for the device SDK's app-class drivers (openwakeword #192; kws-streaming
+#194 reuses it). Fetch with `node scripts/fetch-onnxruntime.mjs`; the pin +
+sha256s live in that script and `LICENSES.md`.
+
 Import details live in each pristine-import commit message; the policy
 itself is ADR-037 in `DECISIONS.md`.
 


### PR DESCRIPTION
## What

First real app-class device driver (issue #192): the openwakeword
mel → embedding → classifier pipeline ported from the browser driver
(`packages/modules/kws/openwakeword/core/backend.ts`) to C over the
**onnxruntime C API** — the shared app-class runtime (kws-streaming #194
reuses the same pinned dependency).

- `kws/openwakeword/device/`: C `KWSBackend` adapter (create / load(model_dir) /
  process_frame / reset / destroy), runtime-gated by
  `WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME` (default OFF — the module still
  compiles/registers without it, `load()` fails loudly, `process_frame()`
  stays in warmup, matching the microwakeword driver contract).
- Streaming parity with `backend.ts`: 1280-sample chunks + 480-overlap →
  melspectrogram → last 76 frames → 96-dim embedding → 16-embedding ring →
  classifier (sigmoid'd [0,1]).
- Model files read from the bundle `model_dir` under driver-declared names
  (melspectrogram.onnx / embedding_model.onnx / classifier.onnx, ADR-040 §4.1).
- onnxruntime pinned **1.21.0** prebuilt (ADR-031 style; live upstream —
  no source vendoring): `scripts/fetch-onnxruntime.mjs` downloads + sha256
  verifies into `third_party/onnxruntime/<host>` (gitignored).
- L1 tests: no-runtime contract + real pipeline over the fetched onnx models
  with synthetic 16 kHz audio (warmup → finite [0,1] → reset).
- New CI job `app-runtime` in device.yml: fetches onnxruntime + the
  kws-openwakeword assets, builds with the runtime ON, runs ctest.
- Docs-sync: sdk.md §5.4 device-driver section, module README,
  LICENSES.md onnxruntime row, third_party README.

The hey-buddy classifier (CC-BY-4.0) is commercially clean; CC BY-NC-SA
demo models stay out of commercial bundles (license gate #42).

## Test evidence

- Local: default (runtime OFF) build + ctest green on this Mac
  (macOS workaround per device/README.md).
- CI (this PR): native app/mcu × gcc/clang matrix, cross-MCU, and the new
  app-runtime job (real onnx inference L1).

Closes #192