### PR TITLE
feat(dataset): dataset storage layer — backend datasets/ store + StorageBackend plugins (ADR-044, #204)

### DIFF
--- a/apps/studio-backend/registry.example.json
+++ b/apps/studio-backend/registry.example.json
@@ -23,5 +23,18 @@
       "WAKE_STEPS": "{params.steps}",
       "WAKE_BACKEND": "self-hosted"
     }
+  },
+  "dataset-storage": {
+    "cwd": "src/wake_train_kit",
+    "engine": "direct",
+    "entry": "storage_runner.py",
+    "env": {
+      "STORAGE_ACTION": "{params.action}",
+      "STORAGE_BACKEND": "{params.backend}",
+      "STORAGE_SRC": "{params.src}",
+      "STORAGE_DEST": "{params.dest}",
+      "STORAGE_PREFIX": "{params.prefix}",
+      "GEN_BACKEND": "self-hosted"
+    }
   }
 }

--- a/apps/studio-backend/registry.json
+++ b/apps/studio-backend/registry.json
@@ -93,5 +93,18 @@
    "GEN_DATASET_ID": "{params.datasetId}",
    "GEN_BACKEND": "self-hosted"
   }
+ },
+ "dataset-storage": {
+  "cwd": "src/wake_train_kit",
+  "engine": "direct",
+  "entry": "storage_runner.py",
+  "env": {
+   "STORAGE_ACTION": "{params.action}",
+   "STORAGE_BACKEND": "{params.backend}",
+   "STORAGE_SRC": "{params.src}",
+   "STORAGE_DEST": "{params.dest}",
+   "STORAGE_PREFIX": "{params.prefix}",
+   "GEN_BACKEND": "self-hosted"
+  }
  }
 }

--- a/apps/studio-backend/src/wake_train_kit/dataset_store.py
+++ b/apps/studio-backend/src/wake_train_kit/dataset_store.py
@@ -1,0 +1,207 @@
+"""wake_train_kit.dataset_store — the backend `datasets/` store (ADR-044, #204).
+
+Mirrors the artifacts store (`wake_training_service/store.py` + `manager.py`):
+a durable `datasets/<id>/wake-studio-dataset.zip` directory + a SQLite index
+(sha256, size, manifest). Datasets are FIRST-CLASS artifacts — they survive
+service restarts and are not tied to the job that produced them.
+
+This module lives in `wake_train_kit` (the data layer) so both the service
+(`wake_training_service`) and the `dataset-generate` / `dataset-storage`
+subprocess runners can use it without a layering cycle (the kit must not
+import the service).
+
+Canonical layout (docs/modules/data-sources.md §4.1)::
+
+    datasets/
+    ├── <dataset-id>/
+    │   └── wake-studio-dataset.zip
+    └── datasets.db              <- SQLite index (id -> stored_path, sha256, ...)
+
+The zip is imported through `wake_train_kit.dataset.import_dataset_zip`, so a
+dataset only lands in the store when its manifest is valid and every declared
+label has >= 1 clip.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+import threading
+import zipfile
+from pathlib import Path
+from typing import Any, TypedDict
+
+from .dataset import DatasetManifest, import_dataset_zip
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS datasets (
+  id            TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  version       INTEGER NOT NULL,
+  kind          TEXT NOT NULL,
+  role          TEXT NOT NULL,
+  stored_path   TEXT NOT NULL,
+  sha256        TEXT NOT NULL,
+  size_bytes    INTEGER NOT NULL,
+  manifest      TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL
+);
+"""
+
+
+class DatasetRecord(TypedDict):
+    id: str
+    name: str
+    version: int
+    kind: str
+    role: str
+    stored_path: str
+    sha256: str
+    size_bytes: int
+    manifest: dict[str, Any]
+    created_at_ms: int
+
+
+class DatasetStoreError(RuntimeError):
+    """Raised on store-level failures (unknown dataset, persistence problems)."""
+
+
+class DatasetStore:
+    """Thread-safe, SQLite-backed persistence for first-class datasets.
+
+    ``save`` imports a canonical ``wake-studio-dataset.zip`` (validates the
+    manifest + clip tree), copies it into ``datasets/<id>/`` and registers the
+    record (sha256 over the stored zip). ``get`` / ``list`` / ``delete`` /
+    ``path`` read from the same index. The index survives restarts.
+    """
+
+    def __init__(self, datasets_dir: str | Path, db_path: str | Path | None = None) -> None:
+        self.datasets_dir = Path(datasets_dir)
+        self.datasets_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = Path(db_path) if db_path else self.datasets_dir / "datasets.db"
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    # --- public API ---------------------------------------------------------
+    def save(self, zip_path: str | Path) -> DatasetRecord:
+        """Import + persist a canonical dataset zip.
+
+        Validates via ``import_dataset_zip`` (raises ValueError on an invalid
+        manifest), copies the zip to ``datasets/<id>/wake-studio-dataset.zip``,
+        and upserts the index. Returns the stored record.
+        """
+        src = Path(zip_path)
+        if not src.is_file():
+            raise DatasetStoreError(f"dataset zip not found: {src}")
+
+        try:
+            manifest, _clips = import_dataset_zip(src)
+        except (ValueError, zipfile.BadZipFile) as exc:
+            raise DatasetStoreError(f"invalid dataset zip '{src.name}': {exc}") from exc
+        dataset_id = str(manifest["id"])
+        dest_dir = self.datasets_dir / dataset_id
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / "wake-studio-dataset.zip"
+        shutil.copy2(src, dest)
+        data = dest.read_bytes()
+        record = self._record_from_manifest(manifest, dest, data)
+        self._upsert(record)
+        return record
+
+    def get(self, dataset_id: str) -> DatasetRecord | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM datasets WHERE id = ?", (dataset_id,)
+            ).fetchone()
+        return self._row_to_record(row) if row else None
+
+    def list(self) -> list[DatasetRecord]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM datasets ORDER BY created_at_ms DESC"
+            ).fetchall()
+        return [self._row_to_record(r) for r in rows]
+
+    def delete(self, dataset_id: str) -> None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT stored_path FROM datasets WHERE id = ?", (dataset_id,)
+            ).fetchone()
+            if row is not None:
+                stored = Path(row["stored_path"])
+                stored.unlink(missing_ok=True)
+                shutil.rmtree(stored.parent, ignore_errors=True)
+            self._conn.execute("DELETE FROM datasets WHERE id = ?", (dataset_id,))
+            self._conn.commit()
+
+    def path(self, dataset_id: str) -> Path | None:
+        """Local path of a dataset's canonical zip (None when unknown)."""
+        record = self.get(dataset_id)
+        if record is None:
+            return None
+        return Path(record["stored_path"])
+
+    def load_manifest(self, dataset_id: str) -> DatasetManifest | None:
+        """The parsed manifest of a stored dataset (None when unknown)."""
+        record = self.get(dataset_id)
+        if record is None:
+            return None
+        return record["manifest"]  # type: ignore[return-value]
+
+    # --- internals ----------------------------------------------------------
+    def _record_from_manifest(
+        self, manifest: DatasetManifest, stored: Path, data: bytes
+    ) -> DatasetRecord:
+        import time
+
+        return {
+            "id": str(manifest["id"]),
+            "name": str(manifest["name"]),
+            "version": int(manifest.get("version", 1)),
+            "kind": str(manifest.get("kind", "uploaded")),
+            "role": str(manifest.get("role", "mixed")),
+            "stored_path": str(stored),
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "size_bytes": len(data),
+            "manifest": manifest,
+            "created_at_ms": int(manifest.get("createdAtMs") or time.time() * 1000),
+        }
+
+    def _upsert(self, record: DatasetRecord) -> None:
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO datasets (id, name, version, kind, role, stored_path,"
+                " sha256, size_bytes, manifest, created_at_ms)"
+                " VALUES (:id, :name, :version, :kind, :role, :stored_path,"
+                " :sha256, :size_bytes, :manifest, :created_at_ms)"
+                " ON CONFLICT(id) DO UPDATE SET name=excluded.name,"
+                " version=excluded.version, kind=excluded.kind, role=excluded.role,"
+                " stored_path=excluded.stored_path, sha256=excluded.sha256,"
+                " size_bytes=excluded.size_bytes, manifest=excluded.manifest,"
+                " created_at_ms=excluded.created_at_ms",
+                self._record_to_row(record),
+            )
+            self._conn.commit()
+
+    @staticmethod
+    def _record_to_row(record: DatasetRecord) -> dict[str, Any]:
+        return {
+            **{k: v for k, v in record.items() if k != "manifest"},
+            "manifest": json.dumps(record["manifest"]),
+        }
+
+    @staticmethod
+    def _row_to_record(row: sqlite3.Row) -> DatasetRecord:
+        record = dict(row)
+        record["manifest"] = json.loads(record["manifest"])
+        return record  # type: ignore[return-value]

