### PR TITLE
docs: sync module status table — add dataset + dry-run, correct training score

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ shipped; target adapters and bundle generation remain. See
 | `afe-bss` | afe | draft | ✅✅✅✅✅✅ | 100% |
 | `afe-graph` | afe | pilot | ✅✅✅✅✅✅ | 100% |
 | `rnnoise` | afe | pilot | ✅✅✅✅✅✅ | 100% |
+| `dataset` | data | draft | ✅✅⬜✅✅✅ | 83% |
 | `few-shot` | few-shot | pilot | ✅✅✅✅✅✅ | 100% |
 | `kws-engine` | kws | pilot | ✅✅✅✅✅✅ | 100% |
 | `kws-openwakeword` | kws | pilot | ✅✅✅✅✅✅ | 100% |
 | `kws-plix` | kws | draft | ✅✅✅✅✅✅ | 100% |
 | `kws-sherpa` | kws | draft | ✅✅✅✅✅✅ | 100% |
 | `kws-streaming` | kws | pilot | ✅✅✅✅✅✅ | 100% |
-| `training` | training | draft | ✅✅✅✅✅✅ | 100% |
+| `dry-run` | training | demo | ⬜✅⬜⬜✅✅ | 50% |
+| `training` | training | draft | ✅✅⬜✅✅✅ | 83% |
 <!-- /MODULE-STATUS -->
 
 ## Two domains


### PR DESCRIPTION
Syncs the generated README module-status table (ADR-025 §4) with the current module tree:

- adds the new `data`-category `dataset` module (#203)
- adds `dry-run` (was never listed)
- corrects `training` to 83% (its params moved to the New-train wizard in #105, so the panel evidence is now correctly empty)

Regenerated with `node scripts/gen-module-status.mjs --update` — generated, never hand-maintained.