### PR TITLE
docs: record ADR-043 — PocketSphinx deferred to v1.x (Q12 #34)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1060,11 +1060,11 @@ Status legend: `Proposed` · `Accepted` · `Superseded` · `Deprecated`
   - Follow-ups: lazy driver chunks + backend manifest (v1.x), optional CI rg
     step once P0 fixes land, wire-web package if a second host appears.
 
-_Open questions still pending human input: Q12 (PocketSphinx timing, #34) is
-open for Phase 4/5. Resolved: Q10 (self-hosted training engine, #32) is ADR-042
-(no wakeforge; module-owned openWakeWord pipeline); Q11 (L3 cadence, #33) is
+_Open questions: all resolved — Q10 (self-hosted training engine, #32) is
+ADR-042 (no wakeforge; module-owned openWakeWord pipeline); Q11 (L3 cadence, #33) is
 ADR-026; Q13 (SDK core CI, #35) is ADR-040; Q14 (vendor ONNX wasm, #36) is
-ADR-041. Q9 (training backends) is ADR-013 (amended: in-browser training
+ADR-041; Q12 (PocketSphinx timing, #34) is ADR-043 (deferred to v1.x).
+Q9 (training backends) is ADR-013 (amended: in-browser training
 removed, Cloud Providers unified, Colab added as ADR-023); targets are ADR-019
 (supersedes ADR-006); pluggable KWS backends are ADR-020; the device-side SDK is
 ADR-021; the data-source layer is ADR-022; the module platform is ADR-025
@@ -1496,3 +1496,28 @@ applied per this log and may be overridden._
   - Training effort stays concentrated on the module-owned adapters
     (openwakeword, kws-streaming) per ADR-039 (formats/quantization,
     module-owned convert).
+
+## ADR-043 — PocketSphinx is deferred to v1.x, not a Phase 4 backend
+
+- **Status:** Accepted (2026-08-20)
+- **Origin:** Q12 (#34) — ship PocketSphinx as a Phase 4 backend or defer?
+  Task #40 (Phase 4: PocketSphinx backend) was the pending implementation.
+- **Decision:** **Defer.** PocketSphinx is not built in Phase 4; the Phase 4
+  task #40 is re-phased to the **v1.x backlog** (roadmap Phase 7). The model
+  selection matrix keeps PocketSphinx as a documented "lightweight Traditional
+  alternative" (ADR-020 adapter list) but no driver module or panel is
+  scheduled for Phase 4.
+- **Rationale:** PocketSphinx's niche (lightweight Traditional KWS, HMM/GMM,
+  pure-C) is already covered by **micro-wake-word** (TFLite-Micro, DNN-based,
+  actively maintained) for the MCU tier and **sherpa-onnx** for app-class.
+  It was the original wake-word engine in Mycroft and Jasper, but those
+  projects moved off it precisely because HMM/GMM has a higher error rate
+  than DNN KWS (Mycroft replaced it with Precise). It remains actively
+  maintained upstream (v5.1.1, 2026-06), so the option stays warm; revisit if
+  micro-wake-word proves insufficient on the MCU tier.
+- **Consequences:**
+  - #34 closed as resolved; #40 stays open but re-phased to v1.x (Phase field
+    updated on the board).
+  - Roadmap Phase 4 step 6 and Phase 5/Phase 7 references updated to "deferred".
+  - MCU golden path ships with micro-wake-word only (single MCU backend for
+    Cortex-M), consistent with ADR-040's mcu profile.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -270,7 +270,8 @@ the gate blocks a non-commercial model from a commercial export.
 ### Phase 7 — v1.x backlog (documented, unprioritized)
 
 WebRTC AEC3 WASM (ADR-016 deferral); Silero VAD gating (ADR-018 deferral);
-ESP32-S3 golden path; PocketSphinx full MCU demo; openWakeWord
+ESP32-S3 golden path; PocketSphinx backend + full MCU demo (ADR-043 deferral,
+#40); openWakeWord
 training-verifier integration; node-per-stage AudioWorklet topology (ADR-016).
 
 ## 7. Live work state (GitHub)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,7 +102,7 @@ The durable architecture lives in `docs/architecture.md`; the ADR log in
 | **sherpa-onnx KWS** (`k2-fsa/sherpa-onnx`) | ASR Decoding | Apache-2.0 | App-class + MCU; real KWS transducer, compiled WASM in-browser | ✅ browser + ✅ device driver (`kws/sherpa/device/`, #193) |
 | **PLiX Few-Shot** (`aaqibsaeed/plixkws`) | Few-Shot | Apache-2.0 | App-class, enrollment-based (prototype-distance, ADR-002); onnx + transformers runtimes | ✅ `packages/modules/kws/plix/` |
 | **micro-wake-word** (`OHF-Voice/micro-wake-word`) | Traditional | Apache-2.0 | MCU (Cortex-M, ESP32) via TFLite-Micro | ⏳ Phase 4/5 |
-| **PocketSphinx** (`cmusphinx/pocketsphinx`) | Traditional (lightweight alt) | BSD-style | MCU-class and above, lightweight alternative | ⏳ Pending (ADR-020) |
+| **PocketSphinx** (`cmusphinx/pocketsphinx`) | Traditional (lightweight alt) | BSD-style | MCU-class and above, lightweight alternative | ⏳ Deferred to v1.x (ADR-043) |
 
 AFE components (ADR-016): AEC = passthrough for v1 (WebRTC/SpeexDSP in
 exports); BSS = passthrough or 2-mic approximation (vendor BSS in exports);
@@ -202,7 +202,7 @@ real on every PR (PRs #82/#84/#85/#86):
 > kws-streaming (#194) and sherpa (#193) (PRs #196/#197/#198); Cortex-M
 > cross-compile CI landed (#186). Remaining: microwakeword driver (#185),
 > Pi Python binding (#187), plix driver (#188), bundle generator (#189),
-> license gate (#42), PocketSphinx (#40).
+> license gate (#42).
 
 1. **SDK core (C/C++, `packages/sdk` + `device/`):** portable core
    (`KWSBackend` interface ADR-020, portable AFE ADR-003/016, audio I/O +
@@ -218,7 +218,9 @@ real on every PR (PRs #82/#84/#85/#86):
 5. **License gate:** block CC BY-NC-SA models from commercial exports; offer
    to train a clean replacement (Phase 5).
 6. **PocketSphinx** backend as the lightweight Traditional alternative
-   (ADR-020): driver module + panel under the ADR-024 decoupling rule.
+   (ADR-020) — **deferred to v1.x** (ADR-043, Q12 #34 resolved): micro-wake-word
+   + sherpa cover its niche; revisit only if micro-wake-word proves
+   insufficient on the MCU tier.
 
 Validation: Cortex-M bundle builds on real hardware and triggers on the wake
 word; Pi bundle runs and triggers; bundle README lists every included license;
@@ -284,15 +286,15 @@ contracts/test-kit), [#28](https://github.com/awareride/wake-studio/issues/28)
 (deploy wasm fetch + Cloudflare rename), [#30](https://github.com/awareride/wake-studio/issues/30)
 (vendor ONNX wasm / offline) — all closed 2026-08-12 (Done on the board).
 
-**Open questions** (close with a decision that lands as an ADR): #34 (Q12:
-PocketSphinx timing). Resolved: Q10 (#32) → ADR-042 (no wakeforge; module-owned
-openWakeWord pipeline), Q11 (#33) → ADR-026 (L3 = merge-gate), Q13 (#35) →
-ADR-040 (native-first SDK CI), Q14 (#36) → ADR-041 (onnxruntime-web wasm
-vendored now via P0-4).
+**Open questions**: all resolved (each lands as an ADR): Q10 (#32) →
+ADR-042 (no wakeforge; module-owned openWakeWord pipeline), Q11 (#33) →
+ADR-026 (L3 = merge-gate), Q13 (#35) → ADR-040 (native-first SDK CI), Q14
+(#36) → ADR-041 (onnxruntime-web wasm vendored now via P0-4), Q12 (#34) →
+ADR-043 (PocketSphinx deferred to v1.x).
 
 **Next actions** (from the board): finish Phase 4 SDK — microwakeword driver
 (#185), Raspberry Pi Python binding (#187), plix driver (#188), bundle
-generator (#189); then license gate (#42), PocketSphinx (#40).
+generator (#189); then license gate (#42).
 
 ## 8. Risks & mitigations
 


### PR DESCRIPTION
## What

Resolve Q12 (#34) — PocketSphinx is **deferred to v1.x**, not a Phase 4 backend. Recorded as **ADR-043**.

## Changes

- **`DECISIONS.md`** — new **ADR-043** (PocketSphinx deferred to v1.x; micro-wake-word + sherpa cover its niche; upstream stays active so the option is warm); ADR-034 open-questions note updated (all questions now resolved).
- **`docs/roadmap.md`** — Phase 4 step 6 marked deferred, model table row updated, §7 open-questions list now shows Q12 → ADR-043.

## GitHub-side (no repo files)

- Closed **#34** (Q12) with the decision; moved to Done on the board.
- Re-phased **#40** (PocketSphinx backend task) to the **v1.x** phase on the board, kept open as backlog; issue body + labels updated to note the deferral.

Closes #34
