### PR TITLE
docs: sync roadmap/README/DECISIONS with Phase 4 progress + resolved questions (Q10/Q11/Q14)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1060,8 +1060,11 @@ Status legend: `Proposed` · `Accepted` · `Superseded` · `Deprecated`
   - Follow-ups: lazy driver chunks + backend manifest (v1.x), optional CI rg
     step once P0 fixes land, wire-web package if a second host appears.
 
-_Open questions still pending human input: Q10 (self-hosted training engine) is
-open for Phase 5. Q9 (training backends) is ADR-013 (amended: in-browser training
+_Open questions still pending human input: Q12 (PocketSphinx timing, #34) is
+open for Phase 4/5. Resolved: Q10 (self-hosted training engine, #32) is ADR-042
+(no wakeforge; module-owned openWakeWord pipeline); Q11 (L3 cadence, #33) is
+ADR-026; Q13 (SDK core CI, #35) is ADR-040; Q14 (vendor ONNX wasm, #36) is
+ADR-041. Q9 (training backends) is ADR-013 (amended: in-browser training
 removed, Cloud Providers unified, Colab added as ADR-023); targets are ADR-019
 (supersedes ADR-006); pluggable KWS backends are ADR-020; the device-side SDK is
 ADR-021; the data-source layer is ADR-022; the module platform is ADR-025

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1447,3 +1447,49 @@ applied per this log and may be overridden._
   - Q-SDK-1 resolved (C op-struct mirrors the TS `KWSBackend`); Q-SDK-2 (iOS
     CoreML vs onnxruntime) and Q-SDK-3 (ESP32 scope) remain open.
   - #35 (Q13) closed by this ADR.
+
+## ADR-041 — onnxruntime-web wasm is vendored locally now (P0-4), not deferred to Phase 6
+
+- **Status:** Accepted (2026-08-20)
+- **Origin:** Q14 (#36) — vendor ONNX wasm now (P0-4) vs Phase 6? Resolved by
+  execution: P0-4 (#30) shipped 2026-08-12.
+- **Decision:** The onnxruntime-web wasm pair is **vendored locally** and
+  `ort.env.wasm.wasmPaths` points at the local copy — the CDN dependency is
+  gone, so the PWA's model runtime works offline. The decision is **now, not
+  Phase 6**: P0-4 landed early because the offline requirement is a hard
+  product constraint and the wasm pair is a small, stable artifact.
+- **Rationale:** Q14's recommended default was "Phase 6 unless an earlier
+  phase needs offline validation." The KWS Phase-3.7 closure work surfaced the
+  need for reliable offline boot of the model runtime, so the vendoring was
+  pulled forward as P0-4. Vendoring early also makes CI/e2e asset fetching
+  deterministic and removes a flaky external dependency from every L2/L3 run.
+- **Consequences:**
+  - `#30` closed; the roadmap Phase 6 "Offline" item is now partially
+    satisfied (the remaining Phase 6 offline work is service-worker pre-fetch /
+    asset caching per the ADR-011 amendment).
+  - L2/L3 tests fetch runtime assets via the ADR-027 artifact SOP rather than
+    from a CDN at runtime.
+  - `wasmPaths` remains configurable; a future Phase 6 pre-fetch path may add
+    integrity-checked caching on top of the vendored copy.
+
+## ADR-042 — Self-hosted training engine stays on the module-owned openWakeWord pipeline; wakeforge (ww_trainer) is not integrated
+
+- **Status:** Accepted (2026-08-20)
+- **Origin:** Q10 (#32) — wrap the openWakeWord pipeline directly vs integrate
+  `TigreGotico/wakeforge` (`ww_trainer`)?
+- **Decision:** **No wakeforge integration for now.** The self-hosted training
+  engine wraps the **module-owned openWakeWord pipeline** (ADR-031 "adapt, never
+  rewrite" — the module owns its train adapter and runs it via `uv`, ADR-028).
+  wakeforge stays a **documented candidate only**, evaluated again if the
+  module-owned path hits a real gap.
+- **Rationale:** The module platform already owns per-backend train adapters
+  (ADR-025/031); adding wakeforge would be a second, parallel training path
+  competing with the openwakeword adapter without an identified requirement.
+  Revisit only if (a) openwakeword training quality/FAR proves insufficient,
+  or (b) multi-wake-word or quantization needs outgrow the module-owned path.
+- **Consequences:**
+  - #32 closed; the roadmap Phase 5 "Self-hosted Service" item no longer names
+    wakeforge as the candidate engine (it is now an optional future eval).
+  - Training effort stays concentrated on the module-owned adapters
+    (openwakeword, kws-streaming) per ADR-039 (formats/quantization,
+    module-owned convert).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ models.**
 **This project is work in progress (WIP).** While phases 0–3 shipped (AFE,
 KWS, Few-Shot, console/studio productization) and the module platform
 migration (ADR-025) is complete, v1 is not released: everything below can
-change. Phase 4 (device SDK + export kits) is next. See
+change. Phase 4 (device SDK + export kits) is underway — the C/C++ SDK core
+and the app-class device drivers (openwakeword/sherpa/kws-streaming) have
+shipped; target adapters and bundle generation remain. See
 [`docs/roadmap.md`](./docs/roadmap.md) for the full phased roadmap and
 [`DECISIONS.md`](./DECISIONS.md) for recorded decisions.
 
@@ -36,7 +38,7 @@ change. Phase 4 (device SDK + export kits) is next. See
 | 2 | KWS inference in the browser | ✅ Complete (pluggable KWSBackend, ADR-020; openWakeWord + sherpa-onnx KWS wasm) |
 | 3 | Few-Shot custom wake-word enrollment | ✅ Complete (PLiX embed + prototype-distance, client-side) |
 | 3.5 | Console/Studio productization (shell, projects, library, session console) | ✅ Complete |
-| 4 | Model export & integration kits (device SDK) | ⏳ Pending |
+| 4 | Model export & integration kits (device SDK) | 🔄 In progress (SDK core + app-class device drivers shipped) |
 | 5 | Custom-model training (multi-backend) | ⏳ Pending (contract locked, docs/modules/training.md) |
 | 6 | Polish, PWA, packaging, docs | ⏳ Pending |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,7 +236,8 @@ the gate blocks a non-commercial model from a commercial export.
 2. **Self-hosted Service** (`apps/studio-backend`, ADR-005/036): real training
    runner (Python/FastAPI job manager; `uv run wake-service` spawns module
    `train/` scripts via `uv`, ADR-028); PyInstaller binary + Docker image;
-   candidate engine `TigreGotico/wakeforge` (`ww_trainer`) — evaluate (Q10).
+   engine = the module-owned openWakeWord pipeline (ADR-042; wakeforge is
+   a documented optional future eval, not integrated).
 3. **Cloud Providers** (capability-labeled): AWS / Google Cloud / Hugging
    Face / Alibaba / Tencent / Volcengine adapters behind the common interface;
    credentials client-side only.
@@ -283,10 +284,11 @@ contracts/test-kit), [#28](https://github.com/awareride/wake-studio/issues/28)
 (deploy wasm fetch + Cloudflare rename), [#30](https://github.com/awareride/wake-studio/issues/30)
 (vendor ONNX wasm / offline) — all closed 2026-08-12 (Done on the board).
 
-**Open questions** (close with a decision that lands as an ADR): #32 (Q10:
-self-hosted training engine), #33 (Q11: L3 e2e cadence), #34 (Q12: PocketSphinx
-timing), #36 (Q14: vendor ONNX wasm now vs Phase 6). Q13 (#35) resolved by
-ADR-040 (native-first SDK CI) and closed.
+**Open questions** (close with a decision that lands as an ADR): #34 (Q12:
+PocketSphinx timing). Resolved: Q10 (#32) → ADR-042 (no wakeforge; module-owned
+openWakeWord pipeline), Q11 (#33) → ADR-026 (L3 = merge-gate), Q13 (#35) →
+ADR-040 (native-first SDK CI), Q14 (#36) → ADR-041 (onnxruntime-web wasm
+vendored now via P0-4).
 
 **Next actions** (from the board): finish Phase 4 SDK — microwakeword driver
 (#185), Raspberry Pi Python binding (#187), plix driver (#188), bundle
@@ -323,7 +325,7 @@ generator (#189); then license gate (#42), PocketSphinx (#40).
 - micro-wake-word: https://github.com/OHF-Voice/micro-wake-word (Apache-2.0)
 - sherpa-onnx: https://github.com/k2-fsa/sherpa-onnx (Apache-2.0)
 - wakeforge (`ww_trainer`): https://github.com/TigreGotico/wakeforge
-  (Apache-2.0; Q10 candidate)
+  (Apache-2.0; optional future eval, ADR-042)
 - PLiX KWS: https://github.com/aaqibsaeed/plixkws (Apache-2.0)
 - PocketSphinx: https://github.com/cmusphinx/pocketsphinx (BSD-style)
 - RNNoise: https://gitlab.xiph.org/xiph/rnnoise ; wasm ports (jitsi/timephy)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@
 > (Issues + the `WakeStudio Delivery` project, org `awareride`) — this doc
 > keeps the static vision, phase history, and pointers; it never holds live
 > status.
-> Owner: WakeStudio team · Updated: 2026-08-11 (KWS Phase-3 closure shipped)
+> Owner: WakeStudio team · Updated: 2026-08-20 (Phase 4 SDK core + app-class device drivers shipped)
 > Companions: `docs/architecture.md` (durable architecture), `DECISIONS.md`
 > (ADR log), `LICENSES.md` (license matrix), `docs/modules/*.md` (module
 > specs), `CONTRIBUTING.md` (working agreements + issue/project model).
@@ -84,7 +84,8 @@ The durable architecture lives in `docs/architecture.md`; the ADR log in
 - **Testing** is three-layer (ADR-026): L1 unit, L2 wasm/onnx boot (Node,
   every PR), L3 browser e2e (merge gate). All KWS drivers have L2 suites that
   run for real in CI (sherpa/openwakeword/plix; assets are GitHub Release
-  hosted, ADR-027 §6.7).
+  hosted, ADR-027 §6.7). The device SDK adds native host build + unit tests on
+  every PR (ADR-040 §5; slices #182/#183/#186).
 - **Deploy** (ADR-012): `VITE_BASE_PATH` — `/` for Cloudflare, `/<repo>/` for
   GitHub Pages.
 
@@ -97,8 +98,8 @@ The durable architecture lives in `docs/architecture.md`; the ADR log in
 
 | Backend | Category (ADR-024) | License | Tier / targets | In repo today |
 |---|---|---|---|---|
-| **openWakeWord** (`dscripka/openWakeWord`) | Traditional | Apache-2.0 code; CC BY-NC-SA pre-trained models (demo-only) | App-class (Pi, desktop, mobile, browser) | ✅ `packages/modules/kws/openwakeword/` |
-| **sherpa-onnx KWS** (`k2-fsa/sherpa-onnx`) | ASR Decoding | Apache-2.0 | App-class + MCU; real KWS transducer, compiled WASM in-browser | ✅ `packages/modules/kws/sherpa/` (wasm from Release `models-sherpa-wasm-v1`) |
+| **openWakeWord** (`dscripka/openWakeWord`) | Traditional | Apache-2.0 code; CC BY-NC-SA pre-trained models (demo-only) | App-class (Pi, desktop, mobile, browser) | ✅ browser + ✅ device driver (`kws/openwakeword/device/`, #192) |
+| **sherpa-onnx KWS** (`k2-fsa/sherpa-onnx`) | ASR Decoding | Apache-2.0 | App-class + MCU; real KWS transducer, compiled WASM in-browser | ✅ browser + ✅ device driver (`kws/sherpa/device/`, #193) |
 | **PLiX Few-Shot** (`aaqibsaeed/plixkws`) | Few-Shot | Apache-2.0 | App-class, enrollment-based (prototype-distance, ADR-002); onnx + transformers runtimes | ✅ `packages/modules/kws/plix/` |
 | **micro-wake-word** (`OHF-Voice/micro-wake-word`) | Traditional | Apache-2.0 | MCU (Cortex-M, ESP32) via TFLite-Micro | ⏳ Phase 4/5 |
 | **PocketSphinx** (`cmusphinx/pocketsphinx`) | Traditional (lightweight alt) | BSD-style | MCU-class and above, lightweight alternative | ⏳ Pending (ADR-020) |
@@ -189,11 +190,19 @@ real on every PR (PRs #82/#84/#85/#86):
 - e2e per backend (sherpa/openwakeword/plix onnx + transformers) + stale
   assertions from the panel rewrite fixed.
 
-### Phase 4 — Device-side SDK & export kits (ADR-021) — ⏳ Next
+### Phase 4 — Device-side SDK & export kits (ADR-021) — 🔄 In progress
 
 > Tracked as epic [#31](https://github.com/awareride/wake-studio/issues/31)
-> with sub-issues #37–#42 in the `WakeStudio Delivery` project.
-> Docs-first: `docs/modules/sdk.md` + `docs/modules/export.md` before code.
+> (In Progress) with sub-issues #37–#42 and implementation slices #179–#189
+> in the `WakeStudio Delivery` project.
+> Docs-first: `docs/modules/sdk.md` (Draft v2, landed with ADR-040) +
+> `docs/modules/export.md` (still to write before bundle generation).
+> Status (2026-08-20): SDK core shipped (ADR-040, slices #179–#184 closed,
+> PR #191); app-class device drivers shipped for openwakeword (#192),
+> kws-streaming (#194) and sherpa (#193) (PRs #196/#197/#198); Cortex-M
+> cross-compile CI landed (#186). Remaining: microwakeword driver (#185),
+> Pi Python binding (#187), plix driver (#188), bundle generator (#189),
+> license gate (#42), PocketSphinx (#40).
 
 1. **SDK core (C/C++, `packages/sdk` + `device/`):** portable core
    (`KWSBackend` interface ADR-020, portable AFE ADR-003/016, audio I/O +
@@ -267,19 +276,21 @@ Task state lives in **Issues + the `WakeStudio Delivery` project** (org
 `awareride`, project #2); load it with `gh project item-list 2 --owner
 awareride` (see `CONTRIBUTING.md`). This doc only keeps pointers.
 
-**P0 blockers** (delivery chain — gate every later phase): issues
+**P0 blockers** (delivery chain — all resolved): issues
 [#27](https://github.com/awareride/wake-studio/issues/27) (lint red in
 contracts/test-kit), [#28](https://github.com/awareride/wake-studio/issues/28)
 (playwright CI resolution), [#29](https://github.com/awareride/wake-studio/issues/29)
 (deploy wasm fetch + Cloudflare rename), [#30](https://github.com/awareride/wake-studio/issues/30)
-(vendor ONNX wasm / offline).
+(vendor ONNX wasm / offline) — all closed 2026-08-12 (Done on the board).
 
 **Open questions** (close with a decision that lands as an ADR): #32 (Q10:
 self-hosted training engine), #33 (Q11: L3 e2e cadence), #34 (Q12: PocketSphinx
-timing), #35 (Q13: SDK core CI), #36 (Q14: vendor ONNX wasm now vs Phase 6).
+timing), #36 (Q14: vendor ONNX wasm now vs Phase 6). Q13 (#35) resolved by
+ADR-040 (native-first SDK CI) and closed.
 
-**Next actions** (from the board): close the P0 blockers; start Phase 4 SDK
-(epic #31).
+**Next actions** (from the board): finish Phase 4 SDK — microwakeword driver
+(#185), Raspberry Pi Python binding (#187), plix driver (#188), bundle
+generator (#189); then license gate (#42), PocketSphinx (#40).
 
 ## 8. Risks & mitigations
 
@@ -289,9 +300,9 @@ timing), #35 (Q13: SDK core CI), #36 (Q14: vendor ONNX wasm now vs Phase 6).
 | Export bundles can accidentally ship CC BY-NC-SA models commercially | High | High | License gate (already scaffolded); always train our own models (Phase 5); `LICENSES.md` matrix |
 | Few-Shot high false-alarm rate (only 3–5 samples) | High | Medium | Negative prototypes + VAD gating + min-duration smoothing (shipped) |
 | Cloud-provider credential leakage | Medium | High | Credentials client-side only; never logged/exported; Phase 6 security review |
-| onnxruntime-web wasm on CDN breaks offline promise | Medium | Medium | Vendor locally (Phase 6 / P0-4) |
+| onnxruntime-web wasm on CDN breaks offline promise | Medium | Medium | Resolved — vendored locally (P0-4 #30, closed) |
 | Browser WebGPU/WASM SIMD support varies | Medium | Medium | Feature-detect + WASM fallback |
-| CI red (P0-1/P0-2) blocks all PRs | High | High | P0 blockers land first; they are the gate for everything else |
+| CI red (P0-1/P0-2) blocks all PRs | High | High | Resolved 2026-08-12 (P0s #27/#28 closed); CI green is enforced on PRs |
 
 ## 9. Out of scope (non-goals for v1)
 


### PR DESCRIPTION
## What

Sync the docs with the current real state after the Phase 4 SDK work landed, and record the resolutions of the open `question` issues.

## Changes

- **`docs/roadmap.md`** — Phase 4 marked 🔄 In progress with a status block (SDK core shipped via #179–#184/PR #191; app-class device drivers openwakeword/sherpa/kws-streaming merged via PRs #196/#197/#198; Cortex-M cross-compile CI landed #186). P0 blockers marked resolved, Q13 removed from open questions, next actions updated, model table + testing invariant note the device drivers, risks table updated.
- **`README.md`** — Phase 4 row ⏳ Pending → 🔄 In progress.
- **`DECISIONS.md`** — new **ADR-041** (onnxruntime-web wasm vendored now via P0-4 #30, not Phase 6; resolves Q14 #36) and **ADR-042** (no wakeforge; module-owned openWakeWord pipeline; resolves Q10 #32); ADR-034 open-questions note updated.

## GitHub-side (no repo files)

- Closed **#33** (Q11 — already recorded in ADR-026), **#36** (Q14 → ADR-041), **#32** (Q10 → ADR-042); moved them to `Done` on the board.
- Moved **#37** (SDK core) → Done and **#38** (target adapters) → In Progress on the board; epic #31 checkboxes ticked for shipped slices.

## Notes

- `#34` (Q12, PocketSphinx) intentionally left open — timing decision (ship in Phase 4 vs defer to v1.x) is with the human.
- Local branch commit only; push was authorized by the human.

Closes #199
