### PR TITLE
ci: check dataset-engines catalog freshness in CI + sync module status table (#205 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         # fragments; fail CI if they drift (hand-edit or stale fragment).
         run: pnpm gen:registry:check
 
+      - name: Check generated dataset-engines catalog is fresh (#205)
+        # dataset-engines.json is generated from the data-category engine
+        # modules' spec.tts (ADR-044 §5); fail CI if they drift.
+        run: pnpm gen:engines:check
+
       - name: Fetch L2 test artifacts (sherpa + openwakeword, ADR-027)
         # The L2 wasm/onnx boot tests exercise the gitignored artifacts
         # (ADR-011). Non-fatal: each L2 suite skips when its asset is absent

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ build/
 .env
 .env.local
 
+# Local TTS credentials (e.g. mimo API key, user-provided, client-side only)
+/auth.json
+
 # Archive (old static site)
 _archive/
 .wrangler/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ shipped; target adapters and bundle generation remain. See
 | `afe-graph` | afe | pilot | ✅✅✅✅✅✅ | 100% |
 | `rnnoise` | afe | pilot | ✅✅✅✅✅✅ | 100% |
 | `dataset` | data | draft | ✅✅⬜✅✅✅ | 83% |
+| `edge-tts` | data | draft | ✅✅✅⬜✅✅ | 83% |
+| `mimo-tts` | data | draft | ✅✅✅⬜✅✅ | 83% |
+| `piper` | data | draft | ✅✅✅⬜✅✅ | 83% |
+| `qwen-llm-tts` | data | draft | ✅✅✅⬜✅✅ | 83% |
 | `few-shot` | few-shot | pilot | ✅✅✅✅✅✅ | 100% |
 | `kws-engine` | kws | pilot | ✅✅✅✅✅✅ | 100% |
 | `kws-openwakeword` | kws | pilot | ✅✅✅✅✅✅ | 100% |

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:e2e": "pnpm --filter @wake-studio/web test:e2e",
     "test:unit": "pnpm -r test:unit",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "pnpm -r typecheck",
+    "gen:engines": "node scripts/build-dataset-engines.mjs --update",
+    "gen:engines:check": "node scripts/build-dataset-engines.mjs --check"
   },
   "devDependencies": {
     "typescript": "~5.6.3"


### PR DESCRIPTION
## Summary

Wire the dataset-engines catalog freshness check into CI (the decision from #205) + sync the README module-status table.

## Changes

- **Root scripts**: `gen:engines` / `gen:engines:check` → `scripts/build-dataset-engines.mjs` (mirrors `gen:registry` / `gen:registry:check`)
- **`.github/workflows/ci.yml`**: new `Check generated dataset-engines catalog is fresh (#205)` step right after `gen:registry:check` — a stale `dataset-engines.json` (hand-edit or `spec.tts` drift in an engine module) now fails the build
- **README.md**: module-status table regenerated (17 modules) — adds the 4 `data`-category engine modules (`edge-tts`, `mimo-tts`, `piper`, `qwen-llm-tts`)
- **`.gitignore`**: ignore `/auth.json` — a local TTS credential file (user API key) that must never be committed

Refs https://github.com/awareride/wake-studio/issues/205 (does not close — #205 is already merged via #214; this is the follow-up decision).
