### PR TITLE
feat(sdk): sherpa-onnx-kws device driver — native KeywordSpotter (#193)

### DIFF
--- a/.github/workflows/device.yml
+++ b/.github/workflows/device.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Build
         run: cmake --build build -j
 
-      - name: Run tests (real transducer L1: trigger clip hits, silence does not)
+      - name: "Run tests (real transducer L1: trigger clip hits, silence does not)"
         run: ctest --test-dir build --output-on-failure
 
   cross-mcu:

--- a/.github/workflows/device.yml
+++ b/.github/workflows/device.yml
@@ -59,6 +59,57 @@ jobs:
           python3 packages/sdk/python/wake-sdk-demo.py tone.wav && echo "python tone: OK"
           ! python3 packages/sdk/python/wake-sdk-demo.py silence.wav && echo "python silence: OK"
 
+  app-runtime:
+    name: App profile + sherpa-onnx (sherpa KWS driver, #193)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Pinned sherpa-onnx prebuilt (ADR-031, issue #193): the driver links
+      # it and the L1 test runs the real KWS transducer. Fetched +
+      # sha256-verified, never committed.
+      - name: Fetch sherpa-onnx (pinned v1.13.6)
+        run: node scripts/fetch-sherpa-onnx.mjs
+
+      # The KWS transducer model (encoder/decoder/joiner + tokens) from the
+      # kws-models release, same source the wasm build uses (ADR-027).
+      - name: Fetch sherpa KWS model (kws-models release, pinned)
+        run: |
+          curl -fsSL -o model.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20.tar.bz2
+          echo "68447f4fbc67e70eee3a93961f36e81e98f47aef73ce7e7ca00885c6cd3616a6  model.tar.bz2" | sha256sum -c -
+          tar xjf model.tar.bz2
+          rm -f model.tar.bz2
+
+      # Stage the model files under the names the driver declares (ADR-040
+      # §4.1): encoder/decoder/joiner.onnx, tokens.txt, keywords.txt, and a
+      # positive wake-word clip for the L1 trigger test.
+      - name: Stage driver model dir
+        run: |
+          M=sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20
+          mkdir -p models
+          cp $M/encoder-epoch-13-avg-2-chunk-16-left-64.onnx models/encoder.onnx
+          cp $M/decoder-epoch-13-avg-2-chunk-16-left-64.onnx models/decoder.onnx
+          cp $M/joiner-epoch-13-avg-2-chunk-16-left-64.onnx models/joiner.onnx
+          cp $M/tokens.txt models/tokens.txt
+          cp $M/test_wavs/keywords.txt models/keywords.txt
+          cp $M/test_wavs/en_0.wav models/trigger.wav
+
+      - name: Configure (runtime ON)
+        run: cmake -S device -B build -DCMAKE_BUILD_TYPE=Debug -DWAKE_SDK_PROFILE=app \
+          -DWAKE_SDK_SHERPA_HAS_RUNTIME=ON \
+          -DWAKE_SHERPA_MODEL_DIR=$PWD/models
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run tests (real transducer L1: trigger clip hits, silence does not)
+        run: ctest --test-dir build --output-on-failure
+
   cross-mcu:
     name: Cross-compile (Cortex-M4, arm-none-eabi)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,16 @@ packages/modules/*/*/train/*.egg-info/
 # onnxruntime-web wasm runtime (copied from node_modules at build, P0-4)
 apps/web/public/ort/
 
+# Fetched prebuilt runtimes (ADR-031 pin, issues #192/#193): downloaded by
+# scripts/fetch-onnxruntime.mjs / scripts/fetch-sherpa-onnx.mjs, never
+# committed (ADR-027 spirit).
+third_party/onnxruntime/linux-x64/
+third_party/onnxruntime/linux-aarch64/
+third_party/onnxruntime/osx-universal2/
+third_party/sherpa-onnx/linux-x64/
+third_party/sherpa-onnx/osx-arm64/
+third_party/sherpa-onnx/linux-aarch64/
+
 # studio-backend runtime state (ADR-036): SQLite store + artifacts
 apps/studio-backend/.venv/
 apps/studio-backend/data/

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -81,6 +81,7 @@ Every model or component that enters an **export bundle** is classified:
 | Component | Source | License | Commercial? | Class | How verified |
 |---|---|---|---|---|---|
 | onnxruntime (native C API, pinned **1.21.0**) | `microsoft/onnxruntime` | Apache-2.0 | Yes | ✅ | Release tarball `LICENSE` (Apache-2.0). Fetched prebuilt at `third_party/onnxruntime/<host>` (ADR-031 pin, never committed; issue #192 — shared app-class runtime, kws-streaming #194 reuses it). |
+| sherpa-onnx (native C API, pinned **v1.13.6**) | `k2-fsa/sherpa-onnx` | Apache-2.0 | Yes | ✅ | Repo `LICENSE` (Apache-2.0); the shared lib bundles its own onnxruntime (Apache-2.0). Fetched prebuilt at `third_party/sherpa-onnx/<host>` (ADR-031 pin, never committed; issue #193 — ASR-Decoding KWS driver). |
 
 ## TTS for synthetic training data (Phase 5) — ⚠️ license change
 

--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -33,6 +33,10 @@ add_subdirectory(
   ${CMAKE_BINARY_DIR}/modules/kws/microwakeword
 )
 add_subdirectory(
+  ../packages/modules/kws/sherpa/device
+  ${CMAKE_BINARY_DIR}/modules/kws/sherpa
+)
+add_subdirectory(
   ../packages/modules/afe/rnnoise/device
   ${CMAKE_BINARY_DIR}/modules/afe/rnnoise
 )

--- a/device/tests/unit/CMakeLists.txt
+++ b/device/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(sdk_unit_tests
   afe_graph.test.cxx
   rnnoise.test.cxx
   microwakeword.test.cxx
+  sherpa.test.cxx
 )
 target_link_libraries(sdk_unit_tests PRIVATE
   wake_sdk_core
@@ -13,6 +14,21 @@ target_link_libraries(sdk_unit_tests PRIVATE
   wake_afe_aec
   wake_afe_bss
   wake_kws_microwakeword
+  wake_kws_sherpa
+  wake_adapters_host
 )
+# The sherpa L1 test (issue #193) has two faces: the no-runtime contract
+# test and, when the sherpa-onnx runtime is linked, a real-inference test
+# over the KWS transducer + a real wake-word clip. The compile-time gate +
+# model dir must match the module's own configuration.
+if(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  target_compile_definitions(sdk_unit_tests PRIVATE WAKE_SDK_SHERPA_HAS_RUNTIME=1)
+  set(WAKE_SHERPA_MODEL_DIR "" CACHE PATH
+      "Directory holding the sherpa KWS model files (L1 runtime test)")
+  if(WAKE_SHERPA_MODEL_DIR)
+    target_compile_definitions(sdk_unit_tests PRIVATE
+      WAKE_SHERPA_MODEL_DIR="${WAKE_SHERPA_MODEL_DIR}")
+  endif()
+endif()
 target_include_directories(sdk_unit_tests PRIVATE ${WAKE_REPO_ROOT}/third_party)
 add_test(NAME sdk_unit COMMAND sdk_unit_tests)

--- a/device/tests/unit/sherpa.test.cxx
+++ b/device/tests/unit/sherpa.test.cxx
@@ -1,0 +1,144 @@
+/*
+ * L1 tests for the sherpa-onnx KWS driver contract (issue #193).
+ *
+ * Without WAKE_SDK_SHERPA_HAS_RUNTIME the driver must still create and
+ * register, load() must fail loudly (runtime not linked), and
+ * process_frame() must stay in warmup (-1) — never crash, never fabricate a
+ * score.
+ *
+ * With the runtime + a model dir (WAKE_SHERPA_MODEL_DIR, set by CI): the
+ * real KWS transducer runs over a genuine wake-word clip — a hit (1.0 held)
+ * must appear for trigger.wav and never for silence; semantics mirror the
+ * browser driver (packages/modules/kws/sherpa/core/backend.ts).
+ */
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "doctest/doctest.h"
+#include "wake/kws_backend.h"
+#include "wav_reader.h"
+
+extern "C" const wake_kws_backend_ops_t wake_kws_sherpa_ops;
+
+/* 10 ms @ 16 kHz — the SDK's AFE frame size (docs/modules/sdk.md §6). */
+static const size_t kFrame = 160;
+
+#if !defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+
+TEST_CASE("sherpa driver: creates, load fails without runtime, warmup") {
+  wake_kws_config_t cfg = WAKE_KWS_CONFIG_DEFAULT;
+  const wake_kws_backend_ops_t *ops = &wake_kws_sherpa_ops;
+  CHECK(std::string(ops->id) == "sherpa-onnx-kws");
+
+  void *impl = ops->create(&cfg);
+  REQUIRE(impl != nullptr);
+
+  /* no runtime in this build (default) -> load must fail loudly */
+  wake_model_bundle_t models;
+  models.model_dir = "/nonexistent";
+  CHECK(ops->load(impl, &models, &cfg) != 0);
+
+  /* warmup: -1, never a fabricated score */
+  int16_t frame[kFrame] = {0};
+  CHECK(ops->process_frame(impl, frame, kFrame) == -1.0f);
+
+  ops->reset(impl);
+  ops->destroy(impl);
+}
+
+#else /* runtime linked */
+
+/* Feed a whole wav through the driver; returns the number of hit frames
+ * (1.0) and the number of invalid scores seen. */
+static void feed_wav(const wake_kws_backend_ops_t *ops, void *impl,
+                     const char *path, int *hits, int *bad) {
+  wake_wav_t wav;
+  *hits = 0;
+  *bad = 0;
+  if (wake_wav_open(path, &wav) != 0) {
+    MESSAGE("cannot open " << path << " - skipping");
+    return;
+  }
+  REQUIRE(wav.sample_rate == 16000);
+  REQUIRE(wav.channels == 1);
+
+  size_t i = 0;
+  while (i < wav.sample_count) {
+    size_t n = wav.sample_count - i < kFrame ? wav.sample_count - i : kFrame;
+    const float s = ops->process_frame(impl, wav.samples + i, n);
+    if (s == 1.0f) {
+      (*hits)++;
+    } else if (s < 0.0f || s > 1.0f) {
+      (*bad)++;
+    }
+    i += n;
+  }
+  wake_wav_close(&wav);
+}
+
+TEST_CASE("sherpa driver: real transducer hits on the wake-word clip") {
+  const char *dir = std::getenv("WAKE_SHERPA_MODEL_DIR");
+#if defined(WAKE_SHERPA_MODEL_DIR)
+  if (dir == nullptr || *dir == '\0') {
+    dir = WAKE_SHERPA_MODEL_DIR;
+  }
+#endif
+  if (dir == nullptr || *dir == '\0') {
+    MESSAGE("WAKE_SHERPA_MODEL_DIR unset - skipping real-inference "
+            "assertions (CI sets it from the fetched kws model)");
+    return;
+  }
+
+  /* Skip when the model files are absent (issue #193 acceptance). */
+  {
+    std::string model = std::string(dir) + "/encoder.onnx";
+    std::string trigger = std::string(dir) + "/trigger.wav";
+    FILE *m = fopen(model.c_str(), "rb");
+    FILE *t = fopen(trigger.c_str(), "rb");
+    if (m == nullptr || t == nullptr) {
+      if (m != nullptr) fclose(m);
+      if (t != nullptr) fclose(t);
+      MESSAGE("sherpa model files / trigger.wav absent in " << dir
+              << " - skipping real-inference assertions");
+      return;
+    }
+    fclose(m);
+    fclose(t);
+  }
+
+  wake_kws_config_t cfg = WAKE_KWS_CONFIG_DEFAULT;
+  const wake_kws_backend_ops_t *ops = &wake_kws_sherpa_ops;
+
+  void *impl = ops->create(&cfg);
+  REQUIRE(impl != nullptr);
+
+  wake_model_bundle_t models;
+  models.model_dir = dir;
+  REQUIRE(ops->load(impl, &models, &cfg) == 0);
+
+  /* A real wake-word clip must produce at least one held 1.0 hit, and every
+   * score must be a valid 0.0/1.0 (never NaN or out of range). */
+  int hits = 0, bad = 0;
+  feed_wav(ops, impl, (std::string(dir) + "/trigger.wav").c_str(), &hits, &bad);
+  CHECK(bad == 0);
+  CHECK(hits > 0); /* the transducer must fire on the keyword clip */
+
+  /* Silence must never trigger. */
+  ops->reset(impl);
+  int16_t quiet[kFrame] = {0};
+  for (size_t t = 0; t < 16000 / kFrame; ++t) {
+    const float s = ops->process_frame(impl, quiet, kFrame);
+    CHECK(s == 0.0f || s == 1.0f);
+    CHECK(s != 1.0f);
+  }
+
+  /* reset() clears the hold; the next frame is a clean 0.0 (no hit). */
+  ops->reset(impl);
+  CHECK(ops->process_frame(impl, quiet, kFrame) == 0.0f);
+
+  ops->destroy(impl);
+}
+
+#endif /* runtime linked */

--- a/device/tests/unit/sherpa.test.cxx
+++ b/device/tests/unit/sherpa.test.cxx
@@ -18,7 +18,7 @@
 
 #include "doctest/doctest.h"
 #include "wake/kws_backend.h"
-#include "wav_reader.h"
+#include "host/wav_reader.h"
 
 extern "C" const wake_kws_backend_ops_t wake_kws_sherpa_ops;
 
@@ -130,7 +130,7 @@ TEST_CASE("sherpa driver: real transducer hits on the wake-word clip") {
   int16_t quiet[kFrame] = {0};
   for (size_t t = 0; t < 16000 / kFrame; ++t) {
     const float s = ops->process_frame(impl, quiet, kFrame);
-    CHECK(s == 0.0f || s == 1.0f);
+    CHECK((s == 0.0f || s == 1.0f));
     CHECK(s != 1.0f);
   }
 

--- a/docs/modules/sdk.md
+++ b/docs/modules/sdk.md
@@ -210,6 +210,38 @@ selected modules' specs (see §9). `__attribute__((constructor))` and linker
 section tricks are avoided: fragile on bare-metal (linker scripts, startup
 code), nondeterministic. An explicit root is debuggable and testable.
 
+### 5.4 Device drivers (per-backend `device/` targets)
+
+Each driver is a self-contained module target — `wake_kws_<id>` — behind the
+same C `KWSBackend` op-struct, **runtime-gated** by a CMake option so the
+module always compiles/registers and only links its runtime when the build
+asks for it. A driver without its runtime still appears in capabilities;
+`load()` fails loudly ("runtime not linked") and `process_frame()` stays in
+warmup (`-1`). The bundle generator picks the runtime-ON configuration.
+
+| Driver (issue) | Module `device/` | Runtime | Gate option |
+|---|---|---|---|
+| microwakeword (#185) | `kws/microwakeword/device/` | TFLite-Micro (pinned, `third_party/tflite-micro`) | `WAKE_SDK_MICROWAKEWORD_HAS_RUNTIME` |
+| openwakeword (#192) | `kws/openwakeword/device/` | onnxruntime C API (pinned 1.21.0, `third_party/onnxruntime`, fetched prebuilt) | `WAKE_SDK_OPENWAKEWORD_HAS_RUNTIME` |
+| kws-streaming (#194) | `kws/streaming/device/` | onnxruntime C API (same pinned dep as openwakeword) | `WAKE_SDK_KWS_STREAMING_HAS_RUNTIME` |
+| sherpa-onnx-kws (#193) | `kws/sherpa/device/` | sherpa-onnx C API (pinned v1.13.6, `third_party/sherpa-onnx`, fetched prebuilt; bundles its own onnxruntime) | `WAKE_SDK_SHERPA_HAS_RUNTIME` |
+
+**onnxruntime (shared app-class runtime).** Two drivers share the pinned
+onnxruntime C API: openwakeword (mel → embedding → classifier, a byte-for-byte
+port of `core/backend.ts`) and kws-streaming (the same kwt\*.onnx graphs the
+browser runs, **manifest-driven**: a sidecar `manifest.json` — the browser's
+own sidecar contract — describes mode, tensor names, window/packet sizes and
+labels, so one driver serves every topology upstream ships, in both
+`sliding-window` and `streaming-external-state` shapes). Both read model files
+from the bundle `model_dir` under driver-declared names — no URL bag on
+device (ADR-040 §4.1).
+
+**sherpa-onnx (ASR-Decoding).** The sherpa driver runs the same
+encoder/decoder/joiner transducer the browser wasm runs, through the native
+KeywordSpotter C API. It is **hit-based**, not a per-frame posterior:
+`process_frame()` returns 1.0 on a keyword hit (held ~400 ms so the
+min-duration gate clears), 0.0 otherwise — browser parity.
+
 ### 5.3 Low-power vs high-performance: profiles, not forks (ADR-040 §4)
 
 One core; the mcu/app distinction is **preset configurations**:
@@ -313,8 +345,9 @@ target — this is the hard acceptance for #41.
 6. Composition root + profile system (mcu/app) + capabilities query.
 7. microwakeword device driver (TFLite-Micro) + Cortex-M cross-compile in CI.
 8. Raspberry Pi Python binding golden path.
-9. plix device driver (onnxruntime C API); openwakeword/sherpa reuse the
-   pattern as follow-ups.
+9. openwakeword + kws-streaming + sherpa-onnx-kws device drivers shipped
+   (onnxruntime shared runtime; sherpa-onnx prebuilt); plix reuses the
+   pattern as a follow-up; microwakeword (TFLite-Micro) lands the MCU tier.
 10. On-hardware MCU validation (buy one cheap STM32/Arduino board for the
     golden-path acceptance).
 11. Android (JNI) / iOS (Swift) / desktop bindings; bundle generator consumes

--- a/packages/modules/kws/sherpa/device/CMakeLists.txt
+++ b/packages/modules/kws/sherpa/device/CMakeLists.txt
@@ -1,0 +1,45 @@
+# sherpa-onnx-kws module — device target (ADR-021/040 §2, issue #193).
+
+# Optional sherpa-onnx runtime: -DWAKE_SDK_SHERPA_HAS_RUNTIME=ON.
+# Default OFF — the driver compiles and registers without it; load() reports
+# "runtime not linked" and process_frame() stays in warmup. The prebuilt
+# sherpa-onnx shared library (pinned release, ADR-031 style) is fetched into
+# third_party/sherpa-onnx/<host> by scripts/fetch-sherpa-onnx.mjs; it bundles
+# its own onnxruntime, so no separate runtime is needed.
+option(WAKE_SDK_SHERPA_HAS_RUNTIME "Link the sherpa-onnx C API runtime" OFF)
+
+add_library(wake_kws_sherpa STATIC src/sherpa_driver.c)
+target_link_libraries(wake_kws_sherpa PUBLIC wake_sdk_core)
+
+if(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  set(WAKE_SDK_SHERPA_DIR "${WAKE_REPO_ROOT}/third_party/sherpa-onnx"
+      CACHE PATH "sherpa-onnx prebuilt root (fetched; never committed)")
+  if(APPLE)
+    set(_sherpa_host osx-arm64)
+    set(_sherpa_lib "libsherpa-onnx-c-api.dylib")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    set(_sherpa_host linux-aarch64)
+    set(_sherpa_lib "libsherpa-onnx-c-api.so")
+  else()
+    set(_sherpa_host linux-x64)
+    set(_sherpa_lib "libsherpa-onnx-c-api.so")
+  endif()
+  set(_sherpa_root "${WAKE_SDK_SHERPA_DIR}/${_sherpa_host}")
+
+  if(NOT EXISTS "${_sherpa_root}/include/sherpa-onnx/c-api/c-api.h")
+    message(FATAL_ERROR
+      "sherpa-onnx not found at ${_sherpa_root} — run: "
+      "node scripts/fetch-sherpa-onnx.mjs")
+  endif()
+
+  target_compile_definitions(wake_kws_sherpa
+    PRIVATE WAKE_SDK_SHERPA_HAS_RUNTIME=1)
+  target_include_directories(wake_kws_sherpa
+    PUBLIC "${_sherpa_root}/include")
+  target_link_libraries(wake_kws_sherpa
+    PUBLIC "${_sherpa_root}/lib/${_sherpa_lib}")
+  # Consumers (test binaries, bundles) must find the runtime (and the
+  # onnxruntime it bundles) at load time.
+  target_link_options(wake_kws_sherpa
+    INTERFACE "-Wl,-rpath,${_sherpa_root}/lib")
+endif()

--- a/packages/modules/kws/sherpa/device/README.md
+++ b/packages/modules/kws/sherpa/device/README.md
@@ -1,0 +1,64 @@
+# sherpa-onnx-kws module — device target
+
+`sherpa-onnx` (Apache-2.0, k2-fsa) is the **ASR-Decoding category** backend
+(ADR-024): a real KWS transducer (`KeywordSpotter`) tuned for fixed wake
+words. The browser driver (`core/backend.ts`) runs the same library compiled
+to wasm; the device driver runs the **same encoder/decoder/joiner onnx
+models** through the native sherpa-onnx C API.
+
+## Current state
+
+The full C `KWSBackend` adapter ships (`wake_kws_sherpa_ops`):
+create / load(model_dir) / process_frame / reset / destroy, plus the CMake
+target and the runtime-gating option `WAKE_SDK_SHERPA_HAS_RUNTIME` (default
+OFF).
+
+Without the runtime the module still compiles, registers, and appears in
+capabilities; `load()` returns a clear "runtime not linked" error and
+`process_frame()` stays in warmup (`-1`).
+
+## Runtime (sherpa-onnx prebuilt, pinned 1.13.6)
+
+Pinned release **v1.13.6** (ADR-031 style; live upstream — ADR-037 Tier 1-2,
+no source vendoring). The shared tarball bundles its own onnxruntime, so no
+separate runtime is needed. Fetched per host into
+`third_party/sherpa-onnx/<host>` (gitignored):
+
+```bash
+node scripts/fetch-sherpa-onnx.mjs          # linux-x64 | osx-arm64
+cmake -S device -B build -DCMAKE_BUILD_TYPE=Debug -DWAKE_SDK_PROFILE=app \
+  -DWAKE_SDK_SHERPA_HAS_RUNTIME=ON
+cmake --build build -j
+ctest --test-dir build --output-on-failure
+```
+
+The L1 test exercises the real transducer when a model dir is supplied:
+
+```bash
+cmake -S device -B build ... -DWAKE_SDK_SHERPA_HAS_RUNTIME=ON \
+  -DWAKE_SHERPA_MODEL_DIR=<dir-with-model-files>
+```
+
+## Model files (driver-declared names, ADR-040 §4.1)
+
+The driver reads these names from the bundle's `model_dir`:
+
+| File | Content |
+|---|---|
+| `encoder.onnx` / `decoder.onnx` / `joiner.onnx` | the KWS transducer (chunk-16 variant, e.g. `sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20`) |
+| `tokens.txt` | BPE token list |
+| `keywords.txt` | keyword list in sherpa phone format, one per line (`L AY1 T AH1 P @LIGHT_UP`) — spec-driven, the bundle generator emits it |
+| `trigger.wav` | a positive wake-word clip (test-only, staged by CI) |
+
+Fetched from the `kws-models` release
+(`sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20.tar.bz2`); the module's
+`fetch-artifact` recipe covers the browser wasm bundle — the device driver's
+model files are fetched directly from the same upstream release (pinned URL,
+see `device.yml`).
+
+## Scoring semantics (browser parity)
+
+sherpa KWS is **hit-based**, not a per-frame posterior: `process_frame()`
+returns `1.0` on a keyword hit (held ~400 ms so the engine's min-duration
+gate clears), `0.0` otherwise, and `-1` only before `load()`. The core's
+smoothing/threshold/cooldown handle the rest (ADR-018).

--- a/packages/modules/kws/sherpa/device/src/sherpa_driver.c
+++ b/packages/modules/kws/sherpa/device/src/sherpa_driver.c
@@ -52,29 +52,41 @@ typedef struct sherpa_impl {
 /* Browser-parity config (backend.ts load()): feat 16000/80, cpu EP,
  * maxActivePaths 4, numTrailingBlanks 1, keywordsScore 1.0,
  * keywordsThreshold 0.25. */
+
+/* The config holds raw pointers to the model path strings; the buffers must
+ * stay alive until SherpaOnnxCreateKeywordSpotter has copied them (it loads
+ * eagerly). fill_config() fills a caller-owned struct so the strings are not
+ * local to this function. */
+typedef struct sherpa_model_paths {
+  char encoder[1024];
+  char decoder[1024];
+  char joiner[1024];
+  char tokens[1024];
+  char keywords[1024];
+} sherpa_model_paths_t;
+
 static void fill_config(SherpaOnnxKeywordSpotterConfig *config,
-                        const char *dir) {
-  char encoder[1024], decoder[1024], joiner[1024], tokens[1024], keywords[1024];
-  snprintf(encoder, sizeof(encoder), "%s/encoder.onnx", dir);
-  snprintf(decoder, sizeof(decoder), "%s/decoder.onnx", dir);
-  snprintf(joiner, sizeof(joiner), "%s/joiner.onnx", dir);
-  snprintf(tokens, sizeof(tokens), "%s/tokens.txt", dir);
-  snprintf(keywords, sizeof(keywords), "%s/keywords.txt", dir);
+                        sherpa_model_paths_t *paths, const char *dir) {
+  snprintf(paths->encoder, sizeof(paths->encoder), "%s/encoder.onnx", dir);
+  snprintf(paths->decoder, sizeof(paths->decoder), "%s/decoder.onnx", dir);
+  snprintf(paths->joiner, sizeof(paths->joiner), "%s/joiner.onnx", dir);
+  snprintf(paths->tokens, sizeof(paths->tokens), "%s/tokens.txt", dir);
+  snprintf(paths->keywords, sizeof(paths->keywords), "%s/keywords.txt", dir);
 
   memset(config, 0, sizeof(*config));
   config->feat_config.sample_rate = 16000;
   config->feat_config.feature_dim = 80;
-  config->model_config.transducer.encoder = encoder;
-  config->model_config.transducer.decoder = decoder;
-  config->model_config.transducer.joiner = joiner;
-  config->model_config.tokens = tokens;
+  config->model_config.transducer.encoder = paths->encoder;
+  config->model_config.transducer.decoder = paths->decoder;
+  config->model_config.transducer.joiner = paths->joiner;
+  config->model_config.tokens = paths->tokens;
   config->model_config.provider = "cpu";
   config->model_config.num_threads = 1;
   config->max_active_paths = 4;
   config->num_trailing_blanks = 1;
   config->keywords_score = 1.0f;
   config->keywords_threshold = 0.25f;
-  config->keywords_file = keywords;
+  config->keywords_file = paths->keywords;
 }
 
 /* Check the bundle dir has every file the driver declares. */
@@ -133,9 +145,11 @@ static int sherpa_load(void *v, const wake_model_bundle_t *models,
   }
 
   /* The config strings only need to live for the create call: sherpa-onnx
-   * loads the models eagerly into memory. */
+   * loads the models eagerly into memory. The path buffers are owned by
+   * sherpa_model_paths_t, which stays alive through the create call. */
+  sherpa_model_paths_t paths;
   SherpaOnnxKeywordSpotterConfig config;
-  fill_config(&config, models->model_dir);
+  fill_config(&config, &paths, models->model_dir);
 
   impl->spotter = SherpaOnnxCreateKeywordSpotter(&config);
   if (impl->spotter == NULL) {

--- a/packages/modules/kws/sherpa/device/src/sherpa_driver.c
+++ b/packages/modules/kws/sherpa/device/src/sherpa_driver.c
@@ -1,0 +1,235 @@
+/*
+ * sherpa_driver.c — sherpa-onnx KWS device driver (issue #193).
+ *
+ * C KWSBackend adapter for the ASR-Decoding category (ADR-024): real KWS
+ * transducer via sherpa-onnx's KeywordSpotter (streaming transducer tuned
+ * for fixed wake words). The browser runs the same library compiled to wasm
+ * (`core/backend.ts` is the reference); on device the same C API runs the
+ * encoder/decoder/joiner onnx models directly.
+ *
+ * Pipeline (browser parity, backend.ts):
+ *   AFE 16 kHz frames -> SherpaOnnxOnlineStreamAcceptWaveform
+ *   -> (ready) DecodeKeywordStream -> GetKeywordResult
+ *   -> keyword string -> binary score: 1.0 on a hit (held ~400 ms so the
+ *     engine's min-duration gate clears), else 0.0. The generic detection
+ *     loop (smoothing/threshold/cooldown) lives in the core.
+ *
+ * Model files are read from the bundle's model_dir with the names this
+ * driver declares (ADR-040 §4.1):
+ *   <model_dir>/encoder.onnx   <model_dir>/decoder.onnx
+ *   <model_dir>/joiner.onnx    <model_dir>/tokens.txt
+ *   <model_dir>/keywords.txt   (keyword list; spec-driven — sherpa phone
+ *                               format "L AY1 T AH1 P @LIGHT_UP", one per line)
+ *
+ * Runtime gating: WAKE_SDK_SHERPA_HAS_RUNTIME (CMake option, default OFF).
+ * Without the runtime, load() reports "runtime not linked" and
+ * process_frame() stays in warmup (-1) — the module still compiles and
+ * registers, so the composition root and capabilities work end-to-end.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "wake/kws_backend.h"
+
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+#include "sherpa-onnx/c-api/c-api.h"
+#endif
+
+typedef struct sherpa_impl {
+  int loaded;
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  const SherpaOnnxKeywordSpotter *spotter;
+  const SherpaOnnxOnlineStream *stream;
+  int hold_frames; /* post-hit hold, browser parity (40 frames = 400 ms) */
+  float frame_buf[160]; /* int16 -> float [-1,1] conversion scratch */
+#endif
+} sherpa_impl_t;
+
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+
+/* Browser-parity config (backend.ts load()): feat 16000/80, cpu EP,
+ * maxActivePaths 4, numTrailingBlanks 1, keywordsScore 1.0,
+ * keywordsThreshold 0.25. */
+static void fill_config(SherpaOnnxKeywordSpotterConfig *config,
+                        const char *dir) {
+  char encoder[1024], decoder[1024], joiner[1024], tokens[1024], keywords[1024];
+  snprintf(encoder, sizeof(encoder), "%s/encoder.onnx", dir);
+  snprintf(decoder, sizeof(decoder), "%s/decoder.onnx", dir);
+  snprintf(joiner, sizeof(joiner), "%s/joiner.onnx", dir);
+  snprintf(tokens, sizeof(tokens), "%s/tokens.txt", dir);
+  snprintf(keywords, sizeof(keywords), "%s/keywords.txt", dir);
+
+  memset(config, 0, sizeof(*config));
+  config->feat_config.sample_rate = 16000;
+  config->feat_config.feature_dim = 80;
+  config->model_config.transducer.encoder = encoder;
+  config->model_config.transducer.decoder = decoder;
+  config->model_config.transducer.joiner = joiner;
+  config->model_config.tokens = tokens;
+  config->model_config.provider = "cpu";
+  config->model_config.num_threads = 1;
+  config->max_active_paths = 4;
+  config->num_trailing_blanks = 1;
+  config->keywords_score = 1.0f;
+  config->keywords_threshold = 0.25f;
+  config->keywords_file = keywords;
+}
+
+/* Check the bundle dir has every file the driver declares. */
+static int model_files_present(const char *dir) {
+  static const char *names[] = {
+      "encoder.onnx", "decoder.onnx", "joiner.onnx", "tokens.txt",
+      "keywords.txt", NULL};
+  for (size_t i = 0; names[i] != NULL; ++i) {
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/%s", dir, names[i]);
+    FILE *f = fopen(path, "rb");
+    if (f == NULL) {
+      fprintf(stderr, "[sherpa] missing model file %s\n", path);
+      return 0;
+    }
+    fclose(f);
+  }
+  return 1;
+}
+
+#endif /* WAKE_SDK_SHERPA_HAS_RUNTIME */
+
+static void *sherpa_create(const wake_kws_config_t *cfg) {
+  (void)cfg;
+  return calloc(1, sizeof(sherpa_impl_t));
+}
+
+static void sherpa_destroy(void *v) {
+  sherpa_impl_t *impl = (sherpa_impl_t *)v;
+  if (impl == NULL) {
+    return;
+  }
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  if (impl->stream != NULL) {
+    SherpaOnnxDestroyOnlineStream(impl->stream);
+    impl->stream = NULL;
+  }
+  if (impl->spotter != NULL) {
+    SherpaOnnxDestroyKeywordSpotter(impl->spotter);
+    impl->spotter = NULL;
+  }
+#endif
+  free(impl);
+}
+
+static int sherpa_load(void *v, const wake_model_bundle_t *models,
+                       const wake_kws_config_t *cfg) {
+  (void)cfg;
+  sherpa_impl_t *impl = (sherpa_impl_t *)v;
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  if (models == NULL || models->model_dir == NULL) {
+    return 1;
+  }
+  if (!model_files_present(models->model_dir)) {
+    return 1;
+  }
+
+  /* The config strings only need to live for the create call: sherpa-onnx
+   * loads the models eagerly into memory. */
+  SherpaOnnxKeywordSpotterConfig config;
+  fill_config(&config, models->model_dir);
+
+  impl->spotter = SherpaOnnxCreateKeywordSpotter(&config);
+  if (impl->spotter == NULL) {
+    fprintf(stderr, "[sherpa] SherpaOnnxCreateKeywordSpotter failed\n");
+    return 1;
+  }
+  impl->stream = SherpaOnnxCreateKeywordStream(impl->spotter);
+  if (impl->stream == NULL) {
+    SherpaOnnxDestroyKeywordSpotter(impl->spotter);
+    impl->spotter = NULL;
+    fprintf(stderr, "[sherpa] SherpaOnnxCreateKeywordStream failed\n");
+    return 1;
+  }
+  impl->loaded = 1;
+  return 0;
+#else
+  (void)impl;
+  (void)models;
+  return 1; /* sherpa-onnx not linked in this build */
+#endif
+}
+
+static float sherpa_process_frame(void *v, const int16_t *samples, size_t n) {
+  sherpa_impl_t *impl = (sherpa_impl_t *)v;
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  if (!impl->loaded || samples == NULL) {
+    return -1.0f; /* warmup */
+  }
+
+  /* sherpa expects float samples in [-1, 1]. */
+  size_t n32 = n > sizeof(impl->frame_buf) / sizeof(impl->frame_buf[0])
+                   ? sizeof(impl->frame_buf) / sizeof(impl->frame_buf[0])
+                   : n;
+  for (size_t i = 0; i < n32; ++i) {
+    impl->frame_buf[i] = (float)samples[i] * (1.0f / 32768.0f);
+  }
+  SherpaOnnxOnlineStreamAcceptWaveform(impl->stream, 16000, impl->frame_buf,
+                                       (int32_t)n32);
+
+  /* Hold a detected hit for the trigger min-duration window (browser
+   * parity: 40 frames of 1.0 after a hit). */
+  if (impl->hold_frames > 0) {
+    impl->hold_frames -= 1;
+    return 1.0f;
+  }
+
+  /* Decode as many ready chunks as the stream has buffered; reset only after
+   * a hit (sherpa auto-resets after trailing silence; a mid-utterance reset
+   * would wipe the encoder states and break multi-chunk keywords). */
+  int hit = 0;
+  while (SherpaOnnxIsKeywordStreamReady(impl->spotter, impl->stream)) {
+    SherpaOnnxDecodeKeywordStream(impl->spotter, impl->stream);
+    const SherpaOnnxKeywordResult *result =
+        SherpaOnnxGetKeywordResult(impl->spotter, impl->stream);
+    const char *keyword = result != NULL ? result->keyword : NULL;
+    if (keyword != NULL && keyword[0] != '\0') {
+      hit = 1;
+    }
+    if (result != NULL) {
+      SherpaOnnxDestroyKeywordResult(result);
+    }
+    if (hit) {
+      SherpaOnnxResetKeywordStream(impl->spotter, impl->stream);
+      break;
+    }
+  }
+
+  if (hit) {
+    impl->hold_frames = 40; /* ~400 ms @ 10 ms frames */
+    return 1.0f;
+  }
+  return 0.0f;
+#else
+  (void)impl;
+  (void)samples;
+  (void)n;
+  return -1.0f; /* warmup — sherpa-onnx not linked */
+#endif
+}
+
+static void sherpa_reset(void *v) {
+  sherpa_impl_t *impl = (sherpa_impl_t *)v;
+#if defined(WAKE_SDK_SHERPA_HAS_RUNTIME)
+  impl->hold_frames = 0;
+  if (impl->spotter != NULL && impl->stream != NULL) {
+    SherpaOnnxResetKeywordStream(impl->spotter, impl->stream);
+  }
+#else
+  (void)impl;
+#endif
+}
+
+const wake_kws_backend_ops_t wake_kws_sherpa_ops = {
+    "sherpa-onnx-kws",
+    "sherpa-onnx KWS (transducer, sherpa-onnx C API)",
+    sherpa_create, sherpa_destroy, sherpa_load, sherpa_process_frame,
+    sherpa_reset};

--- a/scripts/fetch-sherpa-onnx.mjs
+++ b/scripts/fetch-sherpa-onnx.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Fetch the pinned sherpa-onnx prebuilt C API (issue #193; ASR-Decoding
+ * device driver, kws/sherpa).
+ *
+ * sherpa-onnx is a live upstream project (ADR-037 Tier 1-2): we pin a release
+ * (ADR-031 style) instead of vendoring source. The official release tarballs
+ * ship the C API headers + shared library (which bundles its own
+ * onnxruntime); this script downloads the platform tarball for the current
+ * host, verifies its sha256, and extracts it to
+ * third_party/sherpa-onnx/<host> (gitignored — fetched, never committed).
+ *
+ * Usage:
+ *   node scripts/fetch-sherpa-onnx.mjs            # detect host
+ *   node scripts/fetch-sherpa-onnx.mjs --force    # re-fetch even if present
+ *
+ * Pinned: SHERPA_VERSION + per-platform sha256 below. When bumping, update
+ * both (sha256sum of the release tarball).
+ */
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const VERSION = '1.13.6'
+const BASE = `https://github.com/k2-fsa/sherpa-onnx/releases/download/v${VERSION}`
+
+const PLATFORMS = {
+  'linux-x64': {
+    tarball: `sherpa-onnx-v${VERSION}-linux-x64-shared.tar.bz2`,
+    sha256: '58cc7d360fdedf9702954e8b585eb400bbee8668484bf25e4461d5d22ba439d8',
+  },
+  'osx-arm64': {
+    // The macOS shared builds are named after the onnxruntime they bundle;
+    // 1.27.1 matches the upstream single-threaded wasm line (#3836).
+    tarball: `sherpa-onnx-v${VERSION}-onnxruntime-1.27.1-osx-arm64-shared.tar.bz2`,
+    sha256: '5cbb17b6857a1b3d48c9c8e2386d318710eb00f0ccecb01022424fee93bb77b8',
+  },
+}
+
+function die(msg) {
+  console.error(`[fetch-sherpa-onnx] ${msg}`)
+  process.exit(1)
+}
+
+function detectHost() {
+  const { platform, arch } = process
+  if (platform === 'darwin' && (arch === 'arm64' || arch === 'x64')) {
+    // The osx-arm64 tarball is a universal2 build (ships both slices).
+    return 'osx-arm64'
+  }
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64'
+  die(`unsupported host ${platform}/${arch} (supported: linux-x64, osx-arm64)`)
+}
+
+async function main() {
+  const force = process.argv.includes('--force')
+  const host = detectHost()
+  const cfg = PLATFORMS[host]
+  const sherpaDir = resolve(import.meta.dirname, '..', 'third_party', 'sherpa-onnx')
+  const dest = join(sherpaDir, host)
+  const marker = join(dest, 'include', 'sherpa-onnx', 'c-api', 'c-api.h')
+
+  if (!force && existsSync(marker)) {
+    console.log(`[fetch-sherpa-onnx] ${host} already fetched at ${dest}`)
+    return
+  }
+
+  const url = `${BASE}/${cfg.tarball}`
+  mkdirSync(sherpaDir, { recursive: true })
+  console.log(`[fetch-sherpa-onnx] downloading ${url}`)
+  const res = await fetch(url)
+  if (!res.ok) {
+    die(`download failed: HTTP ${res.status} ${res.statusText}`)
+  }
+
+  const buf = Buffer.from(await res.arrayBuffer())
+  const got = createHash('sha256').update(buf).digest('hex')
+  if (cfg.sha256 && got !== cfg.sha256) {
+    die(`sha256 mismatch for ${cfg.tarball}:\n  expected ${cfg.sha256}\n  got      ${got}`)
+  }
+  console.log(`[fetch-sherpa-onnx] sha256 ok (${got})`)
+
+  rmSync(dest, { recursive: true, force: true })
+  mkdirSync(dest, { recursive: true })
+  const tmp = join(sherpaDir, `.${host}.${VERSION}.tar.bz2`)
+  writeFileSync(tmp, buf)
+  const tar = spawnSync('tar', ['xjf', tmp, '-C', dest, '--strip-components=1'], {
+    stdio: 'inherit',
+  })
+  rmSync(tmp, { force: true })
+  if (tar.status !== 0) {
+    die(`extraction failed (tar exit ${tar.status})`)
+  }
+  console.log(`[fetch-sherpa-onnx] ${host} -> ${dest} (sherpa-onnx ${VERSION})`)
+}
+
+main().catch((e) => {
+  console.error('[fetch-sherpa-onnx]', e)
+  process.exit(1)
+})

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -26,6 +26,16 @@ on the record instead of pointing at a moving (or frozen) remote.
 |---|---|---|---|---|
 | `kws_streaming/` | `google-research/google-research` subtree `kws_streaming` | `cf61877d4c0021ff40ec3ecc0334aaa3937a1fcb` (2026-07-22, last commit touching the subtree) | Apache-2.0 | Archived upstream (project-level ARCHIVED); consumed unmodified by the kws-streaming train adapter (ADR-031; #156) |
 
+## Fetched prebuilt runtimes (not vendored source)
+
+`onnxruntime/` and `sherpa-onnx/` hold **fetched prebuilt binaries**
+(gitignored), not source: live upstreams (ADR-037 Tier 1-2), pinned releases
+(ADR-031 style) for the device SDK's app-class drivers — onnxruntime
+**1.21.0** (openwakeword #192; kws-streaming #194 reuses it) and sherpa-onnx
+**v1.13.6** (sherpa #193; its shared lib bundles its own onnxruntime). Fetch
+with `node scripts/fetch-onnxruntime.mjs` / `node scripts/fetch-sherpa-onnx.mjs`;
+the pins + sha256s live in those scripts and `LICENSES.md`.
+
 Import details live in each pristine-import commit message; the policy
 itself is ADR-037 in `DECISIONS.md`.
 


### PR DESCRIPTION
## What

Third app-class device driver (issue #193): the sherpa-onnx KWS transducer
(ASR-Decoding category, ADR-024) ported from the browser driver
(`packages/modules/kws/sherpa/core/backend.ts`) to the **native sherpa-onnx
C API** — the same encoder/decoder/joiner onnx models the browser wasm runs.

- `kws/sherpa/device/`: C `KWSBackend` adapter (create / load(model_dir) /
  process_frame / reset / destroy), runtime-gated by
  `WAKE_SDK_SHERPA_HAS_RUNTIME` (default OFF — same contract as the other
  drivers).
- **Hit-based scoring, browser parity**: 1.0 on a keyword hit (held ~400 ms
  so the engine's min-duration gate clears), 0.0 otherwise, -1 only before
  load(). Accepts int16 AFE frames → float [-1,1] →
  SherpaOnnxOnlineStreamAcceptWaveform; decodes ready chunks; resets only
  after a hit (mid-utterance resets wipe encoder states and break
  multi-chunk keywords — the wasm driver hit this exact bug).
- Config mirrors the browser: feat 16000/80, cpu EP, maxActivePaths 4,
  numTrailingBlanks 1, keywordsScore 1.0, keywordsThreshold 0.25.
- Model files read from the bundle `model_dir` under driver-declared names
  (encoder/decoder/joiner.onnx + tokens.txt + keywords.txt, ADR-040 §4.1).
- sherpa-onnx pinned **v1.13.6** prebuilt (ADR-031; its shared lib bundles
  its own onnxruntime): `scripts/fetch-sherpa-onnx.mjs` sha256-verifies and
  extracts to `third_party/sherpa-onnx/<host>` (gitignored).
- L1 tests: no-runtime contract + the **real transducer over a genuine
  wake-word clip** — trigger.wav must produce held 1.0 hits, silence must
  not (reuses the host wav_reader).
- New CI job in device.yml: fetches the pinned sherpa-onnx + the kws-models
  transducer tarball (sha256-pinned), builds with the runtime ON, runs
  ctest.
- Docs-sync: sdk.md §5.4 driver row, module README, third_party README.

## Test evidence

- Local: `-fsyntax-only` clean for the runtime-ON path against the pinned
  sherpa-onnx headers (-Werror).
- CI (this PR): native app/mcu × gcc/clang matrix, cross-MCU, and the new
  app-runtime job — real transducer trigger test on a genuine wake-word
  clip.

Closes #193