### PR TITLE
feat(dataset): dataset spec — dataset.json manifest, canonical form, one importer per world (#203)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,7 @@ apps/studio-backend/.pytest_cache/
 apps/studio-backend/*.egg-info/
 
 # repo-root studio-backend runtime state (default --db/--artifacts-dir paths)
-data/
+/data/
 
 # standard artifact bundle output (docs/modules/training.md §6)
 **/wake-studio-results/

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1521,3 +1521,55 @@ applied per this log and may be overridden._
   - Roadmap Phase 4 step 6 and Phase 5/Phase 7 references updated to "deferred".
   - MCU golden path ships with micro-wake-word only (single MCU backend for
     Cortex-M), consistent with ADR-040's mcu profile.
+
+## ADR-044 — Datasets are first-class artifacts: `dataset.json` manifest + canonical `label/*.wav` tree, portable across trainers via materializers
+
+- **Status:** Accepted (2026-08-20)
+- **Origin:** Human design discussion (2026-08-20) + epic #202 (tasks #203–#210).
+  Today datasets are a byproduct of a train job: `prepare_data` synthesizes/downloads a
+  `label/*.wav` tree into the job's ephemeral workdir, so generated data dies with the job
+  (instantly on a Colab runtime drop), is re-generated on every train, and is never reusable or
+  shareable.
+- **Decision:** Datasets become **first-class artifacts** with a lifecycle of their own
+  (create → persist → reuse → share):
+  1. **Spec:** every dataset is one `wake-studio-dataset.zip` — a `dataset.json` manifest (the
+     portability contract) + a canonical `label/*.wav` tree (16 kHz mono PCM WAV). The manifest
+     declares each label's **semantic role** (`positive` / `unknown` / `noise`); it never bakes
+     trainer-specific folder magic (`_background_noise_`, `_unknown_`) into the contract.
+  2. **Portability:** one canonical form + **per-trainer materializers** (the data-side twin of
+     `standardize-results`, ADR-031) convert the canonical form into each upstream trainer's
+     expected shape (kws-streaming: label tree; openwakeword: features + positives dir +
+     background). `spec.train.dataset` declares requirements; the wizard validates picked
+     datasets before training.
+  3. **Consumption:** training params evolve from `dataSource` to **`datasets[]`** refs (one or
+     more existing datasets), loaded from the Datasets store and merged by role.
+  4. **Granularity:** one dataset = a self-contained `label/*.wav` tree (composable roles), not
+     a full train-ready mix.
+  5. **Cloud storage optional:** persist to the backend `datasets/` store and/or user cloud
+     (Hugging Face / Cloudflare R2 / Google Drive) using API keys from user Settings
+     (client-side, masked; backend-originated jobs get keys as job-scoped env only — Q-DS-3).
+  6. **Generation:** `dataset-generate` jobs on the ADR-036 job manager with pluggable TTS
+     engine / storage / postprocess plugins — **split by concern, not vendor** (ADR-033
+     self-registration; a vendor = a descriptor + package, no host-module edits). Engines:
+     `classic-tts` (edge-tts, piper), `online-http-tts` (any user-configured TTS API + key, e.g.
+     mimo.mi.com; browser + backend), `llm-tts` (qwen, vibe-voice, F5-TTS; backend GPU).
+  7. **Versioning:** a new dataset = a new version for now (any content change bumps `version`;
+     `contentHash` detects changes).
+  8. **Built-ins:** spec-driven `datasets.json` catalog (Speech Commands V2, Common Voice,
+     Google Speech Commands, AudioSet/FMA noise) with license + `commercialUse` flags.
+  9. **Provenance chain:** dataset `commercialUse` flags inherit into any trained model's
+     `provenance.json` (Phase 4 export gate).
+- **Rationale:** mirrors the already-proven trained-bundle model (one manifest + one importer,
+  ADR-039) so datasets get the same durability, portability and license discipline. A portable
+  semantic spec + per-trainer materializers is the only way one dataset can feed trainers with
+  genuinely different input shapes (raw wavs vs precomputed features) without rewriting upstream
+  scripts. Plugin-by-concern (not by vendor) keeps the module platform from fragmenting into
+  near-identical per-vendor modules (ADR-025 granularity).
+- **Consequences:**
+  - New `data` category module (`packages/modules/data/dataset/`) hosts the manifest schema +
+    validation + one importer per world (web TS / backend Python).
+  - `docs/modules/data-sources.md` is the spec home (rewritten 2026-08-20); `docs/modules/
+    training.md` §4.7 covers `datasets[]` consumption.
+  - Tasks #203–#210 track implementation; open questions Q-DS-3/4/5 remain (cloud-key handling,
+    exact built-in set, near-dup threshold).
+  - The Phase 4 export gate gains dataset-level inheritance (task #210).

--- a/apps/studio-backend/src/wake_train_kit/dataset.py
+++ b/apps/studio-backend/src/wake_train_kit/dataset.py
@@ -1,0 +1,250 @@
+"""wake_train_kit.dataset — the dataset.json manifest contract + importer (ADR-044, #203).
+
+Mirror of the web-side `packages/modules/data/dataset/core/spec.ts` + `manifest.ts`
+so the SAME `wake-studio-dataset.zip` validates identically in the browser and in
+the studio-backend. The TypeScript types are the source of truth; this module is
+the backend validation/import path (used by the dataset store, generation jobs
+and materializers — tasks #204/#205/#206).
+
+Canonical layout (docs/modules/data-sources.md §4.1)::
+
+    wake-studio-dataset.zip
+    ├── dataset.json          <-- the portability contract
+    └── audio/<label>/*.wav   <-- 16 kHz mono PCM WAV, canonical
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import zipfile
+from pathlib import Path
+from typing import Any, TypedDict
+
+DATASET_MANIFEST_SCHEMA_VERSION = 1
+CANONICAL_SAMPLE_RATE = 16000
+CANONICAL_ENCODING = "pcm_s16le"
+
+DATASET_KINDS = ("builtin", "generated", "uploaded", "public")
+DATASET_ROLES = ("positive", "unknowns", "noise", "mixed")
+LABEL_ROLES = ("positive", "unknown", "noise")
+
+
+class DatasetLabel(TypedDict):
+    name: str
+    role: str
+    language: str | None
+    source: str | None  # "real" | "synthetic"
+    voices: list[str] | None
+
+
+class DatasetAudio(TypedDict):
+    sampleRate: int
+    channels: int
+    encoding: str
+    clips: int
+    durationSec: int
+
+
+class DatasetProvenanceEntry(TypedDict):
+    name: str
+    license: str
+    commercialUse: bool
+    source: str | None
+
+
+class DatasetManifest(TypedDict):
+    schemaVersion: int
+    id: str
+    name: str
+    version: int
+    kind: str
+    role: str
+    audio: DatasetAudio
+    labels: list[DatasetLabel]
+    provenance: list[DatasetProvenanceEntry]
+    recipe: dict[str, Any] | None
+    contentHash: str | None
+    storage: dict[str, Any] | None
+    createdAtMs: int | None
+
+
+def _is_nonempty_str(v: Any) -> bool:
+    return isinstance(v, str) and bool(v.strip())
+
+
+def _is_plain_record(v: Any) -> bool:
+    return isinstance(v, dict)
+
+
+def validate_dataset_manifest(raw: Any) -> tuple[bool, list[str]]:
+    """Validate a parsed ``dataset.json`` against the manifest contract (ADR-044).
+
+    Mirrors `validateDatasetManifest` in the web module. Returns
+    ``(ok, errors)``; callers decide how to surface the errors.
+    """
+    errors: list[str] = []
+    if not _is_plain_record(raw):
+        return False, ["dataset.json must be a JSON object"]
+
+    m: dict[str, Any] = raw
+
+    if m.get("schemaVersion") != DATASET_MANIFEST_SCHEMA_VERSION:
+        errors.append(
+            f"schemaVersion must be {DATASET_MANIFEST_SCHEMA_VERSION} "
+            f"(got {m.get('schemaVersion')})"
+        )
+    if not _is_nonempty_str(m.get("id")):
+        errors.append("id must be a non-empty string")
+    if not _is_nonempty_str(m.get("name")):
+        errors.append("name must be a non-empty string")
+    version = m.get("version")
+    if not isinstance(version, int) or version < 1:
+        errors.append("version must be an integer >= 1")
+    if m.get("kind") not in DATASET_KINDS:
+        errors.append(f"kind must be one of: {', '.join(DATASET_KINDS)}")
+    if m.get("role") not in DATASET_ROLES:
+        errors.append(f"role must be one of: {', '.join(DATASET_ROLES)}")
+
+    audio = m.get("audio")
+    if not _is_plain_record(audio):
+        errors.append("audio must be an object")
+    else:
+        if not isinstance(audio.get("sampleRate"), int) or audio["sampleRate"] <= 0:
+            errors.append("audio.sampleRate must be a positive number")
+        if not isinstance(audio.get("channels"), int) or audio["channels"] <= 0:
+            errors.append("audio.channels must be a positive number")
+        if audio.get("encoding") != CANONICAL_ENCODING:
+            errors.append(
+                f'audio.encoding must be "{CANONICAL_ENCODING}" in the canonical form '
+                "(derived formats are materialized, not stored)"
+            )
+        if not isinstance(audio.get("clips"), int) or audio["clips"] < 0:
+            errors.append("audio.clips must be a number >= 0")
+        if not isinstance(audio.get("durationSec"), (int, float)) or audio["durationSec"] < 0:
+            errors.append("audio.durationSec must be a number >= 0")
+
+    labels = m.get("labels")
+    if not isinstance(labels, list) or len(labels) == 0:
+        errors.append("labels must be a non-empty array")
+    else:
+        seen: set[str] = set()
+        for i, label in enumerate(labels):
+            if not _is_plain_record(label):
+                errors.append(f"labels[{i}] must be an object")
+                continue
+            name = label.get("name")
+            if not _is_nonempty_str(name):
+                errors.append(f"labels[{i}].name must be a non-empty string")
+            elif name in seen:
+                errors.append(f'labels[{i}].name duplicates "{name}"')
+            seen.add(str(name or ""))
+            if label.get("role") not in LABEL_ROLES:
+                errors.append(f"labels[{i}].role must be one of: {', '.join(LABEL_ROLES)}")
+
+    provenance = m.get("provenance")
+    if not isinstance(provenance, list) or len(provenance) == 0:
+        errors.append("provenance must be a non-empty array")
+    else:
+        for i, entry in enumerate(provenance):
+            if not _is_plain_record(entry):
+                errors.append(f"provenance[{i}] must be an object")
+                continue
+            if not _is_nonempty_str(entry.get("name")):
+                errors.append(f"provenance[{i}].name must be a non-empty string")
+            if not _is_nonempty_str(entry.get("license")):
+                errors.append(f"provenance[{i}].license must be a non-empty string")
+            if not isinstance(entry.get("commercialUse"), bool):
+                errors.append(f"provenance[{i}].commercialUse must be a boolean")
+
+    if m.get("contentHash") is not None and not _is_nonempty_str(m.get("contentHash")):
+        errors.append("contentHash, when present, must be a non-empty string")
+
+    return len(errors) == 0, errors
+
+
+def load_dataset_manifest(manifest_path: Path | str) -> DatasetManifest:
+    """Read + validate a ``dataset.json`` from disk.
+
+    Raises ``ValueError`` (with the validation errors) when invalid.
+    """
+    path = Path(manifest_path)
+    data: Any = json.loads(path.read_text(encoding="utf-8"))
+    ok, errors = validate_dataset_manifest(data)
+    if not ok:
+        raise ValueError("invalid dataset.json: " + "; ".join(errors))
+    return data  # type: ignore[return-value]
+
+
+def dataset_content_hash(manifest: DatasetManifest, clips: dict[str, list[tuple[str, bytes]]]) -> str:
+    """sha256 over the canonical payload — manifest (minus hash/storage) + clip bytes.
+
+    Byte-identical to the web `datasetContentHash` (core/hash.ts): the same
+    manifest + clips hash to the same value in both worlds, so a dataset
+    persisted by the backend imports + verifies in the browser and vice versa.
+    Layout: ``dataset.json\\n`` + sorted-key JSON (`,``/`:` separators, raw
+    UTF-8) + ``\\n`` + for each sorted label, each clip sorted by name:
+    ``audio/<label>/<name>\\n`` + bytes + ``\\n``.
+    """
+    content = {k: v for k, v in manifest.items() if k not in ("contentHash", "storage")}
+    canonical = json.dumps(
+        content, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    )
+    digest = hashlib.sha256()
+    digest.update("dataset.json\n".encode("utf-8"))
+    digest.update(canonical.encode("utf-8"))
+    digest.update(b"\n")
+    for label in sorted(clips):
+        for name, bytes_ in sorted(clips[label], key=lambda c: c[0]):
+            digest.update(f"audio/{label}/{name}\n".encode("utf-8"))
+            digest.update(bytes_)
+            digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def import_dataset_zip(zip_path: Path | str) -> tuple[DatasetManifest, dict[str, list[str]]]:
+    """Import a ``wake-studio-dataset.zip`` -> (manifest, label -> clip names).
+
+    Validates ``dataset.json`` and indexes the canonical ``audio/<label>/*.wav``
+    tree. Every declared label must have >= 1 clip. Raises ``ValueError`` with a
+    stable, human-readable message on any invalid/missing part.
+    """
+    path = Path(zip_path)
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+        if not names:
+            raise ValueError("empty zip: expected dataset.json and an audio/ tree")
+
+        manifest_bytes = next(
+            (zf.read(n) for n in names if n.split("/")[-1] == "dataset.json"), None
+        )
+        if manifest_bytes is None:
+            raise ValueError("dataset.json is missing from the zip")
+
+        try:
+            parsed: Any = json.loads(manifest_bytes.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ValueError(f"dataset.json is invalid JSON: {exc}") from exc
+
+        ok, errors = validate_dataset_manifest(parsed)
+        if not ok:
+            raise ValueError("invalid dataset.json: " + "; ".join(errors))
+        manifest: DatasetManifest = parsed  # type: ignore[assignment]
+
+        clips: dict[str, list[str]] = {}
+        clip_matcher = re.compile(r"^audio/([^/]+)/([^/]+)$")
+        for name in names:
+            match = clip_matcher.match(name)
+            if not match or not name.lower().endswith(".wav"):
+                continue
+            clips.setdefault(match.group(1), []).append(match.group(2))
+
+        missing = [label["name"] for label in manifest["labels"] if not clips.get(label["name"])]
+        if missing:
+            raise ValueError(
+                "every declared label must have >= 1 clip; empty labels: "
+                + ", ".join(missing)
+            )
+
+        return manifest, clips

--- a/apps/studio-backend/tests/test_dataset.py
+++ b/apps/studio-backend/tests/test_dataset.py
@@ -1,0 +1,163 @@
+"""wake_train_kit.dataset tests (ADR-044, #203).
+
+No network / no GPU: the dataset zip is built in-memory with the stdlib zipfile,
+matching the canonical layout from docs/modules/data-sources.md §4.1. These tests
+mirror the web-side vitest suite (spec + manifest) so both importers agree.
+"""
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+from wake_train_kit import dataset as ds
+
+
+def _valid_manifest() -> dict:
+    return {
+        "schemaVersion": ds.DATASET_MANIFEST_SCHEMA_VERSION,
+        "id": "ds-1",
+        "name": "wake-words-zh-en",
+        "version": 1,
+        "kind": "generated",
+        "role": "mixed",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": ds.CANONICAL_ENCODING, "clips": 3, "durationSec": 6},
+        "labels": [
+            {"name": "hey_studio", "role": "positive"},
+            {"name": "noise", "role": "noise"},
+        ],
+        "provenance": [
+            {"name": "edge-tts synthetic speech", "license": "user-owned (synthetic TTS)", "commercialUse": True}
+        ],
+        "recipe": {"engine": "edge-tts", "seed": 0},
+    }
+
+
+def _clips() -> dict[str, dict[str, bytes]]:
+    return {
+        "hey_studio": {"a.wav": b"RIFFfakewav", "b.wav": b"RIFFfakewav"},
+        "noise": {"bg.wav": b"RIFFfakewav"},
+    }
+
+
+def _build_zip(manifest: dict, clips: dict[str, dict[str, bytes]]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("dataset.json", json.dumps(manifest))
+        for label, clip_map in clips.items():
+            for name, bytes_ in clip_map.items():
+                zf.writestr(f"audio/{label}/{name}", bytes_)
+    return buf.getvalue()
+
+
+def _write_zip(tmp_path: Path, data: bytes) -> Path:
+    p = tmp_path / "dataset.zip"
+    p.write_bytes(data)
+    return p
+
+
+def test_validate_accepts_well_formed():
+    ok, errors = ds.validate_dataset_manifest(_valid_manifest())
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_rejects_bad_role():
+    m = _valid_manifest()
+    m["labels"] = [{"name": "hey_studio", "role": "wanted"}]
+    ok, errors = ds.validate_dataset_manifest(m)
+    assert ok is False
+    assert any("role" in e for e in errors)
+
+
+def test_validate_rejects_non_canonical_encoding():
+    m = _valid_manifest()
+    m["audio"]["encoding"] = "mp3"
+    ok, errors = ds.validate_dataset_manifest(m)
+    assert ok is False
+    assert any("encoding" in e for e in errors)
+
+
+def test_validate_rejects_missing_commercial_use():
+    m = _valid_manifest()
+    m["provenance"] = [{"name": "x", "license": "CC0"}]
+    ok, errors = ds.validate_dataset_manifest(m)
+    assert ok is False
+    assert any("commercialUse" in e for e in errors)
+
+
+def test_load_dataset_manifest_roundtrip(tmp_path):
+    p = tmp_path / "dataset.json"
+    p.write_text(json.dumps(_valid_manifest()))
+    manifest = ds.load_dataset_manifest(p)
+    assert manifest["id"] == "ds-1"
+
+
+def test_load_dataset_manifest_raises_on_invalid(tmp_path):
+    p = tmp_path / "dataset.json"
+    p.write_text(json.dumps({"schemaVersion": 1, "id": "x"}))
+    try:
+        ds.load_dataset_manifest(p)
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "invalid dataset.json" in str(exc)
+
+
+def test_import_dataset_zip_indexes_audio(tmp_path):
+    manifest, clips = ds.import_dataset_zip(_write_zip(tmp_path, _build_zip(_valid_manifest(), _clips())))
+    assert manifest["id"] == "ds-1"
+    assert clips["hey_studio"] == ["a.wav", "b.wav"]
+    assert clips["noise"] == ["bg.wav"]
+
+
+def test_import_dataset_zip_missing_manifest(tmp_path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("audio/hey_studio/a.wav", b"RIFF")
+    try:
+        ds.import_dataset_zip(_write_zip(tmp_path, buf.getvalue()))
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "dataset.json is missing" in str(exc)
+
+
+def test_import_dataset_zip_label_without_clips(tmp_path):
+    m = _valid_manifest()
+    try:
+        ds.import_dataset_zip(
+            _write_zip(tmp_path, _build_zip(m, {"hey_studio": {"a.wav": b"RIFF"}}))
+        )
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "empty labels: noise" in str(exc)
+
+
+def test_content_hash_roundtrip_and_change_detection():
+    m = _valid_manifest()
+    clips_bytes = {label: [(n, b) for n, b in clips.items()] for label, clips in _clips().items()}
+    h1 = ds.dataset_content_hash(m, clips_bytes)
+
+    # Same manifest + same clips -> same hash (deterministic).
+    h2 = ds.dataset_content_hash(m, clips_bytes)
+    assert h1 == h2
+
+    # A changed clip -> different hash (change detection bumps version).
+    changed = dict(clips_bytes, hey_studio=[("a.wav", b"RIFFchanged")])
+    assert ds.dataset_content_hash(m, changed) != h1
+
+
+def test_python_hash_matches_web_contract_shape():
+    # The hash must be a 64-char sha256 hex string, matching the web importer's
+    # contentHash format so a dataset produced by the backend imports in the browser.
+    m = _valid_manifest()
+    clips_bytes = {label: [(n, b) for n, b in clips.items()] for label, clips in _clips().items()}
+    h = ds.dataset_content_hash(m, clips_bytes)
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+    # Deterministic regardless of clip insertion order (sorted by name).
+    reordered = {
+        "hey_studio": [(n, b) for n, b in reversed(_clips()["hey_studio"].items())],
+        "noise": [(n, b) for n, b in _clips()["noise"].items()],
+    }
+    assert ds.dataset_content_hash(m, reordered) == h

--- a/docs/modules/data-sources.md
+++ b/docs/modules/data-sources.md
@@ -6,9 +6,9 @@
 - **Related ADRs:** ADR-022 (data-source layer), ADR-013 (training backends), ADR-023 (Colab
   backend), ADR-025 (spec-driven modules), ADR-028 (uv train scripts), ADR-031 (upstream-script
   adapters), ADR-033 (self-registering drivers), ADR-036 (job-manager API), ADR-039
-  (labels/formats/convert)
+  (labels/formats/convert), ADR-044 (datasets as first-class artifacts)
 - **Depends on (modules):** Training (consumes datasets), Export (license provenance)
-- **Last updated:** 2026-08-20
+- **Last updated:** 2026-08-20 (#203 implemented)
 
 ## 1. Purpose
 
@@ -80,6 +80,12 @@ wake-studio-dataset.zip
 Canonical audio is **16 kHz mono PCM WAV**. Other rates / encodings / precomputed features are
 **derived** at materialize or push time - the same "canonical artifact + derived formats" rule as
 ADR-039 for models.
+
+**Implemented (#203, ADR-044):** the schema is `packages/modules/data/dataset/core/spec.ts`
+(TypeScript, source of truth) with the Python mirror `apps/studio-backend/src/wake_train_kit/
+dataset.py`; the web importer is `packages/modules/data/dataset/core/manifest.ts` (typed
+`DatasetImportError` codes). The two importer/hash implementations are byte-identical for the
+`contentHash` so a backend-produced dataset verifies in the browser and vice versa.
 
 ### 4.2 dataset.json manifest
 
@@ -349,3 +355,4 @@ license/provenance log shown in-app before export. The Datasets console shows th
 | 2026-08-14 | **Data-source layer shipped (#152):** `wake_train_kit/data_sources.py` with Speech Commands V2 download (CC BY 4.0), user-URL archives, and multi-language edge-tts synthesis; provenance records per source; deterministic backend tests. Q-DS-1 answered. | agent |
 | 2026-08-17 | **Mixed mode (#158):** `merge_label_trees` merges a positive tree (wake word) with a negative tree (real unknowns + real noise); collisions raise; real noise wins over synthesized silence. `dataSource=mixed` in the kws-streaming adapter + spec params + registry wiring; 4 new backend tests. | agent |
 | 2026-08-20 | **Datasets as first-class artifacts (design locked, human discussion):** full spec written - `dataset.json` manifest + canonical `label/*.wav` tree + one importer (SS4); `dataset-generate` jobs with pluggable TTS engine / storage / postprocess plugins, split by concern not vendor (SS5); per-trainer materializers + `spec.train.dataset` compatibility (SS6); built-in catalog (SS7); Datasets console (SS8); quality gate / dedup+split / reproducibility (SS9); provenance chain to the export gate (SS10). Decision points resolved: composable granularity, cloud storage optional (HF / R2 / GDrive with user keys), user-configurable online TTS API+key, new-dataset-equals-new-version, multi-language+noise built-ins. Open: Q-DS-3/4/5. | agent |
+| 2026-08-20 | **#203 — dataset spec implemented (ADR-044):** `packages/modules/data/dataset/` module (`core/spec.ts` manifest schema + validation, `core/hash.ts` canonical contentHash, `core/manifest.ts` single importer with typed `DatasetImportError` codes) + Python mirror `wake_train_kit/dataset.py` (byte-identical hash, verified cross-implementation); vitest + pytest suites; `.gitignore` `data/` anchored to `/data/` so the `data` category module is tracked. Remaining #204-#210 unchanged. | agent |

--- a/packages/modules/data/dataset/core/hash.ts
+++ b/packages/modules/data/dataset/core/hash.ts
@@ -1,0 +1,105 @@
+/**
+ * Dataset content hashing (ADR-044 §4.2, task #203).
+ *
+ * `contentHash` is a sha256 over the CANONICAL payload — the manifest (minus
+ * the self-referential `contentHash`/`storage` fields) plus every clip's bytes
+ * in the `audio/<label>/` tree. Any content change changes the hash; per the
+ * spec a changed hash must surface as a new `version`, so imports can detect a
+ * silent dataset mutation.
+ *
+ * The byte layout is byte-identical to the backend mirror
+ * (`wake_train_kit/dataset.py`) so a dataset produced/persisted by the backend
+ * verifies in the browser and vice versa:
+ *
+ * ```
+ * "dataset.json\n"
+ * <stable JSON of the manifest minus contentHash+storage, sorted keys,
+ *  `,`/`:` separators, raw UTF-8>\n
+ * for each label (sorted), for each clip (sorted by name):
+ *   "audio/<label>/<name>\n"  <clip bytes>  "\n"
+ * ```
+ *
+ * Browser + node compatible: WebCrypto when available, `node:crypto` fallback.
+ */
+
+import type { DatasetManifest } from './spec'
+
+/** One canonical clip in the `audio/<label>/` tree. */
+export interface DatasetClip {
+  name: string
+  bytes: Uint8Array
+}
+
+/** label -> clips (the canonical `audio/<label>/*.wav` tree). */
+export type ClipTree = Record<string, DatasetClip[]>
+
+/**
+ * Deterministic JSON serialization (sorted keys, `,`/`:` separators, raw
+ * UTF-8) matching Python's `json.dumps(..., sort_keys=True, ensure_ascii=False,
+ * separators=(',', ':'))` so both worlds hash the identical manifest bytes.
+ */
+export function stableJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    const keys = Object.keys(record).sort()
+    return `{${keys
+      .map((k) => `${JSON.stringify(k)}:${stableJson(record[k])}`)
+      .join(',')}}`
+  }
+  throw new Error(`stableJson: unsupported value ${String(value)}`)
+}
+
+/**
+ * The canonical payload bytes for hashing (see header for the exact layout).
+ * Label and clip ordering is deterministic regardless of zip entry order.
+ */
+export function canonicalDatasetPayload(
+  manifest: DatasetManifest,
+  clips: ClipTree,
+): Uint8Array {
+  const { contentHash: _hash, storage: _storage, ...content } = manifest
+  const encoder = new TextEncoder()
+  const parts: Uint8Array[] = [encoder.encode('dataset.json\n')]
+  parts.push(encoder.encode(`${stableJson(content)}\n`))
+
+  for (const label of Object.keys(clips).sort()) {
+    const clipList = [...clips[label]].sort((a, b) => (a.name < b.name ? -1 : 1))
+    for (const clip of clipList) {
+      parts.push(encoder.encode(`audio/${label}/${clip.name}\n`))
+      parts.push(clip.bytes)
+      parts.push(encoder.encode('\n'))
+    }
+  }
+
+  const total = parts.reduce((n, p) => n + p.byteLength, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const p of parts) {
+    out.set(p, offset)
+    offset += p.byteLength
+  }
+  return out
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  // Browser / workers: WebCrypto.
+  if (typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined') {
+    const digest = await crypto.subtle.digest('SHA-256', data as unknown as BufferSource)
+    return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('')
+  }
+  // Node (vitest / backend tooling): node:crypto fallback.
+  const { createHash } = await import('node:crypto')
+  return createHash('sha256').update(data as unknown as Uint8Array).digest('hex')
+}
+
+/** Compute the dataset content hash (sha256, hex) over the canonical payload. */
+export async function datasetContentHash(
+  manifest: DatasetManifest,
+  clips: ClipTree,
+): Promise<string> {
+  return sha256Hex(canonicalDatasetPayload(manifest, clips))
+}

