### PR TITLE
docs: datasets as first-class artifacts — spec, generation jobs, storage, console (#202)

### DIFF
--- a/docs/modules/data-sources.md
+++ b/docs/modules/data-sources.md
@@ -1,153 +1,351 @@
-# Data Sources (Audio Generation & Datasets) - Module Specification
+# Data Sources & Datasets (Audio Generation & Dataset Management) - Module Specification
 
-- **Status:** Draft (stub - to be filled at Phase 5 start, per the docs-first rule)
+- **Status:** Draft - design locked from human discussion (2026-08-20); implementation at Phase 5 start
 - **Owner:** WakeStudio team
 - **Plan phase:** Phase 5
-- **Related ADRs:** ADR-022 (data-source layer), ADR-013 (training backends),
-  ADR-023 (Colab backend)
-- **Depends on (modules):** Training (consumes data), Export (license provenance)
-- **Last updated:** 2026-07-27
+- **Related ADRs:** ADR-022 (data-source layer), ADR-013 (training backends), ADR-023 (Colab
+  backend), ADR-025 (spec-driven modules), ADR-028 (uv train scripts), ADR-031 (upstream-script
+  adapters), ADR-033 (self-registering drivers), ADR-036 (job-manager API), ADR-039
+  (labels/formats/convert)
+- **Depends on (modules):** Training (consumes datasets), Export (license provenance)
+- **Last updated:** 2026-08-20
 
 ## 1. Purpose
 
-Training-data sourcing is a **pluggable data-source layer** with in-app endpoint
-configuration (ADR-022). It provides the audio a wake-word model is trained on:
-**platform pre-built resources** (public datasets, project-organized datasets)
-and **auto-generated spoken audio samples**. Audio generation **does not run
-inside WASM**; it runs in the selected training backend (Self-hosted Service,
-Cloud Provider, or Colab - ADR-013 amendment) or is fetched from configured
-endpoints. This module is what makes "train a custom wake word from a phrase"
-possible without the user hand-collecting audio.
+Training-data sourcing is a **pluggable data-source layer** with in-app endpoint configuration
+(ADR-022). It provides the audio a wake-word model is trained on: **platform pre-built resources**
+(public datasets, project-organized datasets) and **auto-generated spoken audio samples**. Audio
+generation **does not run inside WASM**; it runs in the selected training backend (Self-hosted
+Service, Cloud Provider, or Colab - ADR-013 amendment) or, for online HTTP TTS, directly in the
+browser. This module is what makes "train a custom wake word from a phrase" possible without the
+user hand-collecting audio.
 
-> This is a **stub**. The full contract is written just-in-time at Phase 5 start
-> (plan §11). Recorded now so ADR-022 has a concrete document home.
+**Phase 5 addition (this revision):** datasets are **first-class artifacts with a lifecycle of
+their own** - create, persist, reuse, share - not a byproduct of a train job. The same dataset is
+usable across **different training pipelines** via a portable spec + per-trainer materializers.
 
-## 2. Scope & boundaries
+> This document was a stub until 2026-08-20. The dataset-as-artifact design below was locked in a
+> human design discussion (2026-08-20) and is the spec home for the Phase 5 dataset work. It will
+> also be recorded as a new ADR alongside the train integration contract (ADR-013/022/039).
+
+## 2. The problem this solves
+
+Today datasets are a byproduct of a train job: `prepare_data` synthesizes/downloads a
+`label/*.wav` tree into the job's ephemeral workdir. Consequences:
+
+- The generated data is **lost** when the job ends (and instantly on a Colab runtime drop).
+- Every train **re-generates / re-downloads** the same data from scratch.
+- Datasets cannot be **reused, versioned, or shared**.
+
+Goal (2026-08-20 discussion): datasets are **first-class artifacts** - users pick one or more
+existing datasets before starting a train, common datasets ship as built-ins, generated datasets
+persist to the backend store and/or the user's cloud (Hugging Face / Cloudflare R2 / Google Drive),
+and a portable **dataset spec** lets the same dataset feed different trainers.
+
+## 3. Scope & boundaries
 
 - **In scope:**
-  - A common **data-source interface** (list/fetch/generate) consumed by the
-    Training module.
-  - Three pluggable source kinds, configurable in-app:
-    1. **Local services** (e.g. a local TTS / generation service the user runs).
-    2. **Project server APIs** (WakeStudio-provided dataset/generation endpoints).
-    3. **General public TTS online endpoints** (user-configurable URLs).
-  - Platform pre-built resources: public datasets and project-organized datasets
-    (with license provenance tracked per source).
-  - Mixing generated audio with dataset negatives/augmentation for training.
+  - The **dataset spec**: `dataset.json` manifest + canonical `label/*.wav` tree + one importer.
+  - **Dataset lifecycle**: generation jobs, persistence, cloud push/pull, built-in catalog,
+    Datasets console.
+  - The **generation pipeline** with pluggable TTS engines + postprocess transforms.
+  - **Materializers**: canonical dataset -> per-trainer input shape (portability).
+  - **Mixing datasets** (positives / unknowns / noise) with collision safety (existing
+    `merge_label_trees`, #158).
+  - Quality gate, dedup/split, reproducibility, provenance chain.
 - **Out of scope:**
   - Model training itself (Training module / Phase 5 backends).
   - In-browser WASM generation (explicitly excluded by ADR-022).
   - The live AFE/KWS pipeline (AFE/KWS modules).
-- **Public surface:** the data-source descriptor + interface, the in-app endpoint
-  configuration UI contract, and the per-source license/provenance record.
+- **Public surface:** the dataset spec + importer, the generation-job contract, the
+  engine/storage plugin descriptors, the Datasets console contract, and per-source
+  license/provenance records.
 
-## 3. Dependencies
+## 4. Dataset as a first-class artifact - the spec
 
-- **Upstream (consumes from):** configured endpoints (studio-backend / project API
-  / public TTS); platform dataset catalog.
-- **Downstream (provides to):** Training module (Phase 5) feeds generated/fetched
-  audio into the selected backend's training pipeline.
-- **External libraries / models:** Piper TTS (GPL-3.0 active / MIT archived - see
-  `LICENSES.md`), `piper-sample-generator` (MIT, training-time only), and
-  **edge-tts** (MIT, Microsoft Edge TTS client; used for multi-language synthesis
-  via the kws-streaming module train `tts` extra - the module owns its training
-  env per ADR-028; the backend stays generic). Generation runs in the backend
-  runtime (module env), not in the browser:
-  browser, so copyleft does not infect exported device bundles. Generated audio
-  owned by the user feeds commercially-ownable models.
+### 4.1 Canonical form
 
-## 4. Public API & types
+Every dataset, regardless of origin (builtin / generated / uploaded / public), is one
+`wake-studio-dataset.zip`:
+
+```
+wake-studio-dataset.zip
+├── dataset.json          <-- the portability contract
+└── audio/
+    ├── hey-studio/<clips>.wav     (16 kHz mono PCM WAV, canonical)
+    ├── good-morning/<clips>.wav
+    └── ...label folders...
+```
+
+Canonical audio is **16 kHz mono PCM WAV**. Other rates / encodings / precomputed features are
+**derived** at materialize or push time - the same "canonical artifact + derived formats" rule as
+ADR-039 for models.
+
+### 4.2 dataset.json manifest
+
+```jsonc
+{
+  "id": "uuid",
+  "name": "wake-words-zh-en",
+  "version": 1,
+  "kind": "builtin" | "generated" | "uploaded" | "public",
+  "role": "positive" | "unknowns" | "noise" | "mixed",     // what the dataset is for
+  "audio": { "sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le",
+             "clips": 210, "durationSec": 940 },
+  "labels": [
+    { "name": "hey studio",   "role": "positive" },        // -> wanted word
+    { "name": "good morning", "role": "positive" },        // -> wanted word (multi-word)
+    { "name": "_unknown",     "role": "unknown"  },        // -> folds into _unknown_
+    { "name": "noise",        "role": "noise"    }         // -> _background_noise_ / augmentation
+  ],
+  "provenance": [ { "name": "...", "license": "...", "commercialUse": true, "source": "..." } ],
+  "recipe": { "engine": "edge-tts", "phrases": [...], "languages": ["zh-CN", "en-US"],
+              "seed": 0, "toolVersions": { "edge-tts": "..." } },
+  "contentHash": "sha256:...",                              // change detection; any change bumps version
+  "storage": { "backend": "datasets/<id>/",
+               "cloud": "hf://user/ds | r2://bucket | gdrive://" }
+}
+```
+
+**The portability rule:** the manifest declares each label's **semantic role**
+(`positive` / `unknown` / `noise`); it never bakes trainer-specific folder magic
+(`_background_noise_`, `_unknown_`) into the contract. Per-trainer materializers create the
+folders the upstream trainer expects. **Roles are the portable vocabulary; folders are
+per-trainer.**
+
+### 4.3 Lifecycle
+
+```
+create (generate/import) -> validate -> persist (backend [+ optional cloud]) -> reuse in N trains -> share/upload -> (eventually) delete/GC
+```
+
+- Datasets live in the backend `datasets/` store (survives restarts), optionally also in the
+  user's cloud (HF / R2 / GDrive) for durability and sharing.
+- A trained model records the exact dataset refs + versions it consumed (provenance chain, SS10).
+
+## 5. Generation as a first-class job
+
+`prepare_data` is split out of the train adapter into a **`dataset-generate` job** - a new
+registry entry on the existing job manager (ADR-036: subprocess-per-job, NDJSON reporting,
+pause/resume/cancel, SSE, SQLite persistence). Generation is a short job on the same machinery.
+One pipeline runs everywhere:
+
+```
+collect -> synthesize -> postprocess -> assemble -> persist
+```
+
+### 5.1 TTS engine plugins
+
+The **TTS engine** is a pluggable capability (ADR-033 self-registration style), not a hard-coded
+list. Three kinds:
+
+| Kind | Examples | Runtime |
+|---|---|---|
+| `classic-tts` | edge-tts, piper | backend |
+| `online-http-tts` | any user-configured online TTS API (e.g. mimo.mi.com speech synthesis v2.5) - user enters endpoint + API key | browser + backend |
+| `llm-tts` | qwen (e.g. Qwen2.5-Omni), vibe-voice, F5-TTS | backend (GPU) |
+
+Engine descriptor (drives a generated panel, ADR-025):
+
+```jsonc
+{ "id": "mimo-http", "kind": "online-http-tts", "runtime": ["browser", "backend"],
+  "params": { "endpoint": { "type": "string" }, "apiKey": { "type": "secret" },
+              "voice": {}, "rate": {} },
+  "provenanceTemplate": { "name": "mimo TTS", "commercialUse": true } }
+```
+
+An `online-http-tts` engine (mimo-style) can run **in the browser** (pure fetch + fflate zip, no
+backend) or in the backend; the pipeline is one code path, only the executor differs.
+
+### 5.2 Postprocess transforms
+
+Postprocessing (e.g. openwakeword-style augmentation/perturbation) is a **third pluggable type**,
+composable after any engine - not a vendor. Transforms: augment/perturb, normalize loudness,
+resample, trim / silence handling.
+
+### 5.3 Storage plugins
+
+Persistence is a **StorageBackend plugin** behind one interface (`push` / `pull` / `list` /
+`delete`): `backend-disk` (default), `huggingface` (dataset repo), `cloudflare-r2`
+(S3-compatible), `google-drive`, `url` (built-in / public, read-only). Descriptor declares its
+auth key:
+
+```jsonc
+{ "id": "r2", "kind": "s3-compatible", "authKey": "cloud.r2",
+  "capabilities": ["push", "pull", "list", "delete"], "format": "zip" }
+```
+
+**Credentials** live in Settings (new "Cloud storage" group), client-side, masked, never logged
+or exported - the same guarantees as the existing `backend.apiKey` / `backend.secret`.
+**ADR-013 tension (open, Q-DS-3):** a *backend* job pushing to cloud needs the key server-side.
+Precedent exists (Colab notebook keys already flow as job params/env, ADR-013/023); recommended
+default: key passed as a **job-scoped env var only**, never persisted.
+
+### 5.4 Extensibility model - split by concern, not by vendor
+
+One host `dataset` module + engine / storage / postprocess plugin axes. A full module owns
+core + spec + generated panel + tests + playground + multi-target deliverables (ADR-025); TTS /
+storage vendors do not need a playground each, and their panels are the same
+"endpoint + key + voice" form. Plugins **self-register** via descriptors; a build script
+generates the catalog (like `train-modules.json` from `scripts/build-model-registry.mjs`).
+**Adding a vendor = drop in a package + descriptor, no host-module edits.**
+
+```
+packages/modules/dataset/            <- ONE host module (new `dataset` category)
+  core/
+    spec.ts            dataset.json manifest schema + validation
+    generation.ts      pipeline: collect -> synthesize -> postprocess -> assemble -> persist
+    materialize.ts     canonical -> per-trainer shape (SS6)
+  engines/             <- plugin type #1 (TTS / synthesis)
+    edge-tts/  piper/  mimo/  qwen/  vibe-voice/  f5-tts/
+  storage/             <- plugin type #2 (cloud / local persistence)
+    backend-disk/  huggingface/  cloudflare-r2/  google-drive/  url/
+  postprocess/         <- plugin type #3 (transforms, e.g. openwakeword-style augment)
+```
+
+Backend-runnable engines/storages become entries in the existing studio-backend `registry.json`
+(subprocess per generation job, ADR-036); browser-capable ones (online HTTP) run client-side with
+the same pipeline code.
+
+## 6. Materializers - making the spec usable by different trainings
+
+Different trainers consume data differently (kws-streaming: raw `label/*.wav` tree;
+openwakeword: precomputed mel features + a positives wav dir + background dirs). One canonical
+spec + **per-trainer materializer** (the data-side twin of `standardize-results`, ADR-031):
+
+| Trainer | Requires (`spec.train.dataset`) | Materializer does |
+|---|---|---|
+| kws-streaming | label tree, 16k, multi-label, needs noise | near-identity: role -> folder map, write `_background_noise_` from `role: noise` |
+| openwakeword | positives wav dir + features + background | run its feature extractor on positive clips -> `.npy`; negatives -> precomputed features; noise -> `background_paths` |
+| future trainers | whatever | its own materializer |
+
+- `spec.train.dataset` declares requirements: `sampleRate`, `minClipsPerLabel`, `needsNoise`,
+  `needsUnknowns`, `labelMode` (`single` / `multi` / `class`).
+- The wizard **validates** picked datasets against these requirements before training (clear
+  warnings, no cryptic trainer crash).
+- Training params evolve from `dataSource` (a source selector) to **`datasets[]`** (refs to
+  existing datasets). The adapter's `prepare_data` becomes "load refs from store -> materialize ->
+  merge roles" (reusing `merge_label_trees` collision rules, #158).
+
+## 7. Built-in dataset catalog
+
+Spec-driven `datasets.json` (like `train-modules.json`), focused on multi-language + noise
+coverage. v1 candidates (license + `commercialUse` flagged; Q-DS-4 to confirm the exact list):
+
+- **Speech Commands V2** (CC BY 4.0) - already integrated.
+- **Common Voice** (multi-language, CC0).
+- **Google Speech Commands** (CC BY 4.0).
+- **AudioSet / FMA** noise clips + openwakeword features (research-use - flagged so the export
+  gate stays honest).
+
+Built-ins are immutable references (`kind: builtin`), materialized on first use.
+
+## 8. Datasets console (web)
+
+A top-level **`Datasets`** menu item (between Training and Backends) mirroring the Training
+console layout:
+
+- **Left rail:** dataset list (name, kind badge `builtin` / `generated` / `uploaded` / `cloud`,
+  clip count, license).
+- **Details pane:** manifest (labels, counts, provenance, storage), quality report, actions:
+  **New generation task**, **Train with this**, **Upload to cloud**, **Download**, **Delete**.
+- **New** = generation wizard (engine -> phrases/languages/voices -> postprocess -> save
+  destination); generation jobs are tracked in the rail (same job UI as Training).
+
+The Training wizard's dataset-picker step is fed by this same Datasets store (SS6).
+
+## 9. Quality & reproducibility (v1 priorities)
+
+1. **Quality gate** - a `check-dataset` job produces a health report: clip counts per label,
+   duration distribution, silence/empty clips, exact duplicates, clipping/distortion, sample-rate
+   drift, label imbalance. Trainers refuse (or warn loudly) when a required label is empty.
+2. **Synthetic-to-real gap** - record distinct voice count per label and `source:
+   real | synthetic` per clip; warn on too-few voices or a 100% synthetic wake-word dataset (TTS
+   overfit risk at inference).
+3. **Dedup + reproducible splits** - exact/near-duplicate detection (perceptual hash) when mixing
+   datasets (no train/eval leakage); a "split dataset" op records a fixed train/val/test
+   partition in the manifest so every backend trains on the same split.
+4. **Reproducibility** - `recipe.seed`, tool versions, and `contentHash`; "regenerate" is
+   byte-reproducible; any silent change bumps `version`.
+
+## 10. Provenance chain to the export gate
+
+Dataset `commercialUse` flags **inherit** into any model trained on the dataset: training
+metadata records the dataset refs + license flags, and `provenance.json` in the trained bundle
+carries the inherited restriction so the Phase 4 export gate is honest without manual review.
+
+## 11. Public API & types (existing training-time layer)
 
 The layer is implemented in `apps/studio-backend/src/wake_train_kit/data_sources.py`
-(training-time only; never imported by the browser). It exposes:
+(training-time only; never imported by the browser). It exposes the **generation / mixing
+primitives** used by dataset-generation jobs and materializers:
 
-- `prepare_speech_commands_v2(data_dir, reporter) -> (root, provenance)` —
+- `prepare_speech_commands_v2(data_dir, reporter) -> (root, provenance)` -
   download + extract Speech Commands V2 (CC BY 4.0).
-- `prepare_user_archive(url, data_dir, reporter) -> (root, provenance)` —
+- `prepare_user_archive(url, data_dir, reporter) -> (root, provenance)` -
   download + extract a user-provided `.tar.gz`/`.tgz`/`.tar`/`.zip` archive.
-- `build_edge_tts_kws_dataset(phrases, languages, out_dir, ...) -> provenance` —
-  multi-language wake-word positives + "unknown" negatives + `_background_noise_`
-  silence clips, arranged as a `label/*.wav` tree.
-- `merge_label_trees(positive_root, negative_root, out_dir) -> Path` — merge a
-  positive tree (wake-word positives) with a negative tree (real-speech
-  unknowns + real `_background_noise_`) into one data root. Positive labels
-  are authoritative: a folder present in both trees is a **collision** and
-  raises `DataSourceError` (never silently mixed). Real noise wins over
-  synthesized silence; with `negative_root=None` the positive tree's silence
-  is kept.
-- Lower-level helpers: `download_file`, `extract_archive`, `find_data_root`,
-  `synthesize`, `mp3_to_wav`, `write_silence_wav`.
+- `build_edge_tts_kws_dataset(phrases, languages, out_dir, ...) -> provenance` -
+  multi-language wake-word positives + "unknown" negatives + `_background_noise_` silence clips,
+  arranged as a `label/*.wav` tree.
+- `merge_label_trees(positive_root, negative_root, out_dir) -> Path` -
+  merge a positive tree with a negative tree into one data root. Positive labels are
+  authoritative: a folder present in both trees is a **collision** and raises `DataSourceError`
+  (never silently mixed). Real noise wins over synthesized silence; with `negative_root=None` the
+  positive tree's silence is kept.
+- Lower-level helpers: `download_file`, `extract_archive`, `find_data_root`, `synthesize`,
+  `mp3_to_wav`, `write_silence_wav`.
 
-Each source returns a **provenance** dict (name/license/source/commercialUse)
-recorded into the bundle's `provenance.json` — the Phase 4 license-gate input.
+Each source returns a **provenance** dict (name/license/source/commercialUse) recorded into the
+bundle's `provenance.json` - the Phase 4 license-gate input.
 
-## 5. Data flow / sequence
+## 12. Error model & failure modes
 
-1. The user picks a data source in the module's train params
-   (`spec.train.params.dataSource`: `speech-commands-v2` | `user-url` |
-   `edge-tts` | `local-dir` | `mixed`). For `mixed`, `positiveSource`
-   (`edge-tts` | `user-url`) supplies the wake-word positives and
-   `negativeSource` (`speech-commands-v2` | `user-url` | `none`) supplies
-   real-speech unknowns + real noise.
-2. The module's train adapter calls the matching helper, which downloads /
-   synthesizes a `label/*.wav` tree (plus `_background_noise_`).
-3. The adapter runs the upstream trainer on that tree (`--wanted_words` = the
-   wake-word folder(s); everything else folds into `_unknown_`).
-4. The adapter writes the returned provenance into `provenance.json` and the
-   model/metrics into the standard artifact bundle.
-
-## 6. Configuration & constants
-
-_To be specified._ Surfaced via `describeParameters()` (ADR-017): endpoint URLs,
-TTS voice selection, sample counts, augmentation flags, per-source license tags.
-
-## 7. Error model & failure modes
-
-- `DataSourceError` on an unsupported archive type, a missing `dataUrl`, a
-  missing `edge-tts` install, or a missing `ffmpeg` (edge-tts emits mp3; ffmpeg
-  converts to 16 kHz WAV).
+- `DataSourceError` on an unsupported archive type, a missing `dataUrl`, a missing `edge-tts`
+  install, or a missing `ffmpeg` (edge-tts emits mp3; ffmpeg converts to 16 kHz WAV).
 - `find_data_root` raises when no `label/*.wav` tree is found after extraction.
-- Network downloads stream with heartbeats; a failure surfaces as an
-  `error` NDJSON event from the adapter (the job is marked `failed`).
+- Network downloads stream with heartbeats; a failure surfaces as an `error` NDJSON event from
+  the adapter (the job is marked `failed`).
+- New: materializer validation errors (dataset does not satisfy `spec.train.dataset`) surface as
+  clear pre-train warnings, not trainer crashes; cloud push failures are surfaced per-storage
+  plugin without corrupting the local dataset.
 
-## 8. Observability
+## 13. Observability
 
-_To be specified._ Generation progress, per-source counts, and license/provenance
-log shown in-app before export.
+_To be specified._ Generation progress, per-source counts, per-label clip counts, and
+license/provenance log shown in-app before export. The Datasets console shows the quality report
+(SS9) and per-job NDJSON progress for generation jobs.
 
-## 9. Testing strategy
+## 14. Security & privacy
 
-`apps/studio-backend/tests/test_data_sources.py`: archive extraction + root
-finding, `file://` downloads (no network), and a monkeypatched edge-tts run that
-asserts the label-tree layout + provenance. Adapter-level coverage lives in
-`packages/modules/kws/streaming/train/tests/` (fake upstream, no GPU/network).
+- Endpoint/cloud credentials (if any) are held client-side only, never logged or exported
+  (ADR-013 security note); cloud keys live in Settings, masked.
+- Generated audio provenance is recorded so the export license gate (Phase 4) can verify
+  commercial usability (SS10).
 
-## 10. Security & privacy
+## 15. Open questions [Q]
 
-- Endpoint credentials (if any) are held client-side only, never logged or
-  exported (ADR-013 security note).
-- Generated audio provenance is recorded so the export license gate (Phase 4) can
-  verify commercial usability.
+| ID | Question | Recommended default |
+|---|---|---|
+| Q-DS-1 | Canonical default public-TTS endpoint(s) to ship pre-configured | **Answered (2026-08-14):** edge-tts is the default multi-language TTS path (studio-backend `tts` extra); Speech Commands V2 (CC BY 4.0) is the default corpus. Piper remains an option for the openwakeword path. |
+| Q-DS-2 | Whether project server APIs are WakeStudio-hosted or community/self-hosted | Resolved at Phase 5 start. |
+| Q-DS-3 | Cloud keys for backend-originated push jobs (ADR-013 tension) | Job-scoped env var only, never persisted (precedent: Colab notebook keys). |
+| Q-DS-4 | Exact v1 built-in dataset catalog list | SC2 + Common Voice + Google Speech Commands + AudioSet/FMA noise (SS7). |
+| Q-DS-5 | Near-duplicate detection threshold for the leakage guard | Tune at implementation; start with exact-hash + conservative perceptual hash. |
 
-## 11. Open questions
+## 16. References
 
-- `[Q-DS-1]` Canonical default public-TTS endpoint(s) to ship pre-configured
-  — *answered (2026-08-14):* **edge-tts** is the default multi-language TTS
-  path (studio-backend `tts` extra); Speech Commands V2 (CC BY 4.0) is the
-  default corpus. Piper remains an option for the openwakeword path.
-- `[Q-DS-2]` Whether project server APIs are WakeStudio-hosted or
-  community/self-hosted (resolved at Phase 5 start).
+- ADR-022 (this layer), ADR-013 (training backends), ADR-023 (Colab), ADR-025 (spec-driven
+  modules), ADR-028 (uv train scripts), ADR-031 (upstream-script adapters), ADR-033
+  (self-registering drivers), ADR-036 (job-manager API), ADR-039 (labels/formats/convert).
+- `docs/modules/training.md` (Phase 5 - datasets[] consumption), `LICENSES.md`
+  (Piper/data licenses).
+- Plan Phase 5, SS5.1.
 
-## 12. References
-
-- ADR-022 (this layer), ADR-013 (training backends), ADR-023 (Colab).
-- Plan Phase 5, §5.1.
-- `docs/modules/training.md` (Phase 5), `LICENSES.md` (Piper/data licenses).
-
-## 13. Change log
+## 17. Change log
 
 | Date | Change | Author |
 |---|---|---|
 | 2026-07-27 | Initial stub (ADR-022 recorded; full contract deferred to Phase 5 start). | WakeStudio team |
 | 2026-08-14 | **Data-source layer shipped (#152):** `wake_train_kit/data_sources.py` with Speech Commands V2 download (CC BY 4.0), user-URL archives, and multi-language edge-tts synthesis; provenance records per source; deterministic backend tests. Q-DS-1 answered. | agent |
 | 2026-08-17 | **Mixed mode (#158):** `merge_label_trees` merges a positive tree (wake word) with a negative tree (real unknowns + real noise); collisions raise; real noise wins over synthesized silence. `dataSource=mixed` in the kws-streaming adapter + spec params + registry wiring; 4 new backend tests. | agent |
+| 2026-08-20 | **Datasets as first-class artifacts (design locked, human discussion):** full spec written - `dataset.json` manifest + canonical `label/*.wav` tree + one importer (SS4); `dataset-generate` jobs with pluggable TTS engine / storage / postprocess plugins, split by concern not vendor (SS5); per-trainer materializers + `spec.train.dataset` compatibility (SS6); built-in catalog (SS7); Datasets console (SS8); quality gate / dedup+split / reproducibility (SS9); provenance chain to the export gate (SS10). Decision points resolved: composable granularity, cloud storage optional (HF / R2 / GDrive with user keys), user-configurable online TTS API+key, new-dataset-equals-new-version, multi-language+noise built-ins. Open: Q-DS-3/4/5. | agent |

--- a/docs/modules/training.md
+++ b/docs/modules/training.md
@@ -262,6 +262,25 @@ acts as a detector for every label in the list; a single-phrase model
   manage). A bundle-level `models[]` array is a future escape hatch only if a
   backend genuinely cannot merge.
 
+### 4.7 Dataset consumption - `datasets[]` refs + materializers (design 2026-08-20)
+
+Training consumes **existing datasets** (one or more refs), not raw sources. Design locked in
+`docs/modules/data-sources.md` SS6:
+
+- Train params evolve from `dataSource` (a source selector) to **`datasets[]`** (refs to
+datasets in the Datasets store - built-in, generated, or uploaded).
+- Each dataset is a `wake-studio-dataset.zip` (`dataset.json` manifest + canonical
+`label/*.wav` tree); its manifest declares each label's **semantic role**
+(`positive`/`unknown`/`noise`), which the trainer maps: positives -> wanted words, unknowns ->
+`_unknown_`, noise -> `_background_noise_` / augmentation.
+- A **per-trainer materializer** converts the canonical form into the shape each upstream
+trainer expects (kws-streaming: label tree; openwakeword: features + positives dir + background)
+- the data-side twin of `standardize-results` (ADR-031). The upstream script stays byte-identical.
+- `spec.train.dataset` declares requirements (`sampleRate`, `minClipsPerLabel`, `needsNoise`,
+`needsUnknowns`, `labelMode`); the wizard validates picked datasets against them before training.
+- Dataset `commercialUse` flags inherit into the trained bundle's `provenance.json` (SS10 of
+`data-sources.md`) - the Phase 4 export-gate input.
+
 ### 4.6 Formats, quantization & conversion (ADR-039)
 
 **Decision: formats and quantization are spec-driven train params; conversion
@@ -541,4 +560,5 @@ for every provider. Capability labels: train-capable vs inference-only.
 | 2026-08-14 | **Backends panel v2 (Trains-style) + kind auto-detection:** the Backends view mirrors the Training console layout (toolbar `New` + `Free On Google Colab`, left rail + details pane). **Kind is detected from the API** — the service reports `instance` in `/health` (`wake-service --instance short-term`; the Colab launcher always starts `short-term`), and the health check updates the badge; the manual kind field is gone. `New` takes endpoint URL + access token only. `Free On Google Colab` generates a standalone studio-backend notebook client-side (review + download; run in Colab, paste URL + token). | agent |
 | 2026-08-14 | **kws-streaming train adapter + data-source layer (#152):** `packages/modules/kws/streaming/train/train_adapter.py` runs the unpatched upstream `kws_streaming` trainer and normalizes into the standard bundle; `wake_train_kit/data_sources.py` adds Speech Commands V2 (CC BY 4.0), user-URL archives, and multi-language edge-tts synthesis; registry entry + fake-upstream tests. | agent |
 | 2026-08-17 | **Mixed data sources (#158):** kws-streaming `dataSource=mixed` merges TTS positives (wake word) with real-speech unknowns + real noise (SC2 / user-url / none) via `merge_label_trees` — collision-safe, per-source provenance into `provenance.json`. | agent |
+| 2026-08-20 | **§4.7 dataset consumption design (2026-08-20 discussion):** training params evolve from `dataSource` to `datasets[]` refs; per-trainer materializers convert the canonical dataset (`docs/modules/data-sources.md` SS4/SS6) into each upstream trainer's shape; `spec.train.dataset` requirements gate the picker; dataset license flags inherit into `provenance.json`. | agent |
 | 2026-08-18 | **§7.1 importer accepts all backends + auto pull & import (#159):** `importColabBundle` (aliased `importResultBundle`) now accepts `colab` | `self-hosted` | `cloud` bundles — the real studio-backend run's zip imports cleanly (was colab-only). Tracked jobs auto-pull their results when they succeed (`GET /artifacts/{job}/{name}`, one importer + registration path), persist `resultArtifact` on the job for post-refresh fallback, gain a manual **Pull results & import** button, and `HistoryJob`/registration read the kws-streaming `wakePhrases` key so the phrase shows for studio-backend trains. | agent |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -245,8 +245,13 @@ the gate blocks a non-commercial model from a commercial export.
    credentials client-side only.
 4. **Google Colab** (ADR-023): version-controlled notebooks (`colab/`);
    standard result bundle convention (shared artifact-bundle manifest).
-5. **Data-source layer** (ADR-022): in-app endpoint config for local
-   services / project APIs / public TTS endpoints.
+5. **Data-source layer + Datasets** (ADR-022; design locked 2026-08-20): in-app endpoint
+   config for local services / project APIs / public TTS endpoints. Datasets become
+   **first-class artifacts** (`dataset.json` manifest + canonical `label/*.wav` tree, spec in
+   `docs/modules/data-sources.md` SS4): `dataset-generate` jobs with pluggable TTS engine / storage
+   / postprocess plugins (SS5), per-trainer materializers + `datasets[]` train consumption (SS6,
+   `docs/modules/training.md` SS4.7), built-in catalog (SS7), and a top-level Datasets console
+   (SS8).
 6. **Traditional training panels** (ADR-024 §4.2): a trained model is
    commercially ownable (FAR/FRR report before export).
 


### PR DESCRIPTION
## Summary

Capture the 2026-08-20 dataset design discussion into durable docs. Datasets become **first-class artifacts** — create → persist → reuse → share — instead of a byproduct of a train job. Ref https://github.com/awareride/wake-studio/issues/202 (epic; docs-only PR, does not close it).

## Changes

- **`docs/modules/data-sources.md`** — full dataset spec (was a stub):
  - §4 dataset as a first-class artifact — `dataset.json` manifest + canonical `label/*.wav` tree + one importer
  - §5 `dataset-generate` jobs + pluggable TTS engine / storage / postprocess plugins (split by concern, not vendor)
  - §6 per-trainer materializers + `spec.train.dataset` compatibility (portability across trainers)
  - §7 built-in dataset catalog
  - §8 Datasets console (web)
  - §9 quality gate, dedup/split, reproducibility
  - §10 provenance chain to the export gate
  - Open questions Q-DS-3/4/5
- **`docs/modules/training.md`** — §4.7 dataset consumption: `datasets[]` refs + materializers
- **`docs/roadmap.md`** — Phase 5 §5 data-source layer expanded with the datasets plan

## Issue plan

Epic #202 with tasks #203–#210 (spec, storage, generation jobs, materializers, built-in catalog, console, quality gate, provenance chain) — all added to the `WakeStudio Delivery` project #2 as P5 Todo.

## Related ADRs

ADR-022 (data-source layer), ADR-013, ADR-023, ADR-025, ADR-028, ADR-031, ADR-033, ADR-036, ADR-039. The dataset spec will land as a new ADR (task #203).