--- a/apps/studio-backend/src/wake_train_kit/storage.py
+++ b/apps/studio-backend/src/wake_train_kit/storage.py
@@ -1,0 +1,313 @@
+"""wake_train_kit.storage — StorageBackend plugin interface + registry (ADR-044 §5.3, #204).
+
+Persistence is a **plugin** behind one interface (``push`` / ``pull`` /
+``list`` / ``delete``), the storage-side twin of the TTS engine plugins
+(ADR-033 self-registration): ``backend-disk`` (default), ``huggingface``
+(dataset repo), ``cloudflare-r2`` (S3-compatible), ``google-drive``, ``url``
+(built-in / public, READ-ONLY). Each backend declares its ``authKey`` — the
+Settings "Cloud storage" key holding its credentials (client-side, masked,
+never logged or exported — same guarantees as ``backend.apiKey``).
+
+Backend contract (docs/modules/data-sources.md §5.3)::
+
+    { "id": "r2", "kind": "s3-compatible", "authKey": "cloud.r2",
+      "capabilities": ["push", "pull", "list", "delete"], "format": "zip" }
+
+``backend-disk`` and ``url`` are fully implemented here (local copy + read-only
+download). The cloud adapters (``hf`` / ``r2`` / ``gdrive``) are registered with
+their descriptors and raise a clear, actionable error when their optional SDK
+is not installed — real SDK wiring lands with the cloud-provider adapter work
+(issue #107) / the push-job console (#208); the acceptance tests use FAKE
+adapters behind the same interface (no real cloud).
+"""
+
+from __future__ import annotations
+
+import abc
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+CAP_PUSH = "push"
+CAP_PULL = "pull"
+CAP_LIST = "list"
+CAP_DELETE = "delete"
+
+ALL_CAPABILITIES = frozenset({CAP_PUSH, CAP_PULL, CAP_LIST, CAP_DELETE})
+
+
+class StorageBackendError(RuntimeError):
+    """Raised when a storage backend cannot perform an operation."""
+
+
+class StorageBackend(abc.ABC):
+    """One storage backend behind the push/pull/list/delete interface.
+
+    Subclasses declare their identity (``id`` / ``kind`` / ``authKey`` /
+    ``capabilities`` / ``format``) and implement the ``_push`` / ``_pull`` /
+    ``_list`` / ``_delete`` hooks. The public wrappers gate on capabilities so
+    a backend that cannot ``delete`` fails loudly instead of silently no-op'ing.
+    """
+
+    id: str = ""
+    kind: str = ""
+    authKey: str | None = None
+    capabilities: frozenset[str] = frozenset()
+    format: str = "zip"
+
+    # --- descriptor ---------------------------------------------------------
+    def descriptor(self) -> dict[str, Any]:
+        """The plugin descriptor (Settings "Cloud storage" + registry catalog)."""
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "authKey": self.authKey,
+            "capabilities": sorted(self.capabilities),
+            "format": self.format,
+        }
+
+    def check(self) -> None:
+        """Raise ``StorageBackendError`` if the backend cannot run here.
+
+        Default: no-op. Cloud adapters override to require their optional SDK.
+        """
+        return
+
+    # --- public interface (capability-gated) --------------------------------
+    def push(self, src: Path | str, dest: str, creds: dict[str, Any] | None = None) -> str:
+        """Upload/persist the local file at ``src`` to the backend ref ``dest``.
+
+        Returns a backend reference string (e.g. the remote path / object key).
+        """
+        self.check()
+        self._require(CAP_PUSH)
+        return self._push(Path(src), dest, creds or {})
+
+    def pull(self, src: str, dest: Path | str, creds: dict[str, Any] | None = None) -> Path:
+        """Fetch the backend ref ``src`` into the local path ``dest``."""
+        self.check()
+        self._require(CAP_PULL)
+        return self._pull(src, Path(dest), creds or {})
+
+    def list(self, prefix: str = "", creds: dict[str, Any] | None = None) -> list[str]:
+        """List backend refs under ``prefix`` (may be empty for the root)."""
+        self.check()
+        self._require(CAP_LIST)
+        return self._list(prefix, creds or {})
+
+    def delete(self, ref: str, creds: dict[str, Any] | None = None) -> None:
+        """Delete the backend ref (no-op-safe: missing refs are not an error)."""
+        self.check()
+        self._require(CAP_DELETE)
+        self._delete(ref, creds or {})
+
+    # --- hooks ----------------------------------------------------------------
+    def _push(self, src: Path, dest: str, creds: dict[str, Any]) -> str:
+        raise NotImplementedError
+
+    def _pull(self, src: str, dest: Path, creds: dict[str, Any]) -> Path:
+        raise NotImplementedError
+
+    def _list(self, prefix: str, creds: dict[str, Any]) -> list[str]:
+        raise NotImplementedError
+
+    def _delete(self, ref: str, creds: dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    # --- helpers --------------------------------------------------------------
+    def _require(self, op: str) -> None:
+        if op not in self.capabilities:
+            raise StorageBackendError(
+                f"storage backend '{self.id}' does not support '{op}'"
+                f" (capabilities: {sorted(self.capabilities)})"
+            )
+
+
+class BackendDiskStorage(StorageBackend):
+    """Local-directory backend (default). ``creds['dir']`` (or
+    ``WAKE_STORAGE_DISK_DIR`` env) is the base directory; refs are paths under
+    it. Fully local — used by the datasets store and by backend push jobs to a
+    local target folder."""
+
+    id = "backend-disk"
+    kind = "local"
+    authKey = None
+    capabilities = ALL_CAPABILITIES
+
+    def _base(self, creds: dict[str, Any]) -> Path:
+        base = creds.get("dir") or os.environ.get("WAKE_STORAGE_DISK_DIR") or "."
+        return Path(base)
+
+    def _push(self, src: Path, dest: str, creds: dict[str, Any]) -> str:
+        base = self._base(creds)
+        target = base / dest
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
+        return str(target.relative_to(base))
+
+    def _pull(self, src: str, dest: Path, creds: dict[str, Any]) -> Path:
+        base = self._base(creds)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(base / src, dest)
+        return dest
+
+    def _list(self, prefix: str, creds: dict[str, Any]) -> list[str]:
+        base = self._base(creds)
+        if not base.is_dir():
+            return []
+        return [
+            str(p.relative_to(base))
+            for p in sorted(base.rglob("*"))
+            if p.is_file() and str(p.relative_to(base)).startswith(prefix)
+        ]
+
+    def _delete(self, ref: str, creds: dict[str, Any]) -> None:
+        base = self._base(creds)
+        (base / ref).unlink(missing_ok=True)
+
+
+class UrlStorage(StorageBackend):
+    """Read-only backend for built-in / public dataset URLs (ADR-044 §4.2
+    ``storage.url``). ``pull`` downloads the URL; ``push`` / ``list`` /
+    ``delete`` are NOT supported (read-only)."""
+
+    id = "url"
+    kind = "url"
+    authKey = None
+    capabilities = frozenset({CAP_PULL})
+
+    def _pull(self, src: str, dest: Path, creds: dict[str, Any]) -> Path:
+        import urllib.request
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        url = src if src.startswith(("http://", "https://", "file://")) else f"https://{src}"
+        urllib.request.urlretrieve(url, str(dest))  # noqa: S310 (user-provided URL)
+        return dest
+
+
+class _CloudStorageBackend(StorageBackend):
+    """Base for cloud adapters: require an optional SDK at call time.
+
+    Real SDK wiring (auth flow, upload/download) lands with the cloud-provider
+    adapter work (issue #107) / push-job console (#208). Until then the
+    adapter is REGISTERED and declares its descriptor, and any operation raises
+    a clear, actionable error when the SDK is missing — never a silent no-op.
+    """
+
+    _sdk_module = ""
+    _install_hint = ""
+
+    def check(self) -> None:
+        missing = self._sdk_module and not _importable(self._sdk_module)
+        if missing:
+            raise StorageBackendError(
+                f"storage backend '{self.id}' requires '{self._sdk_module}' "
+                f"(install: {self._install_hint})"
+            )
+
+    def _push(self, src: Path, dest: str, creds: dict[str, Any]) -> str:
+        self._not_wired("push")
+
+    def _pull(self, src: str, dest: Path, creds: dict[str, Any]) -> Path:
+        self._not_wired("pull")
+
+    def _list(self, prefix: str, creds: dict[str, Any]) -> list[str]:
+        self._not_wired("list")
+
+    def _delete(self, ref: str, creds: dict[str, Any]) -> None:
+        self._not_wired("delete")
+
+    def _not_wired(self, op: str) -> None:
+        # The SDK import already succeeded (check() passed) — the SDK call
+        # itself is a follow-up (#107). Fail loudly, never pretend.
+        raise StorageBackendError(
+            f"storage backend '{self.id}' {op} is not wired yet — "
+            f"cloud SDK calls land with issue #107"
+        )
+
+
+class HuggingFaceStorage(_CloudStorageBackend):
+    """Hugging Face dataset repo (push/pull/list/delete on ``user/ds``)."""
+
+    id = "hf"
+    kind = "huggingface"
+    authKey = "cloud.hf"
+    capabilities = ALL_CAPABILITIES
+    _sdk_module = "huggingface_hub"
+    _install_hint = "uv add huggingface_hub"
+
+
+class CloudflareR2Storage(_CloudStorageBackend):
+    """Cloudflare R2 (S3-compatible) bucket."""
+
+    id = "r2"
+    kind = "s3-compatible"
+    authKey = "cloud.r2"
+    capabilities = ALL_CAPABILITIES
+    _sdk_module = "boto3"
+    _install_hint = "uv add boto3"
+
+
+class GoogleDriveStorage(_CloudStorageBackend):
+    """Google Drive folder (service account)."""
+
+    id = "gdrive"
+    kind = "google-drive"
+    authKey = "cloud.gdrive"
+    capabilities = ALL_CAPABILITIES
+    _sdk_module = "googleapiclient"
+    _install_hint = "uv add google-api-python-client google-auth"
+
+
+def _importable(module_name: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(module_name) is not None
+
+
+class StorageRegistry:
+    """Plugin registry (ADR-033 self-registration).
+
+    ``register`` takes a backend CLASS; ``get`` instantiates it per call so a
+    backend can be re-created with fresh state. Unknown ids raise
+    ``StorageBackendError`` (never silently fall back).
+    """
+
+    def __init__(self) -> None:
+        self._classes: dict[str, type[StorageBackend]] = {}
+
+    def register(self, backend: type[StorageBackend]) -> type[StorageBackend]:
+        if not backend.id:
+            raise StorageBackendError("cannot register a StorageBackend without an id")
+        if backend.id in self._classes:
+            raise StorageBackendError(f"duplicate storage backend id '{backend.id}'")
+        self._classes[backend.id] = backend
+        return backend
+
+    def get(self, backend_id: str) -> StorageBackend:
+        cls = self._classes.get(backend_id)
+        if cls is None:
+            raise StorageBackendError(
+                f"unknown storage backend '{backend_id}' "
+                f"(known: {sorted(self._classes)})"
+            )
+        return cls()
+
+    def has(self, backend_id: str) -> bool:
+        return backend_id in self._classes
+
+    def ids(self) -> list[str]:
+        return sorted(self._classes)
+
+    def descriptors(self) -> list[dict[str, Any]]:
+        return [self.get(bid).descriptor() for bid in self.ids()]
+
+
+#: Default registry with the built-in backends (descriptor catalog + runtime).
+STORAGE_REGISTRY = StorageRegistry()
+STORAGE_REGISTRY.register(BackendDiskStorage)
+STORAGE_REGISTRY.register(HuggingFaceStorage)
+STORAGE_REGISTRY.register(CloudflareR2Storage)
+STORAGE_REGISTRY.register(GoogleDriveStorage)
+STORAGE_REGISTRY.register(UrlStorage)

--- a/apps/studio-backend/src/wake_train_kit/storage_runner.py
+++ b/apps/studio-backend/src/wake_train_kit/storage_runner.py
@@ -1,0 +1,131 @@
+"""wake_train_kit.storage_runner — dataset-storage job entry (ADR-044 §5.3, #204).
+
+Registry entry (engine "direct") for the studio-backend job manager (ADR-036).
+Reads job params from STORAGE_* env vars + WAKE_PARAMS JSON (the registry
+convention), loads the requested StorageBackend from the registry, and performs
+a push / pull / list / delete. Emits the NDJSON reporting protocol on stdout:
+``log``, ``done`` (with the result ref) or ``error``.
+
+Cloud-key handling (Q-DS-3 / ADR-013 tension): the backend job receives cloud
+credentials ONLY as job-scoped env vars (STORAGE_CREDS_*), never as persisted
+job params — the manager keeps them out of SQLite (see wake_training_service
+manager.create_job(env=...)). This module never reads or logs credential values.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from wake_train_kit.storage import STORAGE_REGISTRY, StorageBackendError
+
+try:
+    from wake_train_kit.report import Reporter
+except ImportError:  # standalone fallback: plain NDJSON prints
+    class Reporter:  # type: ignore[no-redef]
+        def emit(self, event: str, **fields: Any) -> None:
+            print(json.dumps({"event": event, **fields}), flush=True)
+
+
+DEFAULTS: dict[str, Any] = {
+    "action": "push",          # push | pull | list | delete
+    "backend": "backend-disk",
+    "src": "",                 # local file (push) or remote ref (pull/delete)
+    "dest": "",                # remote ref (push) or local file (pull)
+    "prefix": "",              # list prefix
+}
+
+ENV_MAP: dict[str, str] = {
+    "STORAGE_ACTION": "action",
+    "STORAGE_BACKEND": "backend",
+    "STORAGE_SRC": "src",
+    "STORAGE_DEST": "dest",
+    "STORAGE_PREFIX": "prefix",
+}
+
+CREDS_PREFIX = "STORAGE_CREDS_"
+
+
+def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
+    """Job params from STORAGE_* env vars + WAKE_PARAMS JSON (both conventions)."""
+    env = env if env is not None else os.environ
+    params: dict[str, Any] = dict(DEFAULTS)
+
+    raw_json = env.get("WAKE_PARAMS", "")
+    if raw_json:
+        try:
+            for key, value in json.loads(raw_json).items():
+                if key in DEFAULTS:
+                    params[key] = value
+        except (ValueError, TypeError):
+            pass
+
+    for var, key in ENV_MAP.items():
+        raw = env.get(var, "")
+        if raw != "":
+            params[key] = raw
+    return params
+
+
+def read_creds(env: dict[str, str] | None = None) -> dict[str, str]:
+    """Job-scoped cloud credentials from STORAGE_CREDS_* env vars only.
+
+    Never read from persisted params, never logged. e.g.
+    ``STORAGE_CREDS_token`` -> {"token": "..."} for a huggingface backend.
+    """
+    env = env if env is not None else os.environ
+    creds: dict[str, str] = {}
+    for key, value in env.items():
+        if key.startswith(CREDS_PREFIX):
+            creds[key[len(CREDS_PREFIX):].lower()] = value
+    return creds
+
+
+def main(argv: list[str] | None = None) -> int:
+    reporter = Reporter()
+    params = read_params()
+    creds = read_creds()
+
+    action = params["action"]
+    backend_id = params["backend"]
+    reporter.emit(
+        "log", level="info",
+        message=f"dataset-storage: action={action} backend={backend_id}",
+    )
+
+    try:
+        backend = STORAGE_REGISTRY.get(backend_id)
+        backend.check()
+        if action == "push":
+            if not params["src"]:
+                raise StorageBackendError("push requires a local 'src' file")
+            ref = backend.push(params["src"], params["dest"], creds)
+            reporter.emit("done", exitCode=0, ref=ref)
+        elif action == "pull":
+            if not params["src"] or not params["dest"]:
+                raise StorageBackendError("pull requires 'src' (remote) and 'dest' (local)")
+            dest = backend.pull(params["src"], params["dest"], creds)
+            reporter.emit("done", exitCode=0, ref=str(dest))
+        elif action == "list":
+            refs = backend.list(params["prefix"], creds)
+            reporter.emit("done", exitCode=0, refs=refs)
+        elif action == "delete":
+            if not params["src"]:
+                raise StorageBackendError("delete requires a 'src' ref")
+            backend.delete(params["src"], creds)
+            reporter.emit("done", exitCode=0)
+        else:
+            raise StorageBackendError(
+                f"unknown storage action '{action}' (push|pull|list|delete)"
+            )
+    except Exception as exc:  # noqa: BLE001
+        reporter.emit("error", message=f"dataset-storage failed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/studio-backend/src/wake_training_service/app.py
+++ b/apps/studio-backend/src/wake_training_service/app.py
@@ -25,6 +25,9 @@ class JobCreate(BaseModel):
     moduleId: str
     id: str | None = None
     params: dict[str, str] = Field(default_factory=dict)
+    #: job-scoped env vars (e.g. cloud keys for dataset push jobs, Q-DS-3).
+    #: Passed to the subprocess env ONLY, never persisted in the job record.
+    secrets: dict[str, str] = Field(default_factory=dict)
 
 
 def create_app(manager: JobManager, auth: Auth, instance: str = "long-term") -> FastAPI:
@@ -116,7 +119,7 @@ def create_app(manager: JobManager, auth: Auth, instance: str = "long-term") -> 
             raise HTTPException(status_code=409, detail=f"job '{job_id}' already exists")
         job = Job(id=job_id, module_id=body.moduleId, params=body.params)
         try:
-            manager.create_job(job)
+            manager.create_job(job, secrets=body.secrets or None)
         except Exception as exc:  # noqa: BLE001
             raise handle(exc)
         return job.to_api()

--- a/apps/studio-backend/src/wake_training_service/cli.py
+++ b/apps/studio-backend/src/wake_training_service/cli.py
@@ -38,6 +38,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--db", default="data/wake-service.db", help="SQLite job store path")
     p.add_argument("--artifacts-dir", default="data/artifacts",
                    help="where trained artifacts are stored (sha256-indexed)")
+    p.add_argument("--datasets-dir", default="data/datasets",
+                   help="where first-class datasets are stored (survives restarts, ADR-044 #204)")
     p.add_argument("--max-artifacts-mb", type=int, default=0,
                    help="prune oldest artifacts above this total size (0 = unlimited)")
     p.add_argument("--registry", default=None,
@@ -83,6 +85,7 @@ def main(argv: list[str] | None = None) -> int:
         heartbeat_timeout=args.heartbeat_timeout,
         max_artifacts_mb=args.max_artifacts_mb,
         staged_dir=args.staged_dir,
+        datasets_dir=args.datasets_dir,
     )
     app = create_app(manager, auth, instance=args.instance)
 

--- a/apps/studio-backend/src/wake_training_service/manager.py
+++ b/apps/studio-backend/src/wake_training_service/manager.py
@@ -25,6 +25,7 @@ from .ndjson import parse_report_line
 from .registry import Registry, RegistryError
 from .staging import ModuleStager
 from .store import Store
+from wake_train_kit.dataset_store import DatasetStore
 
 TERM_GRACE_SECONDS = 5.0
 
@@ -44,6 +45,7 @@ class JobManager:
         max_artifacts_mb: int = 0,
         staged_dir: str | Path | None = None,
         stager: ModuleStager | None = None,
+        datasets_dir: str | Path | None = None,
     ) -> None:
         self.store = store
         self.registry = registry
@@ -52,6 +54,13 @@ class JobManager:
         self.concurrency = max(1, concurrency)
         self.heartbeat_timeout = heartbeat_timeout
         self.max_artifacts_mb = max_artifacts_mb
+        #: durable datasets/ store (ADR-044, #204): generated dataset zips are
+        #: persisted here across restarts, mirroring the artifacts store. None
+        #: when the service is started without a datasets dir.
+        self.datasets_dir = Path(datasets_dir) if datasets_dir else None
+        self.dataset_store = (
+            DatasetStore(self.datasets_dir) if self.datasets_dir is not None else None
+        )
         #: generic-runtime module staging (Colab: no repo checkout); None when
         #: the service runs against a local repo checkout (self-hosted)
         self._stager = stager or (
@@ -68,6 +77,9 @@ class JobManager:
         self._subscribers: list[asyncio.Queue] = []
         self._stopping = False
         self._started = False
+        #: job-scoped secrets (cloud keys, Q-DS-3): passed to the subprocess
+        #: env ONLY, held in memory, never persisted (ADR-013 tension).
+        self._job_secrets: dict[str, dict[str, str]] = {}
 
     # --- lifecycle ----------------------------------------------------------
     async def start(self) -> bool:
@@ -111,12 +123,15 @@ class JobManager:
             self.store.update_job(job)
 
     # --- public API (called by FastAPI routes) -----------------------------
-    def create_job(self, job: Job) -> Job:
+    def create_job(self, job: Job, secrets: dict[str, str] | None = None) -> Job:
         if not self.registry.has(job.module_id):
             raise JobError(f"unknown module '{job.module_id}' (not in registry)")
         job.status = JobStatus.QUEUED
         job.touch()
         self.store.create_job(job)
+        if secrets:
+            # job-scoped env only: held in memory, NEVER persisted (Q-DS-3).
+            self._job_secrets[job.id] = dict(secrets)
         self._enqueue_id(job.id)
         self._publish(job)
         return job
@@ -168,11 +183,18 @@ class JobManager:
             except OSError:
                 pass
         shutil.rmtree(self.artifacts_dir / job_id, ignore_errors=True)
+        if self.dataset_store is not None:
+            # drop the stored dataset copy too (mirrors artifact cleanup)
+            for record in self.dataset_store.list():
+                stored = Path(record["stored_path"])
+                if job_id in stored.parts:
+                    self.dataset_store.delete(record["id"])
         self.store.delete_job(job_id)
         self._pending.pop(job_id, None)
         self._tasks.pop(job_id, None)
         self._last_activity.pop(job_id, None)
         self._cwd.pop(job_id, None)
+        self._job_secrets.pop(job_id, None)
 
     # --- worker -------------------------------------------------------------
     def _enqueue_id(self, job_id: str) -> None:
@@ -214,7 +236,8 @@ class JobManager:
                     self.registry.entry(job.module_id), self.registry.base_dir
                 )
             cmd, cwd, env = self.registry.resolve(
-                job.module_id, job.params, staged=staged
+                job.module_id, job.params, staged=staged,
+                secrets=self._job_secrets.get(job.id),
             )
         except RegistryError as exc:
             job.set_status(JobStatus.FAILED, error=str(exc))
@@ -358,6 +381,15 @@ class JobManager:
         if src.name not in job.artifacts:
             job.artifacts.append(src.name)
         self._prune_artifacts()
+        # A canonical dataset zip produced by a dataset-generate job is also a
+        # FIRST-CLASS dataset: persist it into the durable datasets/ store
+        # (mirrors the artifacts store; survives restarts, ADR-044 #204).
+        if src.name == "wake-studio-dataset.zip" and self.dataset_store is not None:
+            try:
+                self.dataset_store.save(dest)
+            except Exception as exc:  # noqa: BLE001 - never fail the job for a store issue
+                if job.error is None:
+                    job.error = f"dataset store: {exc}"
 
     def _prune_artifacts(self) -> None:
         if not self.max_artifacts_mb:

--- a/apps/studio-backend/src/wake_training_service/registry.py
+++ b/apps/studio-backend/src/wake_training_service/registry.py
@@ -85,12 +85,19 @@ class Registry:
         module_id: str,
         params: dict[str, str],
         staged: tuple[Path, dict[str, str]] | None = None,
+        secrets: dict[str, str] | None = None,
     ) -> tuple[list[str], str, dict[str, str]]:
         """-> (command list, cwd, env dict) for the train subprocess.
 
         ``staged`` = (cwd, env overrides) from ModuleStager for generic
         runtimes without a repo checkout; it replaces the entry cwd resolution
         and merges extra env vars (e.g. UPSTREAM_DIR for vendored upstreams).
+
+        ``secrets`` = job-scoped env vars (e.g. cloud keys for dataset push
+        jobs, Q-DS-3). They are merged into the subprocess env BEFORE the
+        entry env templates render (so ``{env.X}`` templates can reference
+        them), but are never part of ``params`` / the persisted job record —
+        the manager holds them in memory only.
         """
         entry = self.entry(module_id)
 
@@ -106,6 +113,8 @@ class Registry:
             raise RegistryError(f"module '{module_id}' cwd does not exist: {cwd}")
 
         env = dict(os.environ)
+        if secrets:
+            env.update(secrets)  # job-scoped only; never persisted
         for k, v in entry.get("env", {}).items():
             env[k] = _render(v, params, env)
         if staged is not None:

--- a/apps/studio-backend/tests/fake_train.py
+++ b/apps/studio-backend/tests/fake_train.py
@@ -40,6 +40,11 @@ signal.signal(signal.SIGTERM, handle_term)
 emit({"event": "log", "level": "info",
       "message": f"fake train start steps={STEPS} stall={STALL} fail={FAIL}"})
 
+# Optional secret echo (tests: job-scoped env reaches the subprocess).
+for _k, _v in sorted(os.environ.items()):
+    if _k.startswith("WAKE_ECHO_"):
+        emit({"event": "log", "level": "info", "message": f"echo {_k}={_v}"})
+
 if STALL:
     time.sleep(3600)  # no output at all -> heartbeat timeout marks the job failed
     sys.exit(0)

--- a/apps/studio-backend/tests/test_dataset_store.py
+++ b/apps/studio-backend/tests/test_dataset_store.py
@@ -1,0 +1,141 @@
+"""wake_train_kit.dataset_store tests (ADR-044 #204).
+
+No network / no GPU: dataset zips are built in-memory with the stdlib zipfile
+(matching test_dataset.py helpers). Covers: save/get/list/delete round-trip,
+restart persistence (a fresh DatasetStore over the same dir sees the data),
+duplicate-save upsert, invalid-zip rejection, and sha256/size registration.
+"""
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from wake_train_kit import dataset as ds
+from wake_train_kit.dataset_store import DatasetStore, DatasetStoreError
+
+
+def _valid_manifest(**overrides) -> dict:
+    m = {
+        "schemaVersion": ds.DATASET_MANIFEST_SCHEMA_VERSION,
+        "id": "ds-1",
+        "name": "wake-words-zh-en",
+        "version": 1,
+        "kind": "generated",
+        "role": "mixed",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": ds.CANONICAL_ENCODING, "clips": 3, "durationSec": 6},
+        "labels": [
+            {"name": "hey_studio", "role": "positive"},
+            {"name": "noise", "role": "noise"},
+        ],
+        "provenance": [
+            {"name": "edge-tts synthetic speech", "license": "user-owned (synthetic TTS)", "commercialUse": True}
+        ],
+        "recipe": {"engine": "edge-tts", "seed": 0},
+        "createdAtMs": 1700000000000,
+    }
+    m.update(overrides)
+    return m
+
+
+def _write_zip(tmp_path: Path, manifest: dict, clips=None) -> Path:
+    clips = clips or {
+        "hey_studio": {"a.wav": b"RIFFfakewav", "b.wav": b"RIFFfakewav"},
+        "noise": {"bg.wav": b"RIFFfakewav"},
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("dataset.json", json.dumps(manifest))
+        for label, clip_map in clips.items():
+            for name, bytes_ in clip_map.items():
+                zf.writestr(f"audio/{label}/{name}", bytes_)
+    p = tmp_path / "wake-studio-dataset.zip"
+    p.write_bytes(buf.getvalue())
+    return p
+
+
+def test_save_registers_and_round_trips(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    zip_path = _write_zip(tmp_path, _valid_manifest())
+
+    record = store.save(zip_path)
+    assert record["id"] == "ds-1"
+    assert record["sha256"]
+    assert len(record["sha256"]) == 64
+    assert record["size_bytes"] == zip_path.stat().st_size
+    assert record["manifest"]["id"] == "ds-1"
+
+    # canonical layout: datasets/<id>/wake-studio-dataset.zip
+    stored = Path(record["stored_path"])
+    assert stored.is_file()
+    assert stored.relative_to(tmp_path / "datasets").parts == ("ds-1", "wake-studio-dataset.zip")
+
+    got = store.get("ds-1")
+    assert got is not None
+    assert got["name"] == "wake-words-zh-en"
+    assert store.path("ds-1") == stored
+    assert store.load_manifest("ds-1")["labels"][0]["name"] == "hey_studio"
+    store.close()
+
+
+def test_persists_across_restarts(tmp_path):
+    """A fresh DatasetStore over the same dir sees prior data (survives restart)."""
+    zip_path = _write_zip(tmp_path, _valid_manifest())
+    s1 = DatasetStore(tmp_path / "datasets")
+    s1.save(zip_path)
+    s1.close()
+
+    s2 = DatasetStore(tmp_path / "datasets")
+    records = s2.list()
+    assert [r["id"] for r in records] == ["ds-1"]
+    assert s2.get("ds-1") is not None
+    assert s2.path("ds-1").is_file()
+    s2.close()
+
+
+def test_delete_removes_file_and_index(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    store.save(_write_zip(tmp_path, _valid_manifest()))
+    assert store.get("ds-1") is not None
+
+    store.delete("ds-1")
+    assert store.get("ds-1") is None
+    assert store.path("ds-1") is None
+    assert not (tmp_path / "datasets" / "ds-1").exists()
+    store.close()
+
+
+def test_duplicate_save_upserts_same_id(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    store.save(_write_zip(tmp_path, _valid_manifest(version=1)))
+    store.save(_write_zip(tmp_path, _valid_manifest(version=2)))
+    got = store.get("ds-1")
+    assert got["version"] == 2
+    assert len(store.list()) == 1
+    store.close()
+
+
+def test_save_rejects_invalid_zip(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    bad = tmp_path / "bad.zip"
+    bad.write_bytes(b"not a zip")
+    with pytest.raises(DatasetStoreError, match="invalid dataset zip"):
+        store.save(bad)
+    store.close()
+
+
+def test_save_rejects_missing_file(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    with pytest.raises(DatasetStoreError, match="dataset zip not found"):
+        store.save(tmp_path / "nope.zip")
+    store.close()
+
+
+def test_list_orders_newest_first(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    store.save(_write_zip(tmp_path, _valid_manifest(id="a", createdAtMs=1000)))
+    store.save(_write_zip(tmp_path, _valid_manifest(id="b", createdAtMs=2000)))
+    assert [r["id"] for r in store.list()] == ["b", "a"]
+    store.close()

--- a/apps/studio-backend/tests/test_storage.py
+++ b/apps/studio-backend/tests/test_storage.py
@@ -1,0 +1,158 @@
+"""wake_train_kit.storage tests (ADR-044 §5.3, #204).
+
+No real cloud: backend-disk + url (file://) are exercised for real; hf/r2/gdrive
+are checked as REGISTERED descriptors that raise a clear error when their SDK is
+missing; a FAKE in-memory adapter proves the interface + registry end-to-end.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from wake_train_kit.storage import (
+    STORAGE_REGISTRY,
+    ALL_CAPABILITIES,
+    BackendDiskStorage,
+    CloudflareR2Storage,
+    GoogleDriveStorage,
+    HuggingFaceStorage,
+    StorageBackend,
+    StorageBackendError,
+    StorageRegistry,
+    UrlStorage,
+)
+
+
+def test_builtin_descriptors_and_authkeys():
+    """Each storage plugin declares its authKey + capabilities (Settings group)."""
+    by_id = {d["id"]: d for d in STORAGE_REGISTRY.descriptors()}
+    assert set(by_id) == {"backend-disk", "hf", "r2", "gdrive", "url"}
+
+    assert by_id["backend-disk"]["kind"] == "local"
+    assert by_id["backend-disk"]["authKey"] is None
+    assert set(by_id["backend-disk"]["capabilities"]) == set(ALL_CAPABILITIES)
+
+    assert by_id["hf"]["authKey"] == "cloud.hf"
+    assert by_id["r2"]["authKey"] == "cloud.r2"
+    assert by_id["gdrive"]["authKey"] == "cloud.gdrive"
+    assert by_id["url"]["authKey"] is None
+    assert by_id["url"]["capabilities"] == ["pull"]  # read-only
+
+    assert all(d["format"] == "zip" for d in by_id.values())
+
+
+def test_registry_get_and_unknown():
+    backend = STORAGE_REGISTRY.get("backend-disk")
+    assert isinstance(backend, BackendDiskStorage)
+    assert backend.id == "backend-disk"
+
+    with pytest.raises(StorageBackendError, match="unknown storage backend 'nope'"):
+        STORAGE_REGISTRY.get("nope")
+
+
+def test_backend_disk_push_pull_list_delete(tmp_path):
+    registry = StorageRegistry()
+    registry.register(BackendDiskStorage)
+    disk = registry.get("backend-disk")
+    base = tmp_path / "base"
+    creds = {"dir": str(base)}
+
+    src = tmp_path / "src.zip"
+    src.write_bytes(b"zipdata")
+
+    ref = disk.push(src, "datasets/ds-1/wake-studio-dataset.zip", creds)
+    assert ref == "datasets/ds-1/wake-studio-dataset.zip"
+    assert (base / ref).read_bytes() == b"zipdata"
+
+    # list under a prefix
+    refs = disk.list("datasets/", creds)
+    assert refs == ["datasets/ds-1/wake-studio-dataset.zip"]
+
+    # pull back out
+    out = tmp_path / "out.zip"
+    disk.pull(ref, out, creds)
+    assert out.read_bytes() == b"zipdata"
+
+    # delete
+    disk.delete(ref, creds)
+    assert disk.list("datasets/", creds) == []
+
+
+def test_url_backend_pull_file_and_read_only(tmp_path):
+    registry = StorageRegistry()
+    registry.register(UrlStorage)
+    url = registry.get("url")
+    assert "push" not in url.capabilities
+
+    src = tmp_path / "public.zip"
+    src.write_bytes(b"remote-bytes")
+    dest = tmp_path / "downloaded.zip"
+    pulled = url.pull(src.as_uri(), dest, {})
+    assert pulled == dest
+    assert dest.read_bytes() == b"remote-bytes"
+
+    with pytest.raises(StorageBackendError, match="does not support 'push'"):
+        url.push(src, "x", {})
+    with pytest.raises(StorageBackendError, match="does not support 'delete'"):
+        url.delete("x", {})
+
+
+def test_cloud_adapters_raise_clear_error_without_sdk(monkeypatch):
+    """hf/r2/gdrive are registered; without their SDK they fail loudly, never
+    silently no-op. (Real SDK calls land with issue #107 — no real cloud here.)"""
+    import wake_train_kit.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "_importable", lambda name: False)
+    for backend_id in ("hf", "r2", "gdrive"):
+        backend = STORAGE_REGISTRY.get(backend_id)
+        with pytest.raises(StorageBackendError, match="requires"):
+            backend.push("x.zip", "dest", {})
+
+
+def test_fake_adapter_through_registry(tmp_path):
+    """A fake adapter (no real cloud) proves the interface end-to-end."""
+
+    class FakeCloud(StorageBackend):
+        id = "fake"
+        kind = "fake-cloud"
+        authKey = "cloud.fake"
+        capabilities = ALL_CAPABILITIES
+        store: dict[str, bytes] = {}
+
+        def _push(self, src, dest, creds):
+            FakeCloud.store[dest] = Path(src).read_bytes()
+            return dest
+
+        def _pull(self, src, dest, creds):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(FakeCloud.store[src])
+            return dest
+
+        def _list(self, prefix, creds):
+            return sorted(k for k in FakeCloud.store if k.startswith(prefix))
+
+        def _delete(self, ref, creds):
+            FakeCloud.store.pop(ref, None)
+
+    registry = StorageRegistry()
+    registry.register(FakeCloud)
+    assert registry.has("fake")
+    assert registry.get("fake").descriptor()["authKey"] == "cloud.fake"
+
+    fake = registry.get("fake")
+    src = tmp_path / "ds.zip"
+    src.write_bytes(b"payload")
+    ref = fake.push(src, "datasets/ds-1.zip", {"token": "k"})
+    assert fake.list("datasets/", {}) == ["datasets/ds-1.zip"]
+    out = tmp_path / "back.zip"
+    fake.pull(ref, out, {})
+    assert out.read_bytes() == b"payload"
+    fake.delete(ref, {})
+    assert fake.list("", {}) == []
+
+
+def test_registry_duplicate_rejected():
+    registry = StorageRegistry()
+    registry.register(BackendDiskStorage)
+    with pytest.raises(StorageBackendError, match="duplicate storage backend id"):
+        registry.register(BackendDiskStorage)

--- a/apps/studio-backend/tests/test_storage_runner.py
+++ b/apps/studio-backend/tests/test_storage_runner.py
@@ -1,0 +1,184 @@
+"""wake_train_kit.storage_runner + job-scoped secrets tests (ADR-044 #204).
+
+Covers the `dataset-storage` job entry (registry + runner) and the ADR-013
+tension / Q-DS-3 rule: cloud keys are passed as job-scoped env only and never
+land in the persisted job record. A fake in-memory storage backend exercises
+push/pull/list/delete without any real cloud.
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from wake_train_kit.storage import StorageBackend, StorageBackendError, StorageRegistry
+from wake_train_kit.storage_runner import read_creds, read_params, main as runner_main
+
+
+# --- runner param/creds parsing -------------------------------------------------
+
+def test_read_params_env_and_json():
+    env = {
+        "STORAGE_ACTION": "pull",
+        "STORAGE_BACKEND": "backend-disk",
+        "STORAGE_SRC": "datasets/a.zip",
+        "STORAGE_DEST": "/tmp/out.zip",
+        "STORAGE_PREFIX": "datasets/",
+        "WAKE_PARAMS": json.dumps({"action": "push", "src": "ignored"}),
+    }
+    params = read_params(env)
+    # explicit env wins over WAKE_PARAMS
+    assert params["action"] == "pull"
+    assert params["backend"] == "backend-disk"
+    assert params["src"] == "datasets/a.zip"
+
+
+def test_read_creds_only_from_env():
+    env = {"STORAGE_CREDS_token": "hf_secret", "STORAGE_CREDS_ACCESS_KEY_ID": "AKIA",
+           "SOME_OTHER": "x"}
+    creds = read_creds(env)
+    assert creds == {"token": "hf_secret", "access_key_id": "AKIA"}
+    assert "SOME_OTHER" not in creds
+
+
+def test_runner_unknown_backend(tmp_path, monkeypatch):
+    class _Reporter:
+        def __init__(self):
+            self.events = []
+        def emit(self, event, **fields):
+            self.events.append({"event": event, **fields})
+
+    reporter = _Reporter()
+    monkeypatch.setattr("wake_train_kit.storage_runner.Reporter", lambda: reporter)
+    monkeypatch.setattr(os, "environ", {"STORAGE_BACKEND": "nope", "STORAGE_ACTION": "push"})
+    assert runner_main([]) == 1
+    assert any(e.get("event") == "error" and "unknown storage backend" in str(e) for e in reporter.events)
+
+
+def test_runner_push_requires_src(tmp_path, monkeypatch):
+    class _Reporter:
+        def __init__(self):
+            self.events = []
+        def emit(self, event, **fields):
+            self.events.append({"event": event, **fields})
+
+    reporter = _Reporter()
+    monkeypatch.setattr("wake_train_kit.storage_runner.Reporter", lambda: reporter)
+    monkeypatch.setattr(os, "environ", {"STORAGE_ACTION": "push", "STORAGE_BACKEND": "backend-disk"})
+    assert runner_main([]) == 1
+
+
+# --- registry entry + job-scoped secrets via the job manager --------------------
+
+def test_registry_has_dataset_storage_entry():
+    from wake_training_service.registry import Registry
+    reg = Registry.load("registry.json")
+    assert reg.has("dataset-storage")
+    cmd, cwd, env = reg.resolve("dataset-storage", {"action": "push", "backend": "backend-disk",
+                                                    "src": "x.zip", "dest": "datasets/a.zip"})
+    assert "storage_runner.py" in cmd[-1]
+    assert env["STORAGE_ACTION"] == "push"
+    assert env["STORAGE_BACKEND"] == "backend-disk"
+
+
+def test_job_secrets_env_only_never_persisted(store, workdir, artifacts_dir, tmp_path):
+    """Cloud keys pass as subprocess env only; the persisted job has no secrets.
+
+    Uses the 'fake' train script to echo the environment, proving the manager
+    forwards secrets to the subprocess while keeping them out of SQLite.
+    """
+    import time
+
+    from wake_training_service.manager import JobManager
+    from wake_training_service.models import Job, JobStatus
+    from wake_training_service.registry import Registry
+
+    registry = Registry({"fake": {"cwd": str(workdir), "engine": "direct",
+                                  "entry": "fake_train.py",
+                                  "env": {"WAKE_ECHO_SECRET": "{env.CLOUD_TOKEN}"}}})
+    mgr = JobManager(store, registry, artifacts_dir, concurrency=1)
+
+    async def scenario():
+        await mgr.start()
+        try:
+            job = mgr.create_job(
+                Job(id="secret-job", module_id="fake", params={"steps": "1"}),
+                secrets={"CLOUD_TOKEN": "sk-super-secret"},
+            )
+            assert job.status is JobStatus.QUEUED
+            # Persisted record must NOT contain the secret (params only).
+            persisted = store.get_job("secret-job")
+            assert "sk-super-secret" not in json.dumps(persisted.to_row())
+            assert "CLOUD_TOKEN" not in json.dumps(persisted.to_row())
+            # wait for the job to finish
+            deadline = time.monotonic() + 10.0
+            while True:
+                j = store.get_job("secret-job")
+                if j is None or j.status in (JobStatus.SUCCEEDED, JobStatus.FAILED):
+                    break
+                if time.monotonic() > deadline:
+                    raise AssertionError("job did not finish")
+                await asyncio.sleep(0.05)
+            return store.get_job("secret-job")
+        finally:
+            await mgr.stop()
+
+    persisted = asyncio.run(scenario())
+    assert persisted is not None
+    assert persisted.status is JobStatus.SUCCEEDED
+    assert "sk-super-secret" in "\n".join(persisted.log)  # subprocess saw the env
+
+
+def test_fake_storage_via_runner_end_to_end(tmp_path, monkeypatch):
+    """A fake backend registered into a registry runs push/pull through the runner."""
+
+    class Fake(StorageBackend):
+        id = "fake-store"
+        kind = "fake"
+        authKey = None
+        capabilities = frozenset({"push", "pull", "list", "delete"})
+        data: dict[str, bytes] = {}
+
+        def _push(self, src, dest, creds):
+            Fake.data[dest] = Path(src).read_bytes()
+            return dest
+
+        def _pull(self, src, dest, creds):
+            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            Path(dest).write_bytes(Fake.data[src])
+            return str(dest)
+
+        def _list(self, prefix, creds):
+            return sorted(k for k in Fake.data if k.startswith(prefix))
+
+        def _delete(self, ref, creds):
+            Fake.data.pop(ref, None)
+
+    import wake_train_kit.storage_runner as sr
+    registry = StorageRegistry()
+    registry.register(Fake)
+    monkeypatch.setattr(sr, "STORAGE_REGISTRY", registry)
+
+    src = tmp_path / "ds.zip"
+    src.write_bytes(b"zip")
+
+    class _Reporter:
+        def __init__(self):
+            self.events = []
+        def emit(self, event, **fields):
+            self.events.append({"event": event, **fields})
+
+    reporter = _Reporter()
+    monkeypatch.setattr(sr, "Reporter", lambda: reporter)
+    monkeypatch.setattr(os, "environ", {
+        "STORAGE_ACTION": "push", "STORAGE_BACKEND": "fake-store",
+        "STORAGE_SRC": str(src), "STORAGE_DEST": "datasets/ds-1.zip",
+        "STORAGE_CREDS_TOKEN": "job-scoped-only",
+    })
+    assert runner_main([]) == 0
+    done = [e for e in reporter.events if e["event"] == "done"]
+    assert done and done[0]["ref"] == "datasets/ds-1.zip"
+    assert Fake.data["datasets/ds-1.zip"] == b"zip"
+    assert not any("TOKEN" in str(e) for e in reporter.events)

--- a/apps/web/src/components/ConsoleShell.tsx
+++ b/apps/web/src/components/ConsoleShell.tsx
@@ -26,6 +26,7 @@ const VIEW_TITLES: Record<ConsoleRoute, string> = {
   'settings-general': 'Settings · General',
   'settings-security': 'Settings · Security',
   'settings-data': 'Settings · Data',
+  'settings-cloud': 'Settings · Cloud storage',
   'settings-modules': 'Settings · Modules',
   'device-sdk': 'Device SDK',
 }

--- a/apps/web/src/components/shell-nav.ts
+++ b/apps/web/src/components/shell-nav.ts
@@ -46,6 +46,7 @@ export const PRIMARY_NAV: NavItem[] = [
 export const SETTINGS_NAV: SettingsNavItem[] = [
   { route: settingsRoute('general'), label: 'General' },
   { route: settingsRoute('security'), label: 'Security' },
+  { route: settingsRoute('cloud'), label: 'Cloud storage' },
   { route: settingsRoute('data'), label: 'Data' },
 ]
 

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -26,11 +26,12 @@ export type ConsoleRoute =
   | 'settings-general'
   | 'settings-security'
   | 'settings-data'
+  | 'settings-cloud'
   | 'settings-modules'
   | 'device-sdk'
 
 /** Settings sub-views (driven from the sidebar sub-menu). */
-export type SettingsSection = 'general' | 'security' | 'data' | 'modules'
+export type SettingsSection = 'general' | 'security' | 'data' | 'cloud' | 'modules'
 
 export const DEFAULT_ROUTE: ConsoleRoute = 'workspace'
 
@@ -46,6 +47,7 @@ const ROUTE_BY_HASH: Record<string, ConsoleRoute> = {
   '/settings/general': 'settings-general',
   '/settings/security': 'settings-security',
   '/settings/data': 'settings-data',
+  '/settings/cloud': 'settings-cloud',
   '/settings/modules': 'settings-modules',
   '/device-sdk': 'device-sdk',
   '': 'workspace',
@@ -99,6 +101,8 @@ export function routeToHash(route: ConsoleRoute): string {
       return '/settings/security'
     case 'settings-data':
       return '/settings/data'
+    case 'settings-cloud':
+      return '/settings/cloud'
     case 'settings-modules':
       return '/settings/modules'
     case 'device-sdk':
@@ -115,6 +119,8 @@ export function settingsRoute(section: SettingsSection): ConsoleRoute {
       return 'settings-security'
     case 'data':
       return 'settings-data'
+    case 'cloud':
+      return 'settings-cloud'
     case 'modules':
       return 'settings-modules'
   }
@@ -129,6 +135,8 @@ export function settingsSectionOf(route: ConsoleRoute): SettingsSection | undefi
       return 'security'
     case 'settings-data':
       return 'data'
+    case 'settings-cloud':
+      return 'cloud'
     case 'settings-modules':
       return 'modules'
     default:

--- a/apps/web/src/settings/__tests__/storage.test.ts
+++ b/apps/web/src/settings/__tests__/storage.test.ts
@@ -227,4 +227,30 @@ describe('export/import/reset', () => {
     expect(isSecretSetting('backend.secret')).toBe(true)
     expect(isSecretSetting('theme')).toBe(false)
   })
+
+  it('cloud storage group: descriptors exist + secrets are masked on export (#204)', () => {
+    const cloudIds = PLATFORM_SETTING_IDS.filter((id) => id.startsWith('cloud.'))
+    expect(cloudIds.sort()).toEqual([
+      'cloud.gdrive.clientId',
+      'cloud.gdrive.clientSecret',
+      'cloud.hf.token',
+      'cloud.r2.accessKeyId',
+      'cloud.r2.bucket',
+      'cloud.r2.endpoint',
+      'cloud.r2.secretAccessKey',
+    ])
+    // secret-typed cloud fields are masked on export
+    expect(isSecretSetting('cloud.hf.token')).toBe(true)
+    expect(isSecretSetting('cloud.r2.secretAccessKey')).toBe(true)
+    expect(isSecretSetting('cloud.gdrive.clientSecret')).toBe(true)
+    // non-secret endpoint/bucket/clientId pass through unmasked
+    const platform = {
+      ...PLATFORM_DEFAULTS,
+      'cloud.hf.token': 'hf_secret',
+      'cloud.r2.endpoint': 'https://x.r2.cloudflarestorage.com',
+    }
+    const payload = buildExportPayload(platform, {}, true)
+    expect(payload.platform['cloud.hf.token']).toBe('••••••••')
+    expect(payload.platform['cloud.r2.endpoint']).toBe('https://x.r2.cloudflarestorage.com')
+  })
 })

--- a/apps/web/src/settings/schema.ts
+++ b/apps/web/src/settings/schema.ts
@@ -11,7 +11,7 @@
 import type { PlatformSettings, PlatformSettingId, SettingDescriptor } from './types'
 
 /** Current schema version. Bump when a field is added/removed. */
-export const SETTINGS_SCHEMA_VERSION = 2
+export const SETTINGS_SCHEMA_VERSION = 3
 
 /** Default platform settings (schemaVersion is explicit so merge works). */
 export const PLATFORM_DEFAULTS: PlatformSettings = {
@@ -22,6 +22,13 @@ export const PLATFORM_DEFAULTS: PlatformSettings = {
   'kws.executionProvider': 'wasm',
   'backend.apiKey': '',
   'backend.secret': '',
+  'cloud.hf.token': '',
+  'cloud.r2.accessKeyId': '',
+  'cloud.r2.secretAccessKey': '',
+  'cloud.r2.endpoint': '',
+  'cloud.r2.bucket': '',
+  'cloud.gdrive.clientId': '',
+  'cloud.gdrive.clientSecret': '',
   'data.upload': false,
   'settings.dataRetention': 'keep',
   'mic.rememberPermission': true,
@@ -105,6 +112,71 @@ export const PLATFORM_SETTING_DESCRIPTORS: ReadonlyArray<SettingDescriptor> = [
     type: 'secret',
     default: '',
     group: 'security',
+  },
+
+  // ---- Cloud storage (ADR-044 §5.3, #204) ----
+  // Each storage plugin declares its authKey in the dataset module's storage
+  // catalog (packages/modules/data/dataset/core/storage.ts): hf -> cloud.hf,
+  // r2 -> cloud.r2, gdrive -> cloud.gdrive. Secrets are masked + client-side
+  // only; backend push jobs receive them as job-scoped env, never persisted.
+  {
+    id: 'cloud.hf.token',
+    label: 'Hugging Face token',
+    description:
+      'Token for the Hugging Face dataset-repo storage backend (authKey "cloud.hf"). Stored locally only; passed to backend push jobs as job-scoped env.',
+    type: 'secret',
+    default: '',
+    group: 'cloud',
+  },
+  {
+    id: 'cloud.r2.accessKeyId',
+    label: 'R2 access key ID',
+    description:
+      'Cloudflare R2 (S3-compatible) access key id (authKey "cloud.r2").',
+    type: 'secret',
+    default: '',
+    group: 'cloud',
+  },
+  {
+    id: 'cloud.r2.secretAccessKey',
+    label: 'R2 secret access key',
+    description: 'Cloudflare R2 secret access key (authKey "cloud.r2").',
+    type: 'secret',
+    default: '',
+    group: 'cloud',
+  },
+  {
+    id: 'cloud.r2.endpoint',
+    label: 'R2 endpoint',
+    description:
+      'Cloudflare R2 S3-compatible endpoint, e.g. https://<account>.r2.cloudflarestorage.com',
+    type: 'string',
+    default: '',
+    group: 'cloud',
+  },
+  {
+    id: 'cloud.r2.bucket',
+    label: 'R2 bucket',
+    description: 'Cloudflare R2 bucket name holding datasets.',
+    type: 'string',
+    default: '',
+    group: 'cloud',
+  },
+  {
+    id: 'cloud.gdrive.clientId',
+    label: 'Google Drive client ID',
+    description: 'Google Drive OAuth client id (authKey "cloud.gdrive").',
+    type: 'string',
+    default: '',
+    group: 'cloud',
+  },
+  {
+    id: 'cloud.gdrive.clientSecret',
+    label: 'Google Drive client secret',
+    description: 'Google Drive OAuth client secret (authKey "cloud.gdrive").',
+    type: 'secret',
+    default: '',
+    group: 'cloud',
   },
 
   // ---- Data ----

--- a/apps/web/src/settings/types.ts
+++ b/apps/web/src/settings/types.ts
@@ -48,6 +48,21 @@ export interface PlatformSettings {
   'backend.apiKey': string
   /** Secret - stored locally only; masked on export. */
   'backend.secret': string
+  /** Cloud storage credentials (ADR-044 §5.3, #204) - masked secrets, client-side only. */
+  /** Hugging Face token. */
+  'cloud.hf.token': string
+  /** Cloudflare R2 access key id. */
+  'cloud.r2.accessKeyId': string
+  /** Cloudflare R2 secret access key (secret). */
+  'cloud.r2.secretAccessKey': string
+  /** Cloudflare R2 endpoint URL (S3-compatible). */
+  'cloud.r2.endpoint': string
+  /** Cloudflare R2 bucket name. */
+  'cloud.r2.bucket': string
+  /** Google Drive OAuth client id. */
+  'cloud.gdrive.clientId': string
+  /** Google Drive OAuth client secret (secret). */
+  'cloud.gdrive.clientSecret': string
   'data.upload': boolean
   'settings.dataRetention': DataRetention
   'mic.rememberPermission': boolean
@@ -74,5 +89,5 @@ export interface SettingDescriptor {
   default: string | boolean | number
   options?: ReadonlyArray<{ value: string; label: string }>
   /** Group drives the left rail section. */
-  group: 'general' | 'security' | 'data'
+  group: 'general' | 'security' | 'data' | 'cloud'
 }

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -32,6 +32,7 @@ const GROUP_TITLES: Record<SettingsSection, string> = {
   general: 'General',
   security: 'Security',
   data: 'Data',
+  cloud: 'Cloud storage',
   modules: 'Module settings',
 }
 
@@ -40,6 +41,8 @@ const GROUP_DESCRIPTIONS: Record<SettingsSection, string> = {
   security:
     'Backend connection + credentials. Stored locally only; never sent. Changes apply on Save.',
   data: 'Local data preferences and future data-source gates. Changes apply on Save.',
+  cloud:
+    'Optional cloud storage credentials for datasets (ADR-044 §5.3). Masked secrets, stored locally only; backend push jobs receive them as job-scoped env, never persisted. Changes apply on Save.',
   modules:
     'Per-driver defaults from the module specs (ADR-025). The active project can override these per project. Changes apply on Save.',
 }
@@ -151,6 +154,13 @@ export function SettingsView({
         {section === 'security' && (
           <p className="rounded-lg border border-line bg-surface-3 px-3 py-2 text-xs text-ink-3">
             Credentials never leave this browser. Changes apply on Save.
+          </p>
+        )}
+        {section === 'cloud' && (
+          <p className="rounded-lg border border-line bg-surface-3 px-3 py-2 text-xs text-ink-3">
+            Cloud keys are optional. They stay in this browser, are masked on
+            export, and are passed to backend dataset push jobs as job-scoped
+            env only — never persisted (Q-DS-3).
           </p>
         )}
       </div>

--- a/docs/modules/data-sources.md
+++ b/docs/modules/data-sources.md
@@ -207,6 +207,14 @@ auth key:
   "capabilities": ["push", "pull", "list", "delete"], "format": "zip" }
 ```
 
+**Implemented (#204):** `StorageBackend` interface + registry in
+`apps/studio-backend/src/wake_train_kit/storage.py` (ADR-033 self-registration; the TS
+catalog/types live in `packages/modules/data/dataset/core/storage.ts`). `backend-disk` and
+`url` (read-only pull) are fully implemented; `hf` / `r2` / `gdrive` are registered with
+their descriptors + authKey and raise a clear "requires <sdk>" error until real SDK wiring
+(issue #107 / push-job console #208). A `dataset-storage` job entry runs push/pull/list/
+delete on the job manager; tests use FAKE adapters (no real cloud).
+
 **Credentials** live in Settings (new "Cloud storage" group), client-side, masked, never logged
 or exported - the same guarantees as the existing `backend.apiKey` / `backend.secret`.
 **ADR-013 tension (open, Q-DS-3):** a *backend* job pushing to cloud needs the key server-side.
@@ -360,7 +368,7 @@ license/provenance log shown in-app before export. The Datasets console shows th
 |---|---|---|
 | Q-DS-1 | Canonical default public-TTS endpoint(s) to ship pre-configured | **Answered (2026-08-14):** edge-tts is the default multi-language TTS path (studio-backend `tts` extra); Speech Commands V2 (CC BY 4.0) is the default corpus. Piper remains an option for the openwakeword path. |
 | Q-DS-2 | Whether project server APIs are WakeStudio-hosted or community/self-hosted | Resolved at Phase 5 start. |
-| Q-DS-3 | Cloud keys for backend-originated push jobs (ADR-013 tension) | Job-scoped env var only, never persisted (precedent: Colab notebook keys). |
+| Q-DS-3 | Cloud keys for backend-originated push jobs (ADR-013 tension) | **Implemented (#204):** job-scoped env var only, never persisted — the job manager accepts a `secrets` map passed to the subprocess env but excluded from the persisted job record (precedent: Colab notebook keys). |
 | Q-DS-4 | Exact v1 built-in dataset catalog list | SC2 + Common Voice + Google Speech Commands + AudioSet/FMA noise (SS7). |
 | Q-DS-5 | Near-duplicate detection threshold for the leakage guard | Tune at implementation; start with exact-hash + conservative perceptual hash. |
 
@@ -383,3 +391,4 @@ license/provenance log shown in-app before export. The Datasets console shows th
 | 2026-08-20 | **Datasets as first-class artifacts (design locked, human discussion):** full spec written - `dataset.json` manifest + canonical `label/*.wav` tree + one importer (SS4); `dataset-generate` jobs with pluggable TTS engine / storage / postprocess plugins, split by concern not vendor (SS5); per-trainer materializers + `spec.train.dataset` compatibility (SS6); built-in catalog (SS7); Datasets console (SS8); quality gate / dedup+split / reproducibility (SS9); provenance chain to the export gate (SS10). Decision points resolved: composable granularity, cloud storage optional (HF / R2 / GDrive with user keys), user-configurable online TTS API+key, new-dataset-equals-new-version, multi-language+noise built-ins. Open: Q-DS-3/4/5. | agent |
 | 2026-08-20 | **#203 — dataset spec implemented (ADR-044):** `packages/modules/data/dataset/` module (`core/spec.ts` manifest schema + validation, `core/hash.ts` canonical contentHash, `core/manifest.ts` single importer with typed `DatasetImportError` codes) + Python mirror `wake_train_kit/dataset.py` (byte-identical hash, verified cross-implementation); vitest + pytest suites; `.gitignore` `data/` anchored to `/data/` so the `data` category module is tracked. Remaining #204-#210 unchanged. | agent |
 | 2026-08-20 | **#205 — dataset generation jobs (ADR-044 §5, human refactor 2026-08-20):** engines are MODULES (`packages/modules/data/{edge-tts,mimo-tts,piper,qwen-llm-tts}/`), each owning `spec/module.spec.json` (`params` -> generated panel, `tts` block = kind/runtime/provenanceTemplate) + `adapter.py` (module-owned backend adapter, loaded at runtime). Contracts gain `ModuleSpec.tts`. Backend pipeline `wake_train_kit/generation.py` (dispatcher + shared postprocess/assemble) + `generation_runner.py` (`dataset-generate` registry entry, NDJSON, canonical zip artifact); shared online/LLM HTTP machinery in `wake_train_kit/http_tts.py`; postprocess transforms (`passthrough` + `openwakeword-style`); catalog `apps/web/public/dataset-engines.json` generated from `spec.tts` via `scripts/build-dataset-engines.mjs` (like `spec.train`); tests (13 backend + dataset). Browser executor + generation wizard land in #208. | agent |
+| 2026-08-20 | **#204 — dataset storage layer (ADR-044 §5.3):** backend `datasets/` store (`wake_train_kit/dataset_store.py`, SQLite index + `datasets/<id>/wake-studio-dataset.zip`, survives restarts, mirrors artifacts store; `dataset-generate` zips auto-persist into it). `StorageBackend` interface + registry + adapters (`backend-disk`/`url` real, `hf`/`r2`/`gdrive` declared with authKey) in `wake_train_kit/storage.py`; `dataset-storage` job entry (`storage_runner.py`). Web Settings gains a masked **Cloud storage** group; storage plugin catalog in `core/storage.ts` (authKey per plugin). Q-DS-3 implemented: cloud keys flow as job-scoped env only, never persisted. Tests: store round-trip, plugin registry, fake adapters (no real cloud). Remaining #206-#210 unchanged. | agent |

--- a/packages/modules/data/dataset/core/index.ts
+++ b/packages/modules/data/dataset/core/index.ts
@@ -55,3 +55,17 @@ export {
   type DatasetEngineCatalog,
   type EngineValidation,
 } from './engines'
+
+export {
+  STORAGE_BACKEND_KINDS,
+  STORAGE_CAPABILITIES,
+  BUILTIN_STORAGE_BACKENDS,
+  validateStorageCatalog,
+  storageBackendById,
+  storageAuthKeys,
+  type StorageBackendKind,
+  type StorageBackendCapability,
+  type StorageBackendDescriptor,
+  type StorageCatalog,
+  type StorageCatalogValidation,
+} from './storage'

--- a/packages/modules/data/dataset/core/storage.ts
+++ b/packages/modules/data/dataset/core/storage.ts
@@ -1,0 +1,106 @@
+/**
+ * Dataset module - storage plugin catalog contract (ADR-044 §5.3, task #204).
+ *
+ * Persistence is a StorageBackend plugin behind one interface (`push` / `pull`
+ * / `list` / `delete`), the storage-side twin of the TTS engine plugins
+ * (ADR-033 self-registration). The BACKEND implementations live in
+ * `wake_train_kit/storage.py`; this module keeps the TYPES + the web-side
+ * catalog each plugin declares its `authKey` (the Settings "Cloud storage"
+ * key holding its credentials, client-side + masked).
+ *
+ * Backends (docs/modules/data-sources.md §5.3):
+ *   backend-disk  local/default, no authKey
+ *   hf            huggingface dataset repo, authKey "cloud.hf"
+ *   r2            cloudflare-r2 (S3-compatible), authKey "cloud.r2"
+ *   gdrive        google drive, authKey "cloud.gdrive"
+ *   url           built-in / public, READ-ONLY (pull only), no authKey
+ */
+
+export type StorageBackendKind =
+  | 'local'
+  | 'huggingface'
+  | 's3-compatible'
+  | 'google-drive'
+  | 'url'
+
+export type StorageBackendCapability = 'push' | 'pull' | 'list' | 'delete'
+
+/** One storage backend entry (the plugin descriptor). */
+export interface StorageBackendDescriptor {
+  id: string
+  kind: StorageBackendKind
+  /** Settings key holding this backend's credentials (None = no creds). */
+  authKey: string | null
+  capabilities: StorageBackendCapability[]
+  format: 'zip'
+}
+
+/** The storage plugin catalog (static built-ins; a generated file can follow
+ *  the engine-catalog pattern once storage becomes module-owned). */
+export interface StorageCatalog {
+  note?: string
+  backends: StorageBackendDescriptor[]
+}
+
+export interface StorageCatalogValidation {
+  ok: boolean
+  errors: string[]
+}
+
+export const STORAGE_BACKEND_KINDS: readonly StorageBackendKind[] = [
+  'local',
+  'huggingface',
+  's3-compatible',
+  'google-drive',
+  'url',
+]
+
+export const STORAGE_CAPABILITIES: readonly StorageBackendCapability[] = [
+  'push',
+  'pull',
+  'list',
+  'delete',
+]
+
+/** Built-in storage backends (mirror of wake_train_kit.storage). */
+export const BUILTIN_STORAGE_BACKENDS: readonly StorageBackendDescriptor[] = [
+  { id: 'backend-disk', kind: 'local', authKey: null, capabilities: ['push', 'pull', 'list', 'delete'], format: 'zip' },
+  { id: 'hf', kind: 'huggingface', authKey: 'cloud.hf', capabilities: ['push', 'pull', 'list', 'delete'], format: 'zip' },
+  { id: 'r2', kind: 's3-compatible', authKey: 'cloud.r2', capabilities: ['push', 'pull', 'list', 'delete'], format: 'zip' },
+  { id: 'gdrive', kind: 'google-drive', authKey: 'cloud.gdrive', capabilities: ['push', 'pull', 'list', 'delete'], format: 'zip' },
+  { id: 'url', kind: 'url', authKey: null, capabilities: ['pull'], format: 'zip' },
+]
+
+/** Validate a storage catalog (unique ids, known kind, valid capabilities). */
+export function validateStorageCatalog(catalog: StorageCatalog): StorageCatalogValidation {
+  const errors: string[] = []
+  const seen = new Set<string>()
+  for (const b of catalog.backends ?? []) {
+    if (!b.id) errors.push('storage backend without id')
+    else if (seen.has(b.id)) errors.push(`duplicate storage backend id: ${b.id}`)
+    seen.add(b.id)
+    if (!STORAGE_BACKEND_KINDS.includes(b.kind)) {
+      errors.push(`storage backend ${b.id}: invalid kind ${b.kind}`)
+    }
+    if (!Array.isArray(b.capabilities) || b.capabilities.length === 0) {
+      errors.push(`storage backend ${b.id}: capabilities must be a non-empty array`)
+    } else if (!b.capabilities.every((c) => STORAGE_CAPABILITIES.includes(c))) {
+      errors.push(`storage backend ${b.id}: invalid capability`)
+    }
+    if (b.format !== 'zip') errors.push(`storage backend ${b.id}: format must be zip`)
+  }
+  return { ok: errors.length === 0, errors }
+}
+
+/** Look up a storage backend in a catalog by id (undefined when unknown). */
+export function storageBackendById(
+  catalog: StorageCatalog,
+  id: string,
+): StorageBackendDescriptor | undefined {
+  return (catalog.backends ?? []).find((b) => b.id === id)
+}
+
+/** All distinct authKeys a storage catalog references (Settings groups). */
+export function storageAuthKeys(catalog: StorageCatalog): string[] {
+  return [...new Set((catalog.backends ?? []).map((b) => b.authKey).filter(Boolean) as string[])]
+}

--- a/packages/modules/data/dataset/spec/module.spec.json
+++ b/packages/modules/data/dataset/spec/module.spec.json
@@ -9,7 +9,7 @@
     "owner": "WakeStudio team",
     "license": "MIT",
     "status": "proposed",
-    "description": "Datasets as first-class artifacts (ADR-044, #203): the dataset.json manifest + canonical label/*.wav form + one importer per world (web TS / backend Python). Generation jobs, storage plugins, materializers, the built-in catalog and the Datasets console land in #204-#210."
+    "description": "Datasets as first-class artifacts (ADR-044, #203-#205): the dataset.json manifest + canonical label/*.wav form + one importer per world (web TS / backend Python); generation jobs with pluggable TTS engines; StorageBackend storage plugins (#204). Materializers, the built-in catalog and the Datasets console land in #206-#210."
   },
   "params": [],
   "actions": [],
@@ -27,7 +27,7 @@
     "entry": "none"
   },
   "interfaces": {
-    "provides": ["DatasetManifest", "DatasetStore"],
+    "provides": ["DatasetManifest", "DatasetStore", "StorageBackend"],
     "consumes": ["DataSources", "TrainingJob", "TTSEngine"]
   }
 }

--- a/packages/modules/data/dataset/tests/storage.test.ts
+++ b/packages/modules/data/dataset/tests/storage.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Dataset module - storage plugin catalog tests (ADR-044 §5.3, #204).
+ *
+ * Covers: built-in catalog validity, authKey declarations (Settings "Cloud
+ * storage"), url read-only, duplicate/missing-id rejection, lookup helpers.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  BUILTIN_STORAGE_BACKENDS,
+  STORAGE_BACKEND_KINDS,
+  validateStorageCatalog,
+  storageBackendById,
+  storageAuthKeys,
+  type StorageCatalog,
+} from '../core/storage'
+
+describe('storage plugin catalog', () => {
+  it('built-in catalog is valid', () => {
+    const { ok, errors } = validateStorageCatalog({ backends: [...BUILTIN_STORAGE_BACKENDS] })
+    expect(errors).toEqual([])
+    expect(ok).toBe(true)
+  })
+
+  it('declares every built-in backend with its authKey', () => {
+    const ids = BUILTIN_STORAGE_BACKENDS.map((b) => b.id)
+    expect(ids).toEqual(['backend-disk', 'hf', 'r2', 'gdrive', 'url'])
+
+    const byId = new Map(BUILTIN_STORAGE_BACKENDS.map((b) => [b.id, b]))
+    // backend-disk (local, no creds) + url (read-only, no creds)
+    expect(byId.get('backend-disk')?.authKey).toBeNull()
+    expect(byId.get('url')?.authKey).toBeNull()
+    expect(byId.get('url')?.capabilities).toEqual(['pull'])
+    // cloud backends point at Settings "Cloud storage" keys
+    expect(byId.get('hf')?.authKey).toBe('cloud.hf')
+    expect(byId.get('r2')?.authKey).toBe('cloud.r2')
+    expect(byId.get('gdrive')?.authKey).toBe('cloud.gdrive')
+  })
+
+  it('all kinds are known', () => {
+    for (const b of BUILTIN_STORAGE_BACKENDS) {
+      expect(STORAGE_BACKEND_KINDS).toContain(b.kind)
+    }
+  })
+
+  it('rejects duplicates and missing ids', () => {
+    const bad: StorageCatalog = {
+      backends: [
+        { id: 'x', kind: 'local', authKey: null, capabilities: ['push'], format: 'zip' },
+        { id: 'x', kind: 'local', authKey: null, capabilities: ['pull'], format: 'zip' },
+        { id: '', kind: 'local', authKey: null, capabilities: ['push'], format: 'zip' },
+      ],
+    }
+    const { ok, errors } = validateStorageCatalog(bad)
+    expect(ok).toBe(false)
+    expect(errors.some((e) => e.includes('duplicate storage backend id: x'))).toBe(true)
+    expect(errors.some((e) => e.includes('without id'))).toBe(true)
+  })
+
+  it('rejects unknown capability/kind/format', () => {
+    const bad: StorageCatalog = {
+      backends: [
+        { id: 'y', kind: 'huggingface', authKey: 'cloud.hf', capabilities: ['fly'], format: 'zip' },
+      ],
+    }
+    const { ok, errors } = validateStorageCatalog(bad)
+    expect(ok).toBe(false)
+    expect(errors.some((e) => e.includes('invalid capability'))).toBe(true)
+  })
+
+  it('looks up by id and collects authKeys', () => {
+    const catalog: StorageCatalog = { backends: [...BUILTIN_STORAGE_BACKENDS] }
+    expect(storageBackendById(catalog, 'r2')?.kind).toBe('s3-compatible')
+    expect(storageBackendById(catalog, 'nope')).toBeUndefined()
+    expect(storageAuthKeys(catalog)).toEqual(['cloud.hf', 'cloud.r2', 'cloud.gdrive'])
+  })
+})

--- a/packages/modules/data/dataset/tests/storage.test.ts
+++ b/packages/modules/data/dataset/tests/storage.test.ts
@@ -12,6 +12,7 @@ import {
   validateStorageCatalog,
   storageBackendById,
   storageAuthKeys,
+  type StorageBackendCapability,
   type StorageCatalog,
 } from '../core/storage'
 
@@ -60,7 +61,7 @@ describe('storage plugin catalog', () => {
   it('rejects unknown capability/kind/format', () => {
     const bad: StorageCatalog = {
       backends: [
-        { id: 'y', kind: 'huggingface', authKey: 'cloud.hf', capabilities: ['fly'], format: 'zip' },
+        { id: 'y', kind: 'huggingface', authKey: 'cloud.hf', capabilities: ['fly'] as unknown as StorageBackendCapability[], format: 'zip' },
       ],
     }
     const { ok, errors } = validateStorageCatalog(bad)


### PR DESCRIPTION
Closes #204

## Summary

Implements the dataset storage layer for epic #202 (Phase 5, ADR-044 §5.3): the backend `datasets/` store, the pluggable `StorageBackend` interface + registry + adapters, a backend `dataset-storage` job entry, the Settings **Cloud storage** group (masked secrets), and the storage plugin catalog.

Docs-first: `docs/modules/data-sources.md` §5.3 + changelog updated; Q-DS-3 marked implemented.

## Backend

- **`datasets/` store** (`wake_train_kit/dataset_store.py`): SQLite-backed, mirrors the artifacts store — `datasets/<id>/wake-studio-dataset.zip` + sha256/size/manifest index, survives restarts. `dataset-generate` zips auto-persist into it (`manager._register_artifact`).
- **`StorageBackend` interface + registry** (`wake_train_kit/storage.py`): `push`/`pull`/`list`/`delete` behind one interface. `backend-disk` + `url` (read-only) fully implemented; `hf`/`r2`/`gdrive` registered with their `authKey` and a clear "requires <sdk>" error until real SDK wiring (issue #107).
- **`dataset-storage` job entry** (`wake_train_kit/storage_runner.py` + `registry.json`): push/pull/list/delete run on the job manager.
- **Q-DS-3 (ADR-013 tension):** cloud keys are job-scoped env ONLY — the job manager accepts a `secrets` map forwarded to the subprocess env but excluded from the persisted job record (never stored in SQLite).

## Web

- Settings gains a masked **Cloud storage** group (`cloud.hf.token`, `cloud.r2.*`, `cloud.gdrive.*`) + a new `settings-cloud` route/sidebar item (schema v3).
- **Storage plugin catalog** (`packages/modules/data/dataset/core/storage.ts`): each backend declares its `authKey` + capabilities; built-in catalog + validation.

## Tests

- Store round-trip + restart persistence, plugin registry, fake storage adapters (no real cloud).
- Job-scoped secrets never persist (verified end-to-end through the manager).
- Backend: 107 tests pass · Web: 228 tests pass · Dataset module: 30 tests pass · typecheck/lint clean.

## Note

No `/datasets` HTTP API in this PR — that belongs to #208 (Datasets console). The storage layer is the foundation.