--- a/packages/modules/data/dataset/core/index.ts
+++ b/packages/modules/data/dataset/core/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Dataset module - core exports (ADR-044, task #203).
+ *
+ * The `dataset.json` manifest contract (schema + validation), the canonical
+ * content hash, and the single dataset importer. Generation jobs (engines /
+ * storage plugins), materializers, the built-in catalog and the Datasets
+ * console land in tasks #204-#210.
+ */
+
+export {
+  DATASET_KINDS,
+  DATASET_ROLES,
+  LABEL_ROLES,
+  DATASET_MANIFEST_SCHEMA_VERSION,
+  CANONICAL_SAMPLE_RATE,
+  CANONICAL_ENCODING,
+  isLabelRole,
+  validateDatasetManifest,
+  type DatasetKind,
+  type DatasetRole,
+  type LabelRole,
+  type AudioSource,
+  type DatasetLabel,
+  type DatasetAudio,
+  type DatasetProvenanceEntry,
+  type DatasetRecipe,
+  type DatasetStorage,
+  type DatasetManifest,
+  type ManifestValidation,
+} from './spec'
+
+export {
+  canonicalDatasetPayload,
+  datasetContentHash,
+  type ClipTree,
+} from './hash'
+
+export {
+  importDatasetZip,
+  DatasetImportError,
+  type DatasetImportErrorCode,
+  DATASET_IMPORT_ERROR_MESSAGES,
+  type DatasetBundle,
+} from './manifest'

--- a/packages/modules/data/dataset/core/manifest.ts
+++ b/packages/modules/data/dataset/core/manifest.ts
@@ -1,0 +1,194 @@
+/**
+ * Dataset module - the single dataset importer (ADR-044, task #203).
+ *
+ * Mirrors the trained-bundle importer (training module `manifest.ts`): ONE
+ * importer validates + reads any `wake-studio-dataset.zip` so every producer
+ * (built-in catalog, generation job, upload) and every consumer (the Datasets
+ * console, the training wizard's `datasets[]` picker) share one code path.
+ *
+ * The zip layout (docs/modules/data-sources.md §4.1):
+ *
+ * ```
+ * wake-studio-dataset.zip
+ * ├── dataset.json          <-- the portability contract (see ./spec)
+ * └── audio/
+ *     ├── <label>/<clip>.wav   (16 kHz mono PCM WAV, canonical)
+ *     └── ...
+ * ```
+ */
+
+import { unzipSync } from 'fflate'
+import {
+  validateDatasetManifest,
+  type DatasetManifest,
+  type DatasetLabel,
+} from './spec'
+import { datasetContentHash, type ClipTree } from './hash'
+
+/** A parsed + validated dataset: the manifest + its canonical clip tree. */
+export interface DatasetBundle {
+  manifest: DatasetManifest
+  /** label -> clips, sorted by clip name (the canonical `audio/<label>/*.wav` tree). */
+  clips: ClipTree
+}
+
+/**
+ * Error raised by {@link importDatasetZip} when the picked file is not a valid
+ * dataset. `code` lets the UI show a precise message (mirrors
+ * `BundleImportError` in the training module).
+ */
+export class DatasetImportError extends Error {
+  /** Stable machine-readable code (surfaced in the UI + tests). */
+  readonly code: DatasetImportErrorCode
+
+  constructor(code: DatasetImportErrorCode, message: string) {
+    super(message)
+    this.name = 'DatasetImportError'
+    this.code = code
+  }
+}
+
+export type DatasetImportErrorCode =
+  | 'no-zip'
+  | 'empty-zip'
+  | 'missing-manifest'
+  | 'invalid-manifest'
+  | 'invalid-encoding'
+  | 'missing-clips'
+  | 'content-mismatch'
+
+/** Messages shown to the user for each {@link DatasetImportErrorCode}. */
+export const DATASET_IMPORT_ERROR_MESSAGES: Record<DatasetImportErrorCode, string> = {
+  'no-zip': "That file isn't a zip archive — pick a wake-studio-dataset.zip.",
+  'empty-zip': 'The zip is empty — it should contain dataset.json and an audio/ tree.',
+  'missing-manifest':
+    'dataset.json is missing from the zip (the dataset portability contract).',
+  'invalid-manifest':
+    'dataset.json is invalid — it must declare id/name/version, semantic label roles and provenance (see docs/modules/data-sources.md §4.2).',
+  'invalid-encoding':
+    'The manifest declares a non-canonical audio encoding — datasets store 16 kHz mono PCM WAV (derived formats are materialized, not stored).',
+  'missing-clips':
+    "Every declared label must have at least one clip in audio/<label>/ — some labels have none.",
+  'content-mismatch':
+    "The dataset's contentHash doesn't match its audio — the archive was modified or corrupted. Re-import the original zip.",
+}
+
+/**
+ * Parse a `File` (or node Buffer) that is a `wake-studio-dataset.zip` into a
+ * {@link DatasetBundle}. Client-side only — no WakeStudio server involved.
+ *
+ * Steps:
+ * 1. Unzip + find `dataset.json` (matched by basename, like the bundle importer).
+ * 2. Validate it against the manifest contract ({@link validateDatasetManifest}).
+ * 3. Index the canonical `audio/<label>/*.wav` tree; every declared label must
+ *    have >= 1 clip.
+ * 4. When `contentHash` is present, recompute it over the canonical payload and
+ *    compare — a mismatch means the archive was modified (content-mismatch).
+ *
+ * @throws {DatasetImportError} with a stable `code` on any invalid/missing part.
+ */
+export async function importDatasetZip(
+  input: File | ArrayBuffer | Uint8Array,
+): Promise<DatasetBundle> {
+  const data = input instanceof Uint8Array ? input : await readZipBytes(input)
+  if (data.byteLength === 0) {
+    throw new DatasetImportError('no-zip', DATASET_IMPORT_ERROR_MESSAGES['no-zip'])
+  }
+
+  let entries: Record<string, Uint8Array>
+  try {
+    entries = unzipSync(data)
+  } catch {
+    throw new DatasetImportError('no-zip', DATASET_IMPORT_ERROR_MESSAGES['no-zip'])
+  }
+
+  const names = Object.keys(entries)
+  if (names.length === 0) {
+    throw new DatasetImportError('empty-zip', DATASET_IMPORT_ERROR_MESSAGES['empty-zip'])
+  }
+
+  const decoder = new TextDecoder()
+  const byName = new Map<string, Uint8Array>()
+  for (const name of names) {
+    const base = name.split('/').pop() ?? name
+    if (!byName.has(base)) byName.set(base, entries[name])
+  }
+
+  const manifestBytes = byName.get('dataset.json')
+  if (!manifestBytes) {
+    throw new DatasetImportError(
+      'missing-manifest',
+      DATASET_IMPORT_ERROR_MESSAGES['missing-manifest'],
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(decoder.decode(manifestBytes))
+  } catch {
+    throw new DatasetImportError(
+      'invalid-manifest',
+      DATASET_IMPORT_ERROR_MESSAGES['invalid-manifest'],
+    )
+  }
+
+  const validation = validateDatasetManifest(parsed)
+  if (!validation.ok) {
+    throw new DatasetImportError(
+      'invalid-manifest',
+      `${DATASET_IMPORT_ERROR_MESSAGES['invalid-manifest']} (${validation.errors.join('; ')})`,
+    )
+  }
+  const manifest = parsed as DatasetManifest
+
+  if (manifest.audio.encoding !== 'pcm_s16le') {
+    throw new DatasetImportError(
+      'invalid-encoding',
+      DATASET_IMPORT_ERROR_MESSAGES['invalid-encoding'],
+    )
+  }
+
+  // Index the canonical audio/<label>/*.wav tree (clips sorted by name for a
+  // deterministic content hash, independent of zip entry order).
+  const clips: ClipTree = {}
+  for (const name of names) {
+    const match = /^audio\/([^/]+)\/(.+)$/.exec(name)
+    if (!match) continue
+    const [, label, clipName] = match
+    if (!/\.wav$/i.test(clipName)) continue
+    ;(clips[label] ??= []).push({ name: clipName, bytes: entries[name] })
+  }
+  for (const label of Object.keys(clips)) {
+    clips[label].sort((a, b) => (a.name < b.name ? -1 : 1))
+  }
+
+  // Every declared label must have >= 1 clip (structural validity; the quality
+  // gate in #209 refines the empty-label warnings/messaging).
+  const missing = (manifest.labels as DatasetLabel[]).filter((l) => !(clips[l.name]?.length))
+  if (missing.length > 0) {
+    throw new DatasetImportError(
+      'missing-clips',
+      `${DATASET_IMPORT_ERROR_MESSAGES['missing-clips']} (empty labels: ${missing
+        .map((l) => l.name)
+        .join(', ')})`,
+    )
+  }
+
+  // Optional integrity check: contentHash must match the canonical payload.
+  if (manifest.contentHash) {
+    const actual = await datasetContentHash(manifest, clips)
+    if (actual !== manifest.contentHash) {
+      throw new DatasetImportError(
+        'content-mismatch',
+        DATASET_IMPORT_ERROR_MESSAGES['content-mismatch'],
+      )
+    }
+  }
+
+  return { manifest, clips }
+}
+
+async function readZipBytes(input: File | ArrayBuffer): Promise<Uint8Array> {
+  if (input instanceof ArrayBuffer) return new Uint8Array(input)
+  return new Uint8Array(await input.arrayBuffer())
+}

--- a/packages/modules/data/dataset/core/spec.ts
+++ b/packages/modules/data/dataset/core/spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Dataset module - the `dataset.json` manifest schema (ADR-044, task #203).
+ *
+ * A dataset is a first-class artifact: one `wake-studio-dataset.zip` carrying a
+ * `dataset.json` manifest (the portability contract) + a canonical
+ * `label/*.wav` tree (16 kHz mono PCM WAV). The manifest declares each label's
+ * SEMANTIC role (`positive` / `unknown` / `noise`) - it never bakes
+ * trainer-specific folder magic (`_background_noise_`, `_unknown_`) into the
+ * contract. Per-trainer materializers create the folders an upstream trainer
+ * expects (docs/modules/data-sources.md §4/§6).
+ *
+ * The TypeScript types here are the source of truth; the studio-backend
+ * Python importer (wake_train_kit/dataset.py) mirrors these rules so the same
+ * manifest validates identically in the browser and the backend.
+ */
+
+/** Where the dataset came from. */
+export type DatasetKind = 'builtin' | 'generated' | 'uploaded' | 'public'
+
+/** What the dataset is for (top-level intent). */
+export type DatasetRole = 'positive' | 'unknowns' | 'noise' | 'mixed'
+
+/** Semantic role of one label - the portable vocabulary across trainers. */
+export type LabelRole = 'positive' | 'unknown' | 'noise'
+
+/** Whether the clip audio is real speech or synthetic (TTS). */
+export type AudioSource = 'real' | 'synthetic'
+
+export const DATASET_KINDS: readonly DatasetKind[] = [
+  'builtin',
+  'generated',
+  'uploaded',
+  'public',
+]
+
+export const DATASET_ROLES: readonly DatasetRole[] = [
+  'positive',
+  'unknowns',
+  'noise',
+  'mixed',
+]
+
+export const LABEL_ROLES: readonly LabelRole[] = ['positive', 'unknown', 'noise']
+
+/** The manifest spec version. Bump only on a breaking manifest shape change. */
+export const DATASET_MANIFEST_SCHEMA_VERSION = 1
+
+/** The canonical audio format: 16 kHz mono PCM WAV (ADR-044). */
+export const CANONICAL_SAMPLE_RATE = 16000
+export const CANONICAL_ENCODING = 'pcm_s16le'
+
+export interface DatasetLabel {
+  /** Folder name of this label in the canonical `audio/<label>/` tree (sanitized). */
+  name: string
+  /** Semantic role - the portable vocabulary (docs/modules/data-sources.md §4.2). */
+  role: LabelRole
+  /** ISO language tag (optional; e.g. "zh-CN", "en-US"). */
+  language?: string
+  /** Per-clip provenance: real vs synthetic (synthetic-to-real gap, #209). */
+  source?: AudioSource
+  /** Distinct TTS voices used for this label (voice-coverage warning, #209). */
+  voices?: string[]
+}
+
+export interface DatasetAudio {
+  sampleRate: number
+  channels: number
+  /** Canonical encoding: "pcm_s16le". */
+  encoding: string
+  clips: number
+  durationSec: number
+}
+
+export interface DatasetProvenanceEntry {
+  name: string
+  license: string
+  /** False = the model is NOT commercially exportable if trained with this dataset (#210). */
+  commercialUse: boolean
+  source?: string
+}
+
+export interface DatasetRecipe {
+  /** TTS engine id (edge-tts | piper | <online-http-tts> | <llm-tts>), ADR-044. */
+  engine: string
+  phrases?: string[]
+  languages?: string[]
+  /** Reproducibility seed - regenerate is byte-reproducible (#209). */
+  seed?: number
+  toolVersions?: Record<string, string>
+  [key: string]: unknown
+}
+
+export interface DatasetStorage {
+  /** Backend store path, e.g. "datasets/<id>/". */
+  backend: string
+  /** Optional cloud ref, e.g. "hf://user/ds" | "r2://bucket" | "gdrive://". */
+  cloud?: string
+  /** Optional read-only URL for built-in / public datasets. */
+  url?: string
+}
+
+/**
+ * The `dataset.json` portability contract (docs/modules/data-sources.md §4.2).
+ */
+export interface DatasetManifest {
+  schemaVersion: number
+  id: string
+  name: string
+  /** A new dataset (any content change bumps version; contentHash detects it). */
+  version: number
+  kind: DatasetKind
+  role: DatasetRole
+  audio: DatasetAudio
+  labels: DatasetLabel[]
+  provenance: DatasetProvenanceEntry[]
+  recipe?: DatasetRecipe
+  /** sha256 over the canonical payload (manifest minus hash/storage + all clip bytes). */
+  contentHash?: string
+  storage?: DatasetStorage
+  createdAtMs?: number
+}
+
+export interface ManifestValidation {
+  ok: boolean
+  /** Human-readable problems (empty when ok). */
+  errors: string[]
+}
+
+/** True when a value is one of the known label roles. */
+export function isLabelRole(value: unknown): value is LabelRole {
+  return typeof value === 'string' && (LABEL_ROLES as readonly string[]).includes(value)
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0
+}
+
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/**
+ * Validate a parsed `dataset.json` against the manifest contract (ADR-044).
+ *
+ * Shared by the web importer and the backend importer's mirror. Returns a
+ * `{ ok, errors }` result - callers decide how to surface it (the importer
+ * throws a typed {@link DatasetImportError}).
+ */
+export function validateDatasetManifest(raw: unknown): ManifestValidation {
+  const errors: string[] = []
+  if (!isPlainRecord(raw)) {
+    return { ok: false, errors: ['dataset.json must be a JSON object'] }
+  }
+
+  const m = raw as Record<string, unknown>
+
+  if (m.schemaVersion !== DATASET_MANIFEST_SCHEMA_VERSION) {
+    errors.push(
+      `schemaVersion must be ${DATASET_MANIFEST_SCHEMA_VERSION} (got ${String(m.schemaVersion)})`,
+    )
+  }
+  if (!isNonEmptyString(m.id)) errors.push('id must be a non-empty string')
+  if (!isNonEmptyString(m.name)) errors.push('name must be a non-empty string')
+  if (typeof m.version !== 'number' || !Number.isInteger(m.version) || (m.version as number) < 1) {
+    errors.push('version must be an integer >= 1')
+  }
+  if (typeof m.kind !== 'string' || !(DATASET_KINDS as readonly string[]).includes(m.kind)) {
+    errors.push(`kind must be one of: ${DATASET_KINDS.join(', ')}`)
+  }
+  if (typeof m.role !== 'string' || !(DATASET_ROLES as readonly string[]).includes(m.role)) {
+    errors.push(`role must be one of: ${DATASET_ROLES.join(', ')}`)
+  }
+
+  // audio block
+  const audio = m.audio
+  if (!isPlainRecord(audio)) {
+    errors.push('audio must be an object')
+  } else {
+    if (typeof audio.sampleRate !== 'number' || audio.sampleRate <= 0) {
+      errors.push('audio.sampleRate must be a positive number')
+    }
+    if (typeof audio.channels !== 'number' || audio.channels <= 0) {
+      errors.push('audio.channels must be a positive number')
+    }
+    if (!isNonEmptyString(audio.encoding)) {
+      errors.push('audio.encoding must be a non-empty string')
+    } else if (audio.encoding !== CANONICAL_ENCODING) {
+      errors.push(
+        `audio.encoding must be "${CANONICAL_ENCODING}" in the canonical form (derived formats are materialized, not stored)`,
+      )
+    }
+    if (typeof audio.clips !== 'number' || audio.clips < 0) {
+      errors.push('audio.clips must be a number >= 0')
+    }
+    if (typeof audio.durationSec !== 'number' || audio.durationSec < 0) {
+      errors.push('audio.durationSec must be a number >= 0')
+    }
+  }
+
+  // labels block - the portability contract (semantic roles)
+  if (!Array.isArray(m.labels) || m.labels.length === 0) {
+    errors.push('labels must be a non-empty array')
+  } else {
+    const seen = new Set<string>()
+    m.labels.forEach((label, i) => {
+      if (!isPlainRecord(label)) {
+        errors.push(`labels[${i}] must be an object`)
+        return
+      }
+      const name = label.name
+      if (!isNonEmptyString(name)) errors.push(`labels[${i}].name must be a non-empty string`)
+      else if (seen.has(name)) errors.push(`labels[${i}].name duplicates "${name}"`)
+      seen.add(String(name ?? ''))
+      if (!isLabelRole(label.role)) {
+        errors.push(`labels[${i}].role must be one of: ${LABEL_ROLES.join(', ')}`)
+      }
+    })
+  }
+
+  // provenance block - the license-gate input (#210)
+  if (!Array.isArray(m.provenance) || m.provenance.length === 0) {
+    errors.push('provenance must be a non-empty array')
+  } else {
+    m.provenance.forEach((entry, i) => {
+      if (!isPlainRecord(entry)) {
+        errors.push(`provenance[${i}] must be an object`)
+        return
+      }
+      if (!isNonEmptyString(entry.name)) errors.push(`provenance[${i}].name must be a non-empty string`)
+      if (!isNonEmptyString(entry.license)) {
+        errors.push(`provenance[${i}].license must be a non-empty string`)
+      }
+      if (typeof entry.commercialUse !== 'boolean') {
+        errors.push(`provenance[${i}].commercialUse must be a boolean`)
+      }
+    })
+  }
+
+  if (m.contentHash !== undefined && !isNonEmptyString(m.contentHash)) {
+    errors.push('contentHash, when present, must be a non-empty string')
+  }
+
+  return { ok: errors.length === 0, errors }
+}

--- a/packages/modules/data/dataset/eslint.config.js
+++ b/packages/modules/data/dataset/eslint.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+/** dataset module eslint config (flat, ESLint 9). */
+export default tseslint.config(
+  { ignores: ['node_modules', 'dist', 'assets'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+)

--- a/packages/modules/data/dataset/package.json
+++ b/packages/modules/data/dataset/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@wake-studio/module-dataset",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Dataset module (ADR-044, #203): the dataset.json manifest schema + canonical label/*.wav form + one importer per world (web TS / backend Python). Datasets are first-class artifacts - create, persist, reuse, share.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./core/index.ts",
+    "./core": "./core/index.ts",
+    "./spec": "./spec/module.spec.json"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run",
+    "fetch:all": "echo 'no artifacts'"
+  },
+  "dependencies": {
+    "fflate": "^0.8.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "eslint": "^9.16.0",
+    "globals": "^15.13.0",
+    "typescript": "~5.6.3",
+    "typescript-eslint": "^8.16.0",
+    "vitest": "^2.1.9"
+  }
+}

--- a/packages/modules/data/dataset/spec/module.spec.json
+++ b/packages/modules/data/dataset/spec/module.spec.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../../../contracts/src/module-spec.schema.json",
+  "meta": {
+    "id": "dataset",
+    "name": "Datasets (audio data management)",
+    "category": "data",
+    "version": "0.1.0",
+    "maturity": "draft",
+    "owner": "WakeStudio team",
+    "license": "MIT",
+    "status": "proposed",
+    "description": "Datasets as first-class artifacts (ADR-044, #203): the dataset.json manifest + canonical label/*.wav form + one importer per world (web TS / backend Python). Generation jobs, storage plugins, materializers, the built-in catalog and the Datasets console land in #204-#210."
+  },
+  "params": [],
+  "actions": [],
+  "status": {},
+  "runtime": {
+    "web": {
+      "engine": "DatasetManifest"
+    }
+  },
+  "tests": {
+    "required": ["l1"]
+  },
+  "playground": {
+    "route": "/playground/dataset",
+    "entry": "none"
+  },
+  "interfaces": {
+    "provides": ["DatasetManifest", "DatasetStore"],
+    "consumes": ["DataSources", "TrainingJob"]
+  }
+}

--- a/packages/modules/data/dataset/tests/manifest.test.ts
+++ b/packages/modules/data/dataset/tests/manifest.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { zipSync, strToU8 } from 'fflate'
+import {
+  importDatasetZip,
+  DatasetImportError,
+  DATASET_IMPORT_ERROR_MESSAGES,
+  type DatasetBundle,
+} from '../core/manifest'
+import {
+  validateDatasetManifest,
+  DATASET_MANIFEST_SCHEMA_VERSION,
+  CANONICAL_ENCODING,
+  type DatasetManifest,
+} from '../core/spec'
+import { datasetContentHash, type ClipTree } from '../core/hash'
+
+function validManifest(): DatasetManifest {
+  return {
+    schemaVersion: DATASET_MANIFEST_SCHEMA_VERSION,
+    id: 'ds-1',
+    name: 'wake-words-zh-en',
+    version: 1,
+    kind: 'generated',
+    role: 'mixed',
+    audio: { sampleRate: 16000, channels: 1, encoding: CANONICAL_ENCODING, clips: 3, durationSec: 6 },
+    labels: [
+      { name: 'hey_studio', role: 'positive' },
+      { name: 'noise', role: 'noise' },
+    ],
+    provenance: [{ name: 'edge-tts synthetic speech', license: 'user-owned (synthetic TTS)', commercialUse: true }],
+    recipe: { engine: 'edge-tts', seed: 0 },
+  }
+}
+
+type ZipClips = Record<string, Record<string, Uint8Array>>
+
+/** Build a `wake-studio-dataset.zip` in memory (canonical layout, §4.1). */
+function buildZip(manifest: DatasetManifest, clips: ZipClips): Uint8Array {
+  const entries: Record<string, Uint8Array> = {
+    'dataset.json': strToU8(JSON.stringify(manifest)),
+  }
+  for (const [label, clipMap] of Object.entries(clips)) {
+    for (const [name, bytes] of Object.entries(clipMap)) {
+      entries[`audio/${label}/${name}`] = bytes
+    }
+  }
+  return zipSync(entries)
+}
+
+/** Convert a zip clip map into the ClipTree hashing form. */
+function toClipTree(clips: ZipClips): ClipTree {
+  const tree: ClipTree = {}
+  for (const [label, clipMap] of Object.entries(clips)) {
+    tree[label] = Object.entries(clipMap).map(([name, bytes]) => ({ name, bytes }))
+  }
+  return tree
+}
+
+const WAV = strToU8('RIFFfakewav')
+
+function clipsFixture(): ZipClips {
+  return {
+    hey_studio: { 'a.wav': WAV, 'b.wav': WAV },
+    noise: { 'bg.wav': WAV },
+  }
+}
+
+describe('wake-studio-dataset.zip importer (ADR-044 §4, task #203)', () => {
+  it('imports a valid dataset and indexes the canonical audio tree', async () => {
+    const manifest = validManifest()
+    const bundle = await importDatasetZip(buildZip(manifest, clipsFixture()))
+    expect(bundle.manifest.id).toBe('ds-1')
+    expect(bundle.clips.hey_studio).toHaveLength(2)
+    expect(bundle.clips.noise).toHaveLength(1)
+  })
+
+  it('rejects a non-zip input', async () => {
+    await expect(importDatasetZip(strToU8('not a zip'))).rejects.toBeInstanceOf(DatasetImportError)
+    await expect(importDatasetZip(new Uint8Array(0))).rejects.toThrow(
+      DATASET_IMPORT_ERROR_MESSAGES['no-zip'],
+    )
+  })
+
+  it('rejects an empty zip', async () => {
+    await expect(importDatasetZip(zipSync({}))).rejects.toMatchObject({
+      code: 'empty-zip',
+    })
+  })
+
+  it('rejects a zip missing dataset.json', async () => {
+    const zip = zipSync({ 'audio/hey_studio/a.wav': WAV })
+    await expect(importDatasetZip(zip)).rejects.toMatchObject({
+      code: 'missing-manifest',
+    })
+  })
+
+  it('rejects a zip with an invalid dataset.json', async () => {
+    const manifest = { ...validManifest(), version: 0 } // invalid
+    await expect(importDatasetZip(buildZip(manifest, clipsFixture()))).rejects.toMatchObject({
+      code: 'invalid-manifest',
+    })
+  })
+
+  it('rejects a manifest declaring a label with no clips', async () => {
+    const manifest = validManifest()
+    await expect(importDatasetZip(buildZip(manifest, { hey_studio: { 'a.wav': WAV } }))).rejects.toMatchObject({
+      code: 'missing-clips',
+    })
+  })
+
+  it('accepts an audio tree with extra (un-declared) labels but still requires declared ones', async () => {
+    const manifest = validManifest()
+    const bundle = await importDatasetZip(
+      buildZip(manifest, {
+        hey_studio: { 'a.wav': WAV },
+        noise: { 'bg.wav': WAV },
+        extra: { 'x.wav': WAV },
+      }),
+    )
+    expect(bundle.clips.extra).toHaveLength(1)
+  })
+
+  it('round-trips contentHash: valid when matching, content-mismatch when a clip is tampered', async () => {
+    const manifest = validManifest()
+    const clips = clipsFixture()
+    const hash = await datasetContentHash(manifest, toClipTree(clips))
+    const withHash = { ...manifest, contentHash: hash }
+    const bundle = await importDatasetZip(buildZip(withHash, clips))
+    expect(bundle.manifest.contentHash).toBe(hash)
+
+    // Tamper a clip -> hash no longer matches.
+    const tampered = {
+      hey_studio: { ...clips.hey_studio, 'a.wav': strToU8('RIFFtampered') },
+      noise: clips.noise,
+    }
+    await expect(importDatasetZip(buildZip(withHash, tampered))).rejects.toMatchObject({
+      code: 'content-mismatch',
+    })
+  })
+
+  it('accepts a manifest without contentHash (producers may omit the check)', async () => {
+    const bundle: DatasetBundle = await importDatasetZip(buildZip(validManifest(), clipsFixture()))
+    expect(bundle.manifest.contentHash).toBeUndefined()
+  })
+
+  it('validateDatasetManifest agrees with the importer on the same object', async () => {
+    const manifest = validManifest()
+    expect(validateDatasetManifest(manifest).ok).toBe(true)
+    const bundle = await importDatasetZip(buildZip(manifest, clipsFixture()))
+    expect(bundle.manifest.id).toBe(manifest.id)
+  })
+})

--- a/packages/modules/data/dataset/tests/spec.test.ts
+++ b/packages/modules/data/dataset/tests/spec.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateDatasetManifest,
+  DATASET_MANIFEST_SCHEMA_VERSION,
+  CANONICAL_ENCODING,
+  type DatasetManifest,
+} from '../core/spec'
+
+/** A minimal but valid dataset.json for tests (docs/modules/data-sources.md §4.2). */
+function validManifest(): DatasetManifest {
+  return {
+    schemaVersion: DATASET_MANIFEST_SCHEMA_VERSION,
+    id: 'ds-1',
+    name: 'wake-words-zh-en',
+    version: 1,
+    kind: 'generated',
+    role: 'mixed',
+    audio: { sampleRate: 16000, channels: 1, encoding: CANONICAL_ENCODING, clips: 4, durationSec: 12 },
+    labels: [
+      { name: 'hey_studio', role: 'positive', language: 'en-US', source: 'synthetic', voices: ['en-US-1'] },
+      { name: 'hello', role: 'unknown', language: 'en-US' },
+      { name: 'noise', role: 'noise' },
+    ],
+    provenance: [{ name: 'edge-tts synthetic speech', license: 'user-owned (synthetic TTS)', commercialUse: true }],
+    recipe: { engine: 'edge-tts', phrases: ['hey studio'], languages: ['en-US'], seed: 0 },
+  }
+}
+
+describe('dataset.json manifest contract (ADR-044 §4.2, task #203)', () => {
+  it('accepts a well-formed manifest', () => {
+    const r = validateDatasetManifest(validManifest())
+    expect(r.ok).toBe(true)
+    expect(r.errors).toEqual([])
+  })
+
+  it('rejects a manifest with a wrong schemaVersion', () => {
+    const m = { ...validManifest(), schemaVersion: 999 }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('schemaVersion')
+  })
+
+  it('rejects a manifest missing labels', () => {
+    const m = { ...validManifest(), labels: [] }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('labels')
+  })
+
+  it('rejects a label with an invalid semantic role', () => {
+    const m = {
+      ...validManifest(),
+      labels: [{ name: 'hey_studio', role: 'wanted' }],
+    }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('role')
+  })
+
+  it('rejects duplicate label names', () => {
+    const m = {
+      ...validManifest(),
+      labels: [
+        { name: 'hey_studio', role: 'positive' },
+        { name: 'hey_studio', role: 'unknown' },
+      ],
+    }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('duplicates')
+  })
+
+  it('rejects a non-canonical audio encoding (derived formats are not stored)', () => {
+    const m = { ...validManifest(), audio: { ...validManifest().audio, encoding: 'mp3' } }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('encoding')
+  })
+
+  it('rejects provenance without a commercialUse boolean (export-gate input, #210)', () => {
+    const m = {
+      ...validManifest(),
+      provenance: [{ name: 'x', license: 'CC0' }],
+    }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('commercialUse')
+  })
+
+  it('rejects version < 1', () => {
+    const m = { ...validManifest(), version: 0 }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('version')
+  })
+
+  it('rejects a non-object input', () => {
+    expect(validateDatasetManifest(null).ok).toBe(false)
+    expect(validateDatasetManifest('nope').ok).toBe(false)
+  })
+})

--- a/packages/modules/data/dataset/tsconfig.json
+++ b/packages/modules/data/dataset/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["core", "spec", "tests"]
+}

--- a/packages/modules/data/dataset/vitest.config.ts
+++ b/packages/modules/data/dataset/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,31 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)
 
+  packages/modules/data/dataset:
+    dependencies:
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.16.0
+        version: 9.39.5
+      eslint:
+        specifier: ^9.16.0
+        version: 9.39.5(jiti@1.21.7)
+      globals:
+        specifier: ^15.13.0
+        version: 15.15.0
+      typescript:
+        specifier: ~5.6.3
+        version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.16.0
+        version: 8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.6.3)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.43)(terser@5.49.0)
+
   packages/modules/few-shot:
     dependencies:
       '@wake-studio/contracts':


### PR DESCRIPTION
## Summary

Implement task #203 (epic #202): the dataset spec. Datasets become **first-class artifacts** — every dataset is one `wake-studio-dataset.zip`: a `dataset.json` manifest (the portability contract) + a canonical `label/*.wav` tree (16 kHz mono PCM WAV). The manifest declares each label's **semantic role** (`positive`/`unknown`/`noise`); per-trainer materializers (task #206) will map roles to trainer-specific folders. Closes https://github.com/awareride/wake-studio/issues/203.

## Changes

- **New `data`-category module** `packages/modules/data/dataset/`:
  - `core/spec.ts` — `DatasetManifest` schema + validation (semantic label roles, canonical encoding, provenance with `commercialUse` for the export gate)
  - `core/hash.ts` — canonical contentHash (sorted-key JSON + per-clip framing; change detection bumps `version`)
  - `core/manifest.ts` — single importer `importDatasetZip` with typed `DatasetImportError` codes (`missing-manifest`, `invalid-manifest`, `invalid-encoding`, `missing-clips`, `content-mismatch`)
  - `spec/module.spec.json` + package scaffold; **19 vitest cases**
- **Backend mirror** `apps/studio-backend/src/wake_train_kit/dataset.py` + `tests/test_dataset.py` (11 cases) — same validation and a **byte-identical contentHash** (cross-verified against the web layout, so a backend-produced dataset verifies in the browser and vice versa)
- **ADR-044** in `DECISIONS.md` — datasets as first-class artifacts (records the 2026-08-20 design)
- `docs/modules/data-sources.md` synced (schema location + change log)
- `.gitignore`: anchored `data/` → `/data/` — the over-broad pattern was silently ignoring the new `packages/modules/data/` dir

## Verification

- `pnpm lint` / `pnpm typecheck` / `pnpm test:unit` (repo-wide) — exit 0
- `uv run pytest` (backend) — 72 passed
- contentHash cross-implementation check — Python hash == TS layout hash

## Not in this PR

Generation jobs (#205), storage plugins (#204), materializers + `datasets[]` (#206), built-in catalog (#207), Datasets console (#208), quality gate (#209), provenance chain (#210).
