### PR TITLE
feat(dataset): built-in dataset catalog (ADR-044 §7, #207)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         # modules' spec.tts (ADR-044 §5); fail CI if they drift.
         run: pnpm gen:engines:check
 
+      - name: Check generated built-in dataset catalog is fresh (#207)
+        # datasets.json is generated from the curated built-ins file
+        # (ADR-044 §7); fail CI if they drift.
+        run: pnpm gen:catalog:check
+
       - name: Fetch L2 test artifacts (sherpa + openwakeword, ADR-027)
         # The L2 wasm/onnx boot tests exercise the gitignored artifacts
         # (ADR-011). Non-fatal: each L2 suite skips when its asset is absent

--- a/apps/studio-backend/pyproject.toml
+++ b/apps/studio-backend/pyproject.toml
@@ -40,6 +40,10 @@ path = "hatch_build.py"
 # via staged_dir - no per-module knowledge in the notebook, #159).
 [tool.hatch.build.targets.wheel.force-include]
 "registry.json" = "wake_training_service/registry.json"
+# The built-in dataset catalog (ADR-044 §7, #207) so deployed/generic runtimes
+# can materialize built-ins without a repo checkout (builtin_catalog.py loads
+# this packaged copy when the repo file is absent).
+"packages/modules/data/dataset/catalog/builtins.json" = "wake_train_kit/builtin_catalog.json"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/apps/studio-backend/src/wake_train_kit/builtin_catalog.py
+++ b/apps/studio-backend/src/wake_train_kit/builtin_catalog.py
@@ -1,0 +1,167 @@
+"""wake_train_kit.builtin_catalog — built-in dataset catalog (ADR-044 §7, #207).
+
+Mirror of the web-side `packages/modules/data/dataset/core/catalog.ts` + the
+curated `catalog/builtins.json` (the TypeScript types are the source of truth;
+this module is the backend loader + materialize-on-first-use executor).
+
+Built-ins are IMMUTABLE references (`kind: builtin`): the manifest (labels,
+roles, license + `commercialUse` provenance) is known, but the canonical
+`wake-studio-dataset.zip` is only produced on first use. `ensure_builtin`
+materializes a built-in into the `datasets/` store (survives restarts, #204)
+so a picked built-in id works anywhere a generated/uploaded dataset id does
+(the wizard picker, the train adapters' load-refs → materialize → merge, #206).
+
+Materialize types (core/catalog.ts `BuiltinMaterialize`):
+
+- ``speech-commands-v2`` — convert the Google SC2 archive via the existing
+  data-source helper (ADR-022, #152) into a canonical zip (fully wired today).
+- ``canonical-zip`` — fetch a pre-built canonical zip URL and import it.
+- ``pending-host`` — declared (license/provenance known) but no hosted zip
+  yet; not trainable, raises a clear error.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from .data_sources import download_file, prepare_speech_commands_v2
+from .dataset import pack_dataset_zip
+from .dataset_store import DatasetStore
+from .materialize import MaterializeError
+
+CATALOG_SOURCE = "packages/modules/data/dataset/catalog/builtins.json"
+#: wheel-packaged copy (pyproject force-include) for deployed/generic layouts.
+PACKAGED_CATALOG = "builtin_catalog.json"
+
+
+class BuiltinCatalogError(MaterializeError):
+    """Raised when a built-in id is unknown or not yet hostable.
+
+    Subclasses `materialize.MaterializeError` so the train adapters surface it
+    as a clear pre-train error (never a cryptic trainer crash)."""
+
+
+def _catalog_path() -> Path:
+    """Locate the curated catalog: env override → repo file → packaged copy."""
+    env = os.environ.get("BUILTIN_CATALOG")
+    if env:
+        return Path(env)
+    here = Path(__file__).resolve()
+    repo = here.parents[4]  # .../apps/studio-backend/src/wake_train_kit → repo root
+    repo_file = repo / CATALOG_SOURCE
+    if repo_file.is_file():
+        return repo_file
+    packaged = here.parent / PACKAGED_CATALOG
+    if packaged.is_file():
+        return packaged
+    raise BuiltinCatalogError(
+        "built-in catalog not found (set BUILTIN_CATALOG or ship the packaged "
+        f"{PACKAGED_CATALOG})"
+    )
+
+
+def load_catalog() -> list[dict[str, Any]]:
+    """Load + validate the built-in catalog entries (list of manifests)."""
+    import json
+
+    raw = json.loads(_catalog_path().read_text(encoding="utf-8"))
+    datasets = raw.get("datasets") or []
+    for entry in datasets:
+        if entry.get("kind") != "builtin":
+            raise BuiltinCatalogError(
+                f"built-in catalog entry '{entry.get('id')}' must be kind=builtin"
+            )
+        if not entry.get("materialize"):
+            raise BuiltinCatalogError(
+                f"built-in catalog entry '{entry.get('id')}' needs a materialize descriptor"
+            )
+    return datasets
+
+
+def entry(dataset_id: str) -> dict[str, Any] | None:
+    """The catalog entry for a built-in id (None when it is not a built-in)."""
+    return next((e for e in load_catalog() if e.get("id") == dataset_id), None)
+
+
+def is_builtin(dataset_id: str) -> bool:
+    return entry(dataset_id) is not None
+
+
+def _build_manifest(entry: dict[str, Any], clip_counts: dict[str, int], total: int) -> dict[str, Any]:
+    """Stored manifest for a materialized built-in: the entry minus
+    `materialize`, with the audio stats reflecting the real tree."""
+    manifest = {k: v for k, v in entry.items() if k != "materialize"}
+    audio = dict(manifest.get("audio") or {})
+    audio["clips"] = total
+    manifest["audio"] = audio
+    manifest["contentHash"] = None  # pack_dataset_zip recomputes it
+    return manifest
+
+
+def ensure_builtin(
+    store: DatasetStore,
+    dataset_id: str,
+    work_dir: Path | str,
+    reporter: Any = None,
+) -> dict[str, Any]:
+    """Materialize a built-in on first use and return its stored manifest.
+
+    Idempotent: if the built-in is already in the store it is returned
+    unchanged (immutable reference — a second materialize is a no-op).
+    """
+    existing = store.get(dataset_id)
+    if existing is not None:
+        return existing["manifest"]
+
+    catalog_entry = entry(dataset_id)
+    if catalog_entry is None:
+        raise BuiltinCatalogError(
+            f"unknown dataset '{dataset_id}' — it is not in the Datasets store and "
+            "not a built-in (check the catalog / generate or import it first)."
+        )
+
+    work = Path(work_dir)
+    work.mkdir(parents=True, exist_ok=True)
+    materialize = catalog_entry.get("materialize") or {}
+    mtype = materialize.get("type")
+
+    if mtype == "speech-commands-v2":
+        root, prov = prepare_speech_commands_v2(work / "sc2", reporter)
+        counts, total = _count_wavs(root)
+        manifest = _build_manifest(catalog_entry, counts, total)
+        manifest["provenance"] = [prov]
+        zip_path = pack_dataset_zip(root, manifest, work / f"{dataset_id}.zip")
+        store.save(zip_path)
+    elif mtype == "canonical-zip":
+        url = materialize.get("url", "")
+        if not url:
+            raise BuiltinCatalogError(
+                f"built-in '{dataset_id}' is canonical-zip but has no url"
+            )
+        zip_path = download_file(url, work / f"{dataset_id}.zip", reporter)
+        store.save(zip_path)
+    else:
+        note = materialize.get("note") or ""
+        raise BuiltinCatalogError(
+            f"built-in dataset '{dataset_id}' is declared but not yet hosted "
+            f"(materialize.type='{mtype}'). {note}".strip()
+        )
+
+    stored = store.get(dataset_id)
+    if stored is None:  # pragma: no cover - store.save always registers
+        raise BuiltinCatalogError(f"built-in '{dataset_id}' did not persist to the store")
+    return stored["manifest"]
+
+
+def _count_wavs(data_root: Path) -> tuple[dict[str, int], int]:
+    """label → clip count over a `label/*.wav` tree + the total."""
+    counts: dict[str, int] = {}
+    total = 0
+    for label_dir in data_root.iterdir():
+        if label_dir.is_dir():
+            n = len(list(label_dir.glob("*.wav")))
+            counts[label_dir.name] = n
+            total += n
+    return counts, total

--- a/apps/studio-backend/src/wake_train_kit/materialize.py
+++ b/apps/studio-backend/src/wake_train_kit/materialize.py
@@ -86,19 +86,23 @@ def extract_dataset(
     store: DatasetStore,
     dataset_id: str,
     dest: Path,
+    reporter: Any = None,
 ) -> tuple[dict[str, Any], Path]:
     """Extract a stored dataset zip → (manifest, canonical `audio/` clip root).
 
     The manifest comes from the store index (validated at save time, #204);
     the clip root is `dest/audio/<label>/*.wav` (the canonical layout, ADR-044
-    §4.1). Guards against zip-slip member paths.
+    §4.1). Guards against zip-slip member paths. A built-in id that is not yet
+    in the store is materialized on first use via `builtin_catalog` (#207).
     """
     record = store.get(dataset_id)
     if record is None:
-        raise MaterializeError(
-            f"unknown dataset '{dataset_id}' — it is not in the Datasets store "
-            f"({store.datasets_dir}); generate or import it first (#205/#208)."
-        )
+        from . import builtin_catalog  # lazy: avoids an import cycle
+
+        builtin_catalog.ensure_builtin(store, dataset_id, dest.parent / "builtin", reporter)
+        record = store.get(dataset_id)
+        if record is None:  # pragma: no cover - ensure_builtin always persists
+            raise MaterializeError(f"unknown dataset '{dataset_id}' — not in the store or catalog")
     zip_path = Path(record["stored_path"])
     if not zip_path.is_file():
         raise MaterializeError(f"dataset '{dataset_id}' zip is missing: {zip_path}")
@@ -316,6 +320,7 @@ def _materialize_one_tree(
     store: DatasetStore,
     dataset_id: str,
     out_dir: Path,
+    reporter: Any = None,
 ) -> tuple[dict[str, Any], Path, Path, list[str]]:
     """Turn one dataset into a per-dataset `label/*.wav` tree.
 
@@ -324,7 +329,7 @@ def _materialize_one_tree(
     labels become `_background_noise_`. Returns
     (manifest, tree_root, clip_root, label_warnings).
     """
-    manifest, clip_root = extract_dataset(store, dataset_id, out_dir / "src")
+    manifest, clip_root = extract_dataset(store, dataset_id, out_dir / "src", reporter)
     tree = out_dir / dataset_id
     tree.mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
@@ -373,7 +378,7 @@ def materialize_kws_streaming(
     for i, dataset_id in enumerate(dataset_ids):
         _log(reporter, "info", f"materialize kws-streaming: {dataset_id}")
         manifest, tree, _clip_root, label_warnings = _materialize_one_tree(
-            store, dataset_id, out / "trees"
+            store, dataset_id, out / "trees", reporter
         )
         manifests.append(manifest)
         trees.append(tree)
@@ -519,7 +524,7 @@ def materialize_openwakeword(
 
     for dataset_id in dataset_ids:
         _log(reporter, "info", f"materialize openwakeword: {dataset_id}")
-        manifest, clip_root = extract_dataset(store, dataset_id, out / "src")
+        manifest, clip_root = extract_dataset(store, dataset_id, out / "src", reporter)
         manifests.append(manifest)
         sources.extend(manifest.get("provenance") or [])
         for label in manifest.get("labels") or []:

--- a/apps/studio-backend/tests/test_builtin_catalog.py
+++ b/apps/studio-backend/tests/test_builtin_catalog.py
@@ -1,0 +1,184 @@
+"""wake_train_kit.builtin_catalog tests (ADR-044 §7, #207).
+
+No network: the SC2 converter is monkeypatched to build a small fake label
+tree (the real `prepare_speech_commands_v2` would download the 2.3 GB archive,
+which L1 tests must never do), and canonical-zip downloads copy a local file.
+Covers loading the curated catalog, materialize-on-first-use for both wired
+types, the pending-host clear error, idempotency, and that materializers
+resolve a built-in id end-to-end.
+"""
+
+import io
+import json
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from wake_train_kit import builtin_catalog as bc
+from wake_train_kit import dataset as ds
+from wake_train_kit import materialize as mat
+from wake_train_kit.dataset_store import DatasetStore
+
+
+def _sc2_tree(root: Path) -> Path:
+    """A minimal fake SC2 label tree — every label the catalog entry declares
+    (the real archive has all of them; the fake must too so the packed zip
+    imports: every declared label needs >= 1 clip)."""
+    labels = ("yes", "no", "up", "down", "left", "right",
+              "on", "off", "stop", "go", "_silence_", "_background_noise_")
+    for label in labels:
+        d = root / label
+        d.mkdir(parents=True, exist_ok=True)
+        for i in range(2):
+            (d / f"{label}_{i}.wav").write_bytes(b"RIFFfakewav")
+    return root
+
+
+def _fake_sc2_source(monkeypatch) -> None:
+    """Replace the SC2 converter with a fake that builds a local tree — never
+    the real 2.3 GB network download (ADR-026 L1: no network in tests)."""
+
+    def fake_prepare(data_dir, reporter=None):
+        root = _sc2_tree(Path(data_dir))
+        return root, {
+            "name": "Google Speech Commands V2 (speech_commands_v0.02)",
+            "license": "CC BY 4.0 (attribution required)",
+            "commercialUse": True,
+        }
+
+    monkeypatch.setattr(bc, "prepare_speech_commands_v2", fake_prepare)
+
+
+def test_catalog_loads_entries():
+    entries = bc.load_catalog()
+    ids = {e["id"] for e in entries}
+    assert ids >= {
+        "speech-commands-v2",
+        "google-speech-commands",
+        "common-voice",
+        "audioset-fma-noise",
+    }
+    # every entry carries the export-gate input
+    for e in entries:
+        assert e["kind"] == "builtin"
+        assert e.get("provenance") and isinstance(e["provenance"][0].get("commercialUse"), bool)
+
+
+def test_catalog_entry_lookup():
+    assert bc.entry("speech-commands-v2")["materialize"]["type"] == "speech-commands-v2"
+    assert bc.entry("nope") is None
+    assert bc.is_builtin("speech-commands-v2") is True
+    assert bc.is_builtin("nope") is False
+
+
+def test_ensure_builtin_speech_commands_v2(tmp_path, monkeypatch):
+    _fake_sc2_source(monkeypatch)
+    store = DatasetStore(tmp_path / "datasets")
+    manifest = bc.ensure_builtin(store, "speech-commands-v2", tmp_path / "work")
+
+    assert manifest["id"] == "speech-commands-v2"
+    assert manifest["kind"] == "builtin"
+    assert manifest["audio"]["clips"] == 24  # 12 labels × 2 clips
+    # the stored zip imports + verifies (contentHash round-trip)
+    stored = store.path("speech-commands-v2")
+    assert stored is not None and stored.is_file()
+    imported_manifest, _clips = ds.import_dataset_zip(stored)
+    assert imported_manifest["id"] == "speech-commands-v2"
+    assert imported_manifest["contentHash"] == manifest["contentHash"]
+    assert imported_manifest["provenance"][0]["commercialUse"] is True
+
+
+def test_ensure_builtin_is_idempotent(tmp_path, monkeypatch):
+    _fake_sc2_source(monkeypatch)
+    store = DatasetStore(tmp_path / "datasets")
+    first = bc.ensure_builtin(store, "speech-commands-v2", tmp_path / "work")
+    second = bc.ensure_builtin(store, "speech-commands-v2", tmp_path / "work")
+    assert first == second  # no re-download / no re-save
+
+
+def test_ensure_builtin_canonical_zip(tmp_path, monkeypatch):
+    # a minimal canonical zip copied locally (no network)
+    manifest = {
+        "schemaVersion": ds.DATASET_MANIFEST_SCHEMA_VERSION,
+        "id": "some-hosted-builtin",
+        "name": "Hosted Builtin",
+        "version": 1,
+        "kind": "builtin",
+        "role": "unknowns",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le", "clips": 1, "durationSec": 2},
+        "labels": [{"name": "unknown", "role": "unknown"}],
+        "provenance": [{"name": "x", "license": "CC0", "commercialUse": True}],
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("dataset.json", json.dumps(manifest))
+        zf.writestr("audio/unknown/a.wav", b"RIFFwav")
+    zip_path = tmp_path / "builtin.zip"
+    zip_path.write_bytes(buf.getvalue())
+
+    monkeypatch.setattr(
+        bc, "download_file",
+        lambda url, dest, reporter=None: (
+            dest.parent.mkdir(parents=True, exist_ok=True),
+            shutil.copy(zip_path, dest),
+        )[1],
+    )
+    original_load = bc.load_catalog
+
+    def fake_load():
+        entries = original_load()
+        entries.append({**manifest, "storage": {"url": zip_path.as_uri()},
+                        "materialize": {"type": "canonical-zip", "url": zip_path.as_uri()}})
+        return entries
+
+    monkeypatch.setattr(bc, "load_catalog", fake_load)
+
+    store = DatasetStore(tmp_path / "datasets")
+    got = bc.ensure_builtin(store, "some-hosted-builtin", tmp_path / "work")
+    assert got["id"] == "some-hosted-builtin"
+    assert store.get("some-hosted-builtin") is not None
+
+
+def test_ensure_builtin_pending_host_raises_clear_error(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    with pytest.raises(bc.BuiltinCatalogError, match="not yet hosted"):
+        bc.ensure_builtin(store, "common-voice", tmp_path / "work")
+
+
+def test_ensure_builtin_unknown_id(tmp_path):
+    store = DatasetStore(tmp_path / "datasets")
+    with pytest.raises(bc.BuiltinCatalogError, match="unknown dataset"):
+        bc.ensure_builtin(store, "nope", tmp_path / "work")
+
+
+def test_materialize_resolves_builtin_id(tmp_path, monkeypatch):
+    """A built-in id picked in the wizard works end-to-end: materialize pulls
+    it into the store on first use, then merges it as the unknown/noise half."""
+    _fake_sc2_source(monkeypatch)
+    store = DatasetStore(tmp_path / "datasets")
+    # SC2 alone has no positive label → it can't be the whole training set; use
+    # it as the unknown/noise half merged with a small positive dataset.
+    pos = {
+        "schemaVersion": 1, "id": "pos", "name": "positives", "version": 1,
+        "kind": "generated", "role": "positive",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le", "clips": 1, "durationSec": 2},
+        "labels": [{"name": "hey_studio", "role": "positive"}],
+        "provenance": [{"name": "tts", "license": "user-owned", "commercialUse": True}],
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("dataset.json", json.dumps(pos))
+        zf.writestr("audio/hey_studio/a.wav", b"RIFFwav")
+    pos_zip = tmp_path / "pos.zip"
+    pos_zip.write_bytes(buf.getvalue())
+    store.save(pos_zip)
+
+    out = mat.materialize_kws_streaming(store, ["pos", "speech-commands-v2"], tmp_path / "out")
+    # the built-in was materialized into the store + merged as unknowns/noise
+    assert store.get("speech-commands-v2") is not None
+    assert (out.data_dir / "hey_studio" / "a.wav").is_file()
+    assert (out.data_dir / "yes").is_dir()  # SC2 unknowns folded in
+    assert (out.data_dir / "_background_noise_").is_dir()  # SC2 noise
+    assert out.wanted_words == "hey_studio"

--- a/apps/web/public/datasets.json
+++ b/apps/web/public/datasets.json
@@ -1,0 +1,270 @@
+{
+  "note": "Built-in dataset catalog (ADR-044 §7, #207). Immutable references (kind: builtin) - the manifest is the portability contract; each entry's `materialize` says how it becomes a canonical wake-studio-dataset.zip on first use. Curated source of truth: the web bundle (apps/web/public/datasets.json) is generated from this file by scripts/build-dataset-catalog.mjs; the backend mirrors it in wake_train_kit/builtin_catalog.py.",
+  "schemaVersion": 1,
+  "datasets": [
+    {
+      "schemaVersion": 1,
+      "id": "speech-commands-v2",
+      "name": "Google Speech Commands V2 (speech_commands_v0.02)",
+      "version": 1,
+      "kind": "builtin",
+      "role": "unknowns",
+      "audio": {
+        "sampleRate": 16000,
+        "channels": 1,
+        "encoding": "pcm_s16le",
+        "clips": 105829,
+        "durationSec": 264573
+      },
+      "labels": [
+        {
+          "name": "yes",
+          "role": "unknown"
+        },
+        {
+          "name": "no",
+          "role": "unknown"
+        },
+        {
+          "name": "up",
+          "role": "unknown"
+        },
+        {
+          "name": "down",
+          "role": "unknown"
+        },
+        {
+          "name": "left",
+          "role": "unknown"
+        },
+        {
+          "name": "right",
+          "role": "unknown"
+        },
+        {
+          "name": "on",
+          "role": "unknown"
+        },
+        {
+          "name": "off",
+          "role": "unknown"
+        },
+        {
+          "name": "stop",
+          "role": "unknown"
+        },
+        {
+          "name": "go",
+          "role": "unknown"
+        },
+        {
+          "name": "_silence_",
+          "role": "unknown"
+        },
+        {
+          "name": "_background_noise_",
+          "role": "noise"
+        }
+      ],
+      "provenance": [
+        {
+          "name": "Google Speech Commands V2 (speech_commands_v0.02)",
+          "license": "CC BY 4.0 (attribution required)",
+          "source": "https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.02.tar.gz",
+          "commercialUse": true
+        }
+      ],
+      "recipe": {
+        "engine": "builtin",
+        "languages": [
+          "en-US"
+        ],
+        "toolVersions": {
+          "source": "speech_commands_v0.02.tar.gz"
+        }
+      },
+      "storage": {
+        "backend": "datasets/speech-commands-v2/"
+      },
+      "materialize": {
+        "type": "speech-commands-v2"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "id": "google-speech-commands",
+      "name": "Google Speech Commands (speech_commands_v0.01)",
+      "version": 1,
+      "kind": "builtin",
+      "role": "unknowns",
+      "audio": {
+        "sampleRate": 16000,
+        "channels": 1,
+        "encoding": "pcm_s16le",
+        "clips": 64721,
+        "durationSec": 161803
+      },
+      "labels": [
+        {
+          "name": "yes",
+          "role": "unknown"
+        },
+        {
+          "name": "no",
+          "role": "unknown"
+        },
+        {
+          "name": "up",
+          "role": "unknown"
+        },
+        {
+          "name": "down",
+          "role": "unknown"
+        },
+        {
+          "name": "left",
+          "role": "unknown"
+        },
+        {
+          "name": "right",
+          "role": "unknown"
+        },
+        {
+          "name": "on",
+          "role": "unknown"
+        },
+        {
+          "name": "off",
+          "role": "unknown"
+        },
+        {
+          "name": "stop",
+          "role": "unknown"
+        },
+        {
+          "name": "go",
+          "role": "unknown"
+        },
+        {
+          "name": "_silence_",
+          "role": "unknown"
+        },
+        {
+          "name": "_background_noise_",
+          "role": "noise"
+        }
+      ],
+      "provenance": [
+        {
+          "name": "Google Speech Commands (speech_commands_v0.01)",
+          "license": "CC BY 4.0 (attribution required)",
+          "source": "https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.01.tar.gz",
+          "commercialUse": true
+        }
+      ],
+      "recipe": {
+        "engine": "builtin",
+        "languages": [
+          "en-US"
+        ],
+        "toolVersions": {
+          "source": "speech_commands_v0.01.tar.gz"
+        }
+      },
+      "storage": {
+        "backend": "datasets/google-speech-commands/"
+      },
+      "materialize": {
+        "type": "pending-host",
+        "note": "Same family as speech-commands-v2; host a canonical zip (or reuse the SC2 converter with a version param) before it becomes trainable."
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "id": "common-voice",
+      "name": "Common Voice (multi-language speech)",
+      "version": 1,
+      "kind": "builtin",
+      "role": "unknowns",
+      "audio": {
+        "sampleRate": 16000,
+        "channels": 1,
+        "encoding": "pcm_s16le",
+        "clips": 0,
+        "durationSec": 0
+      },
+      "labels": [
+        {
+          "name": "unknown",
+          "role": "unknown"
+        }
+      ],
+      "provenance": [
+        {
+          "name": "Mozilla Common Voice",
+          "license": "CC0 1.0 (public domain dedication)",
+          "source": "https://commonvoice.mozilla.org",
+          "commercialUse": true
+        }
+      ],
+      "recipe": {
+        "engine": "builtin",
+        "languages": [
+          "en",
+          "zh-CN",
+          "ja",
+          "de",
+          "fr",
+          "es"
+        ]
+      },
+      "storage": {
+        "backend": "datasets/common-voice/"
+      },
+      "materialize": {
+        "type": "pending-host",
+        "note": "Multi-language negatives source; needs a hosted canonical zip before it becomes trainable."
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "id": "audioset-fma-noise",
+      "name": "AudioSet / FMA background noise",
+      "version": 1,
+      "kind": "builtin",
+      "role": "noise",
+      "audio": {
+        "sampleRate": 16000,
+        "channels": 1,
+        "encoding": "pcm_s16le",
+        "clips": 0,
+        "durationSec": 0
+      },
+      "labels": [
+        {
+          "name": "noise",
+          "role": "noise"
+        }
+      ],
+      "provenance": [
+        {
+          "name": "AudioSet / FMA noise clips",
+          "license": "research-use; verify before commercial deployment",
+          "source": "https://huggingface.co/datasets/agkphysics/AudioSet, https://huggingface.co/datasets/rudraml/fma",
+          "commercialUse": false
+        }
+      ],
+      "recipe": {
+        "engine": "builtin",
+        "languages": []
+      },
+      "storage": {
+        "backend": "datasets/audioset-fma-noise/"
+      },
+      "materialize": {
+        "type": "pending-host",
+        "note": "Research-use noise: commercialUse=false blocks commercial exports (export gate, #210). Needs a hosted canonical zip before trainable."
+      }
+    }
+  ]
+}

--- a/apps/web/src/training/console/DatasetPicker.tsx
+++ b/apps/web/src/training/console/DatasetPicker.tsx
@@ -1,24 +1,33 @@
 /**
- * Training wizard — Dataset picker (issue #206).
+ * Training wizard — Dataset picker (issues #206 + #207).
  *
  * Replaces the `dataSource` source-selector with a `datasets[]` picker fed
- * from the backend Datasets store (GET /datasets, ADR-044 #204). The user
- * picks one or more existing datasets; the picker validates the selection
- * against the module's `spec.train.dataset` requirements (core/materialize.ts
- * `validateDatasetRequirements`) so the user gets clear warnings instead of a
- * cryptic trainer crash.
+ * from two sources:
  *
- * The picked dataset ids are comma-joined into the `datasets` train param,
- * which flows through the registry (`STREAM_DATASETS` / `WAKE_DATASETS`) to
- * the adapter's load-refs → materialize → merge (ADR-031).
+ * 1. **Built-ins** — the static catalog (`apps/web/public/datasets.json`,
+ *    ADR-044 §7): immutable references (`kind: builtin`), materialized on
+ *    first use by the backend. `pending-host` entries are shown but disabled.
+ * 2. **The backend Datasets store** (GET /datasets, ADR-044 #204): generated /
+ *    uploaded datasets.
+ *
+ * The picker validates the combined selection against the module's
+ * `spec.train.dataset` requirements (core/materialize.ts
+ * `validateDatasetRequirements`) so the user gets clear warnings instead of a
+ * cryptic trainer crash. The picked ids are comma-joined into the `datasets`
+ * train param, which flows through the registry (`STREAM_DATASETS` /
+ * `WAKE_DATASETS`) to the adapter's load-refs → materialize → merge (ADR-031).
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
+  isBuiltinAvailable,
+  validateDatasetCatalog,
   validateDatasetRequirements,
+  type DatasetCatalogEntry,
   type DatasetManifest,
   type TrainerDatasetRequirements,
 } from '@wake-studio/module-dataset'
+import { resolveAsset } from '@wake-studio/platform'
 import { cn } from '../../components/cn'
 import type { StoreDataset, StudioClient } from '../studio-client'
 
@@ -46,14 +55,96 @@ const ROLE_LABEL: Record<string, string> = {
   mixed: 'mixed',
 }
 
+/** One selectable row — a store dataset or a built-in, in a common shape. */
+interface PickableDataset {
+  id: string
+  name: string
+  version: number
+  kind: string
+  role: string
+  clips: number
+  roles: string[]
+  license: string
+  commercialUse: boolean
+  /** false = pending-host builtin (declared but not trainable yet, #207). */
+  available: boolean
+  note?: string
+  /** The manifest the requirements validation reads. */
+  manifest: DatasetManifest
+}
+
+function fromStore(d: StoreDataset): PickableDataset {
+  const m = d.manifest as unknown as DatasetManifest
+  return {
+    id: d.id,
+    name: d.name,
+    version: d.version,
+    kind: d.kind,
+    role: d.role,
+    clips: m.audio?.clips ?? 0,
+    roles: [...new Set((m.labels ?? []).map((l) => l.role))],
+    license: m.provenance?.[0]?.license ?? 'unknown',
+    commercialUse: m.provenance?.[0]?.commercialUse ?? true,
+    available: true,
+    manifest: m,
+  }
+}
+
+function fromBuiltin(e: DatasetCatalogEntry): PickableDataset {
+  const m = e as unknown as DatasetManifest
+  return {
+    id: e.id,
+    name: e.name,
+    version: e.version,
+    kind: e.kind,
+    role: e.role,
+    clips: e.audio?.clips ?? 0,
+    roles: [...new Set((e.labels ?? []).map((l) => l.role))],
+    license: e.provenance?.[0]?.license ?? 'unknown',
+    commercialUse: e.provenance?.[0]?.commercialUse ?? true,
+    available: isBuiltinAvailable(e),
+    note: e.materialize?.type === 'pending-host' ? e.materialize?.note : undefined,
+    manifest: m,
+  }
+}
+
 export function DatasetPicker({ client, requirements, value, onChange }: DatasetPickerProps) {
-  const [datasets, setDatasets] = useState<StoreDataset[] | null>(null)
+  const [storeDatasets, setStoreDatasets] = useState<StoreDataset[] | null>(null)
+  const [builtins, setBuiltins] = useState<DatasetCatalogEntry[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
+  // Built-ins come from the static catalog (always; no backend needed to list).
+  useEffect(() => {
+    let cancelled = false
+    fetch(resolveAsset('datasets.json'))
+      .then((res) => {
+        if (!res.ok) throw new Error(`built-in catalog (HTTP ${res.status})`)
+        return res.json()
+      })
+      .then((catalog) => {
+        if (cancelled) return
+        const validation = validateDatasetCatalog(catalog)
+        if (!validation.ok) {
+          setError(`built-in catalog is invalid: ${validation.errors.join('; ')}`)
+          return
+        }
+        setBuiltins(catalog.datasets)
+      })
+      .catch((err: unknown) => {
+        // A missing catalog degrades to store-only, not a hard failure.
+        if (!cancelled) setBuiltins([])
+        void err
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Store datasets from the connected studio-backend.
   useEffect(() => {
     if (!client) {
-      setDatasets(null)
+      setStoreDatasets(null)
       return
     }
     let cancelled = false
@@ -62,12 +153,12 @@ export function DatasetPicker({ client, requirements, value, onChange }: Dataset
     client
       .listDatasets()
       .then((list) => {
-        if (!cancelled) setDatasets(list)
+        if (!cancelled) setStoreDatasets(list)
       })
       .catch((err: unknown) => {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err))
-          setDatasets(null)
+          setStoreDatasets(null)
         }
       })
       .finally(() => {
@@ -78,10 +169,22 @@ export function DatasetPicker({ client, requirements, value, onChange }: Dataset
     }
   }, [client])
 
+  // Merge built-ins + store datasets into one list (dedup by id, builtin wins).
+  const pickable = useMemo<PickableDataset[]>(() => {
+    const byId = new Map<string, PickableDataset>()
+    for (const d of storeDatasets ?? []) byId.set(d.id, fromStore(d))
+    for (const e of builtins ?? []) byId.set(e.id, fromBuiltin(e))
+    const all = [...byId.values()]
+    // available built-ins first, then store datasets, then pending-host built-ins
+    const rank = (p: PickableDataset) =>
+      p.available ? 0 : p.kind === 'builtin' ? 2 : 1
+    return all.sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))
+  }, [storeDatasets, builtins])
+
   const selected = useMemo(() => {
     const set = new Set(value ? value.split(',').map((s) => s.trim()).filter(Boolean) : [])
-    return (datasets ?? []).filter((d) => set.has(d.id))
-  }, [datasets, value])
+    return pickable.filter((d) => set.has(d.id))
+  }, [pickable, value])
 
   const toggle = useCallback(
     (id: string) => {
@@ -98,25 +201,13 @@ export function DatasetPicker({ client, requirements, value, onChange }: Dataset
   const validation = useMemo(
     () =>
       validateDatasetRequirements(
-        selected.map((d) => ({ manifest: d.manifest as unknown as DatasetManifest })),
+        selected.map((d) => ({ manifest: d.manifest })),
         requirements,
       ),
     [selected, requirements],
   )
 
-
-  if (!client) {
-    return (
-      <div className="rounded-xl border border-line bg-surface-2 p-4">
-        <h3 className="text-sm font-semibold text-ink-1">Datasets</h3>
-        <p className="mt-1.5 text-xs leading-relaxed text-ink-3">
-          Connect a <span className="font-medium text-ink-2">studio-backend</span> in the
-          Backends menu to load the datasets this trainer will train on (one or more from
-          the Datasets store).
-        </p>
-      </div>
-    )
-  }
+  const empty = pickable.length === 0 && !loading
 
   return (
     <div className="rounded-xl border border-line bg-surface-2 p-4">
@@ -127,38 +218,42 @@ export function DatasetPicker({ client, requirements, value, onChange }: Dataset
         </span>
       </div>
       <p className="mt-0.5 text-xs text-ink-3">
-        One or more existing datasets (the materializer merges roles — positives = wake
-        word, unknowns → <span className="font-mono">_unknown_</span>, noise →{' '}
-        <span className="font-mono">_background_noise_</span>).
+        One or more existing datasets (built-ins + your store). The materializer merges
+        roles — positives = wake word, unknowns →{' '}
+        <span className="font-mono">_unknown_</span>, noise →{' '}
+        <span className="font-mono">_background_noise_</span>.
       </p>
 
       {loading && <p className="mt-3 text-xs text-ink-3">Loading datasets…</p>}
       {error && <p className="mt-3 text-xs text-danger">{error}</p>}
-      {!loading && !error && datasets && datasets.length === 0 && (
+      {empty && !error && (
         <p className="mt-3 text-xs text-ink-3">
-          No datasets in the store yet — generate one in the Datasets console (or import a
+          No datasets available yet — generate one in the Datasets console (or import a
           wake-studio-dataset.zip), then come back.
         </p>
       )}
 
-      {datasets && datasets.length > 0 && (
+      {pickable.length > 0 && (
         <div className="mt-3 space-y-1.5">
-          {datasets.map((d) => {
+          {pickable.map((d) => {
             const on = selected.some((s) => s.id === d.id)
-            const clips = d.manifest.audio?.clips ?? 0
-            const roles = [...new Set((d.manifest.labels ?? []).map((l) => l.role))]
             return (
               <label
                 key={d.id}
                 className={cn(
                   'flex cursor-pointer items-start gap-2.5 rounded-lg border px-3 py-2 transition-colors',
-                  on ? 'border-brand-9/60 bg-brand-9/10' : 'border-line bg-surface-3 hover:border-ink-4',
+                  d.available
+                    ? on
+                      ? 'border-brand-9/60 bg-brand-9/10'
+                      : 'border-line bg-surface-3 hover:border-ink-4'
+                    : 'cursor-not-allowed border-line bg-surface-3 opacity-60',
                 )}
               >
                 <input
                   type="checkbox"
                   className="mt-0.5 h-4 w-4 accent-[var(--brand-9)]"
                   checked={on}
+                  disabled={!d.available}
                   onChange={() => toggle(d.id)}
                 />
                 <span className="min-w-0 flex-1">
@@ -171,17 +266,43 @@ export function DatasetPicker({ client, requirements, value, onChange }: Dataset
                       {KIND_LABEL[d.kind] ?? d.kind}
                     </span>
                     <span className="rounded-full bg-surface-3 px-1.5 py-0.5 font-mono text-[10px] text-ink-3">
-                      {clips} clips · {roles.join('/') || (ROLE_LABEL[d.role] ?? d.role)}
+                      {d.clips > 0 ? `${d.clips} clips · ` : ''}
+                      {d.roles.join('/') || (ROLE_LABEL[d.role] ?? d.role)}
                     </span>
+                    {d.commercialUse === false && (
+                      <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-700">
+                        non-commercial
+                      </span>
+                    )}
+                    {!d.available && (
+                      <span className="rounded-full bg-surface-3 px-1.5 py-0.5 text-[10px] text-ink-3">
+                        not hosted yet
+                      </span>
+                    )}
                   </span>
                   <span className="mt-0.5 block truncate text-[11px] text-ink-3" title={d.id}>
                     {d.id}
+                    {d.license && <span className="text-ink-4"> · {d.license}</span>}
                   </span>
+                  {!d.available && d.note && (
+                    <span className="mt-0.5 block text-[11px] leading-relaxed text-ink-3">
+                      {d.note}
+                    </span>
+                  )}
                 </span>
               </label>
             )
           })}
         </div>
+      )}
+
+      {!client && pickable.length > 0 && (
+        <p className="mt-3 border-t border-line pt-3 text-xs text-ink-3">
+          Built-ins are listed here, but training needs a{' '}
+          <span className="font-medium text-ink-2">studio-backend</span> connection to
+          materialize them (and to load your store's datasets) — connect one in the
+          Backends menu.
+        </p>
       )}
 
       {selected.length > 0 && (

--- a/docs/modules/data-sources.md
+++ b/docs/modules/data-sources.md
@@ -287,13 +287,33 @@ ADR-031):
 Spec-driven `datasets.json` (like `train-modules.json`), focused on multi-language + noise
 coverage. v1 candidates (license + `commercialUse` flagged; Q-DS-4 to confirm the exact list):
 
-- **Speech Commands V2** (CC BY 4.0) - already integrated.
+- **Speech Commands V2** (CC BY 4.0) - already integrated; the one built-in that is fully
+  materializable today (`materialize.type: speech-commands-v2` via the ADR-022 converter).
 - **Common Voice** (multi-language, CC0).
 - **Google Speech Commands** (CC BY 4.0).
 - **AudioSet / FMA** noise clips + openwakeword features (research-use - flagged so the export
   gate stays honest).
 
 Built-ins are immutable references (`kind: builtin`), materialized on first use.
+
+**Implemented (#207):**
+
+- Curated source of truth: `packages/modules/data/dataset/catalog/builtins.json` (a
+  `DatasetBuiltinCatalog` — every entry is a full `DatasetManifest` + a `materialize`
+  descriptor). The web bundle `apps/web/public/datasets.json` is generated from it by
+  `scripts/build-dataset-catalog.mjs` (`pnpm gen:catalog` / `gen:catalog:check`, the same
+  update/check pattern as `train-modules.json` / `dataset-engines.json`); CI fails when stale.
+- Catalog types + validation in `core/catalog.ts` (`validateDatasetCatalog`, `BuiltinMaterialize`
+  = `canonical-zip` | `speech-commands-v2` | `pending-host`, `isBuiltinAvailable`).
+- Backend `wake_train_kit/builtin_catalog.py`: `ensure_builtin` materializes a built-in into the
+  `datasets/` store on first use — SC2 via the ADR-022 converter (packed to a canonical zip,
+  contentHash-verified), `canonical-zip` by fetch+import, `pending-host` raises a clear
+  "declared but not yet hosted" error. `materialize.extract_dataset` resolves built-in ids so a
+  picked built-in works in training (load-refs → materialize → merge, #206). The catalog is
+  wheel-packaged (`pyproject` force-include) for deployed/generic runtimes.
+- The Training wizard `datasets[]` picker lists built-ins (from the static catalog) alongside
+  store datasets; `pending-host` entries are shown disabled; `commercialUse: false` entries are
+  flagged "non-commercial".
 
 ## 8. Datasets console (web)
 
@@ -408,3 +428,4 @@ license/provenance log shown in-app before export. The Datasets console shows th
 | 2026-08-20 | **#205 — dataset generation jobs (ADR-044 §5, human refactor 2026-08-20):** engines are MODULES (`packages/modules/data/{edge-tts,mimo-tts,piper,qwen-llm-tts}/`), each owning `spec/module.spec.json` (`params` -> generated panel, `tts` block = kind/runtime/provenanceTemplate) + `adapter.py` (module-owned backend adapter, loaded at runtime). Contracts gain `ModuleSpec.tts`. Backend pipeline `wake_train_kit/generation.py` (dispatcher + shared postprocess/assemble) + `generation_runner.py` (`dataset-generate` registry entry, NDJSON, canonical zip artifact); shared online/LLM HTTP machinery in `wake_train_kit/http_tts.py`; postprocess transforms (`passthrough` + `openwakeword-style`); catalog `apps/web/public/dataset-engines.json` generated from `spec.tts` via `scripts/build-dataset-engines.mjs` (like `spec.train`); tests (13 backend + dataset). Browser executor + generation wizard land in #208. | agent |
 | 2026-08-20 | **#204 — dataset storage layer (ADR-044 §5.3):** backend `datasets/` store (`wake_train_kit/dataset_store.py`, SQLite index + `datasets/<id>/wake-studio-dataset.zip`, survives restarts, mirrors artifacts store; `dataset-generate` zips auto-persist into it). `StorageBackend` interface + registry + adapters (`backend-disk`/`url` real, `hf`/`r2`/`gdrive` declared with authKey) in `wake_train_kit/storage.py`; `dataset-storage` job entry (`storage_runner.py`). Web Settings gains a masked **Cloud storage** group; storage plugin catalog in `core/storage.ts` (authKey per plugin). Q-DS-3 implemented: cloud keys flow as job-scoped env only, never persisted. Tests: store round-trip, plugin registry, fake adapters (no real cloud). Remaining #206-#210 unchanged. | agent |
 | 2026-08-20 | **#206 — materializers + `datasets[]` train consumption (ADR-044 §6):** `spec.train.dataset` requirements schema (contracts + JSON schema); `core/materialize.ts` (role->folder maps + `validateDatasetRequirements` picker validation); `wake_train_kit/materialize.py` (kws-streaming label-tree + openwakeword positives/features/background executors, #158 collision-safe merge); `GET /datasets` store API; wizard `datasets[]` picker replacing `dataSource`; adapters' `prepare_data` = load-refs → materialize → merge (`STREAM_DATASETS`/`WAKE_DATASETS`), upstream scripts byte-identical. Tests: 17 backend materialize + 4 adapter e2e (fake upstream + fake feature extractor) + TS validation suite. Remaining #207-#210 unchanged. | agent |
+| 2026-08-20 | **#207 — built-in dataset catalog (ADR-044 §7):** curated `catalog/builtins.json` (SC2 / Google Speech Commands / Common Voice / AudioSet+FMA noise, each with license + `commercialUse`); `scripts/build-dataset-catalog.mjs` → `apps/web/public/datasets.json` (`pnpm gen:catalog[:check]`, CI check); types + `validateDatasetCatalog` in `core/catalog.ts` (`canonical-zip`/`speech-commands-v2`/`pending-host` materialize); backend `wake_train_kit/builtin_catalog.py` materialize-on-first-use (SC2 via the ADR-022 converter; wheel-packaged); wizard picker lists built-ins (pending-host disabled, non-commercial flagged). Tests: 8 backend (fake SC2 source, no network) + 9 TS catalog. Remaining #208-#210 unchanged. | agent |

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "test:unit": "pnpm -r test:unit",
     "typecheck": "pnpm -r typecheck",
     "gen:engines": "node scripts/build-dataset-engines.mjs --update",
-    "gen:engines:check": "node scripts/build-dataset-engines.mjs --check"
+    "gen:engines:check": "node scripts/build-dataset-engines.mjs --check",
+    "gen:catalog": "node scripts/build-dataset-catalog.mjs --update",
+    "gen:catalog:check": "node scripts/build-dataset-catalog.mjs --check"
   },
   "devDependencies": {
     "typescript": "~5.6.3"

--- a/packages/modules/data/dataset/catalog/builtins.json
+++ b/packages/modules/data/dataset/catalog/builtins.json
@@ -1,0 +1,100 @@
+{
+  "note": "Built-in dataset catalog (ADR-044 §7, #207). Immutable references (kind: builtin) - the manifest is the portability contract; each entry's `materialize` says how it becomes a canonical wake-studio-dataset.zip on first use. Curated source of truth: the web bundle (apps/web/public/datasets.json) is generated from this file by scripts/build-dataset-catalog.mjs; the backend mirrors it in wake_train_kit/builtin_catalog.py.",
+  "schemaVersion": 1,
+  "datasets": [
+    {
+      "schemaVersion": 1,
+      "id": "speech-commands-v2",
+      "name": "Google Speech Commands V2 (speech_commands_v0.02)",
+      "version": 1,
+      "kind": "builtin",
+      "role": "unknowns",
+      "audio": { "sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le", "clips": 105829, "durationSec": 264573 },
+      "labels": [
+        { "name": "yes", "role": "unknown" },
+        { "name": "no", "role": "unknown" },
+        { "name": "up", "role": "unknown" },
+        { "name": "down", "role": "unknown" },
+        { "name": "left", "role": "unknown" },
+        { "name": "right", "role": "unknown" },
+        { "name": "on", "role": "unknown" },
+        { "name": "off", "role": "unknown" },
+        { "name": "stop", "role": "unknown" },
+        { "name": "go", "role": "unknown" },
+        { "name": "_silence_", "role": "unknown" },
+        { "name": "_background_noise_", "role": "noise" }
+      ],
+      "provenance": [
+        { "name": "Google Speech Commands V2 (speech_commands_v0.02)", "license": "CC BY 4.0 (attribution required)", "source": "https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.02.tar.gz", "commercialUse": true }
+      ],
+      "recipe": { "engine": "builtin", "languages": ["en-US"], "toolVersions": { "source": "speech_commands_v0.02.tar.gz" } },
+      "storage": { "backend": "datasets/speech-commands-v2/" },
+      "materialize": { "type": "speech-commands-v2" }
+    },
+    {
+      "schemaVersion": 1,
+      "id": "google-speech-commands",
+      "name": "Google Speech Commands (speech_commands_v0.01)",
+      "version": 1,
+      "kind": "builtin",
+      "role": "unknowns",
+      "audio": { "sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le", "clips": 64721, "durationSec": 161803 },
+      "labels": [
+        { "name": "yes", "role": "unknown" },
+        { "name": "no", "role": "unknown" },
+        { "name": "up", "role": "unknown" },
+        { "name": "down", "role": "unknown" },
+        { "name": "left", "role": "unknown" },
+        { "name": "right", "role": "unknown" },
+        { "name": "on", "role": "unknown" },
+        { "name": "off", "role": "unknown" },
+        { "name": "stop", "role": "unknown" },
+        { "name": "go", "role": "unknown" },
+        { "name": "_silence_", "role": "unknown" },
+        { "name": "_background_noise_", "role": "noise" }
+      ],
+      "provenance": [
+        { "name": "Google Speech Commands (speech_commands_v0.01)", "license": "CC BY 4.0 (attribution required)", "source": "https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.01.tar.gz", "commercialUse": true }
+      ],
+      "recipe": { "engine": "builtin", "languages": ["en-US"], "toolVersions": { "source": "speech_commands_v0.01.tar.gz" } },
+      "storage": { "backend": "datasets/google-speech-commands/" },
+      "materialize": { "type": "pending-host", "note": "Same family as speech-commands-v2; host a canonical zip (or reuse the SC2 converter with a version param) before it becomes trainable." }
+    },
+    {
+      "schemaVersion": 1,
+      "id": "common-voice",
+      "name": "Common Voice (multi-language speech)",
+      "version": 1,
+      "kind": "builtin",
+      "role": "unknowns",
+      "audio": { "sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le", "clips": 0, "durationSec": 0 },
+      "labels": [
+        { "name": "unknown", "role": "unknown" }
+      ],
+      "provenance": [
+        { "name": "Mozilla Common Voice", "license": "CC0 1.0 (public domain dedication)", "source": "https://commonvoice.mozilla.org", "commercialUse": true }
+      ],
+      "recipe": { "engine": "builtin", "languages": ["en", "zh-CN", "ja", "de", "fr", "es"] },
+      "storage": { "backend": "datasets/common-voice/" },
+      "materialize": { "type": "pending-host", "note": "Multi-language negatives source; needs a hosted canonical zip before it becomes trainable." }
+    },
+    {
+      "schemaVersion": 1,
+      "id": "audioset-fma-noise",
+      "name": "AudioSet / FMA background noise",
+      "version": 1,
+      "kind": "builtin",
+      "role": "noise",
+      "audio": { "sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le", "clips": 0, "durationSec": 0 },
+      "labels": [
+        { "name": "noise", "role": "noise" }
+      ],
+      "provenance": [
+        { "name": "AudioSet / FMA noise clips", "license": "research-use; verify before commercial deployment", "source": "https://huggingface.co/datasets/agkphysics/AudioSet, https://huggingface.co/datasets/rudraml/fma", "commercialUse": false }
+      ],
+      "recipe": { "engine": "builtin", "languages": [] },
+      "storage": { "backend": "datasets/audioset-fma-noise/" },
+      "materialize": { "type": "pending-host", "note": "Research-use noise: commercialUse=false blocks commercial exports (export gate, #210). Needs a hosted canonical zip before trainable." }
+    }
+  ]
+}

--- a/packages/modules/data/dataset/core/catalog.ts
+++ b/packages/modules/data/dataset/core/catalog.ts
@@ -1,0 +1,108 @@
+/**
+ * Dataset module - built-in catalog contract (ADR-044 §7, task #207).
+ *
+ * Built-ins are IMMUTABLE references (`kind: builtin`) into a spec-driven
+ * `datasets.json` catalog (like `train-modules.json`), focused on
+ * multi-language + noise coverage. Each entry is a full `DatasetManifest`
+ * (the portability contract) plus a `materialize` descriptor saying how the
+ * immutable reference becomes a canonical `wake-studio-dataset.zip` on first
+ * use.
+ *
+ * License + `commercialUse` flags are first-class so the Phase 4 export gate
+ * stays honest (an entry with `commercialUse: false`, e.g. AudioSet/FMA noise,
+ * blocks commercial exports of any model trained on it — #210).
+ *
+ * Curated source of truth: `packages/modules/data/dataset/catalog/builtins.json`.
+ * The web bundle (`apps/web/public/datasets.json`) is generated from it by
+ * `scripts/build-dataset-catalog.mjs`; the backend mirrors the same file in
+ * `wake_train_kit/builtin_catalog.py`.
+ */
+
+import { validateDatasetManifest, type DatasetManifest } from './spec'
+
+/** How a built-in becomes a canonical zip on first use (materialize-on-demand). */
+export type BuiltinMaterialize =
+  /** A pre-built canonical zip URL: fetch it and import through the store. */
+  | { type: 'canonical-zip'; url: string }
+  /** Backend conversion of the Speech Commands V2 archive (ADR-022, #152). */
+  | { type: 'speech-commands-v2' }
+  /** Declared (license/provenance known) but no hosted zip yet — not trainable. */
+  | { type: 'pending-host'; note?: string }
+
+/** One catalog entry: a valid built-in manifest + its materialize descriptor. */
+export interface DatasetCatalogEntry extends DatasetManifest {
+  kind: 'builtin'
+  materialize: BuiltinMaterialize
+}
+
+export interface DatasetBuiltinCatalog {
+  /** Catalog spec version (bump on a breaking shape change). */
+  schemaVersion: number
+  note?: string
+  datasets: DatasetCatalogEntry[]
+}
+
+export interface CatalogValidation {
+  ok: boolean
+  errors: string[]
+}
+
+export const BUILTIN_CATALOG_SCHEMA_VERSION = 1
+
+export const BUILTIN_MATERIALIZE_TYPES: readonly string[] = [
+  'canonical-zip',
+  'speech-commands-v2',
+  'pending-host',
+]
+
+/** True when a built-in can be materialized today (vs declared-but-pending). */
+export function isBuiltinAvailable(entry: DatasetCatalogEntry): boolean {
+  return entry.materialize.type !== 'pending-host'
+}
+
+/**
+ * Validate a built-in catalog: every entry must be a valid `DatasetManifest`
+ * with `kind: builtin`, a materialize descriptor (with the `url` a
+ * `canonical-zip` entry requires) and non-empty provenance carrying the
+ * `commercialUse` flag the export gate relies on. Mirrored (loosely) by the
+ * backend loader.
+ */
+export function validateDatasetCatalog(catalog: DatasetBuiltinCatalog): CatalogValidation {
+  const errors: string[] = []
+  if (catalog.schemaVersion !== BUILTIN_CATALOG_SCHEMA_VERSION) {
+    errors.push(
+      `schemaVersion must be ${BUILTIN_CATALOG_SCHEMA_VERSION} (got ${String(catalog.schemaVersion)})`,
+    )
+  }
+  if (!Array.isArray(catalog.datasets) || catalog.datasets.length === 0) {
+    return { ok: false, errors: [...errors, 'datasets must be a non-empty array'] }
+  }
+
+  const seen = new Set<string>()
+  for (const entry of catalog.datasets) {
+    const id = entry.id ?? '(no id)'
+    const manifest = validateDatasetManifest(entry)
+    if (!manifest.ok) {
+      for (const e of manifest.errors) errors.push(`${id}: ${e}`)
+    }
+    if (seen.has(id)) errors.push(`duplicate dataset id: ${id}`)
+    seen.add(id)
+
+    if (entry.kind !== 'builtin') errors.push(`${id}: kind must be "builtin"`)
+    if (!entry.materialize || typeof entry.materialize !== 'object') {
+      errors.push(`${id}: materialize descriptor is required`)
+    } else if (!BUILTIN_MATERIALIZE_TYPES.includes(entry.materialize.type)) {
+      errors.push(`${id}: materialize.type must be one of ${BUILTIN_MATERIALIZE_TYPES.join(', ')}`)
+    } else if (
+      entry.materialize.type === 'canonical-zip' &&
+      !(typeof entry.materialize.url === 'string' && entry.materialize.url.length > 0)
+    ) {
+      errors.push(`${id}: canonical-zip materialize requires a non-empty url`)
+    }
+
+    if (!Array.isArray(entry.provenance) || entry.provenance.length === 0) {
+      errors.push(`${id}: provenance must be non-empty (the export gate reads commercialUse)`)
+    }
+  }
+  return { ok: errors.length === 0, errors }
+}

--- a/packages/modules/data/dataset/core/index.ts
+++ b/packages/modules/data/dataset/core/index.ts
@@ -75,6 +75,17 @@ export {
 export type { TrainerDatasetRequirements, LabelMode } from '@wake-studio/contracts'
 
 export {
+  BUILTIN_CATALOG_SCHEMA_VERSION,
+  BUILTIN_MATERIALIZE_TYPES,
+  isBuiltinAvailable,
+  validateDatasetCatalog,
+  type BuiltinMaterialize,
+  type DatasetCatalogEntry,
+  type DatasetBuiltinCatalog,
+  type CatalogValidation,
+} from './catalog'
+
+export {
   STORAGE_BACKEND_KINDS,
   STORAGE_CAPABILITIES,
   BUILTIN_STORAGE_BACKENDS,

--- a/packages/modules/data/dataset/tests/catalog.test.ts
+++ b/packages/modules/data/dataset/tests/catalog.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Dataset module - built-in catalog tests (#207).
+ *
+ * Covers the catalog contract + validation: every shipped entry is a valid
+ * built-in manifest with license + commercialUse (the export-gate input) and
+ * a materialize descriptor. The curated file (`catalog/builtins.json`) is the
+ * fixture — the same file `scripts/build-dataset-catalog.mjs` emits to the
+ * web bundle and the backend `builtin_catalog.py` mirrors.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  isBuiltinAvailable,
+  validateDatasetCatalog,
+  type DatasetCatalogEntry,
+  type DatasetBuiltinCatalog,
+} from '../core/catalog'
+import { validateDatasetManifest } from '../core/spec'
+
+const SHIPPED = JSON.parse(
+  readFileSync(resolve(__dirname, '..', 'catalog', 'builtins.json'), 'utf8'),
+) as DatasetBuiltinCatalog
+
+function entry(id: string): DatasetCatalogEntry {
+  return SHIPPED.datasets.find((d) => d.id === id)!
+}
+
+describe('shipped built-in catalog (catalog/builtins.json)', () => {
+  it('is a valid catalog', () => {
+    const v = validateDatasetCatalog(SHIPPED)
+    expect(v.ok, v.errors.join('; ')).toBe(true)
+  })
+
+  it('has every v1 candidate with license + commercialUse', () => {
+    const ids = SHIPPED.datasets.map((d) => d.id)
+    expect(ids).toContain('speech-commands-v2')
+    expect(ids).toContain('google-speech-commands')
+    expect(ids).toContain('common-voice')
+    expect(ids).toContain('audioset-fma-noise')
+
+    for (const e of SHIPPED.datasets) {
+      expect(e.kind).toBe('builtin')
+      expect(e.provenance.length).toBeGreaterThan(0)
+      expect(typeof e.provenance[0].commercialUse).toBe('boolean')
+    }
+    // research-use noise is NOT commercially usable (the export gate must block it)
+    expect(entry('audioset-fma-noise').provenance[0].commercialUse).toBe(false)
+    expect(entry('speech-commands-v2').provenance[0].commercialUse).toBe(true)
+  })
+
+  it('SC2 is fully materializable today; the rest are declared (pending-host)', () => {
+    expect(isBuiltinAvailable(entry('speech-commands-v2'))).toBe(true)
+    expect(isBuiltinAvailable(entry('common-voice'))).toBe(false)
+    expect(isBuiltinAvailable(entry('audioset-fma-noise'))).toBe(false)
+  })
+
+  it('every entry is a valid DatasetManifest (the picker + store contract)', () => {
+    for (const e of SHIPPED.datasets) {
+      const v = validateDatasetManifest(e)
+      expect(v.ok, `${e.id}: ${v.errors.join('; ')}`).toBe(true)
+    }
+  })
+})
+
+describe('validateDatasetCatalog', () => {
+  it('rejects a duplicate dataset id', () => {
+    const dup: DatasetBuiltinCatalog = {
+      schemaVersion: 1,
+      datasets: [entry('speech-commands-v2'), entry('speech-commands-v2')],
+    }
+    const v = validateDatasetCatalog(dup)
+    expect(v.ok).toBe(false)
+    expect(v.errors.some((e) => e.includes('duplicate dataset id'))).toBe(true)
+  })
+
+  it('rejects a non-builtin kind', () => {
+    const bad = structuredClone(entry('common-voice')) as unknown as {
+      kind: string
+      id: string
+    }
+    bad.kind = 'generated'
+    const v = validateDatasetCatalog({
+      schemaVersion: 1,
+      datasets: [bad as unknown as DatasetCatalogEntry],
+    })
+    expect(v.ok).toBe(false)
+    expect(v.errors.some((e) => e.includes('kind must be "builtin"'))).toBe(true)
+  })
+
+  it('rejects a missing materialize descriptor', () => {
+    const { materialize: _drop, ...rest } = entry('common-voice')
+    const v = validateDatasetCatalog({
+      schemaVersion: 1,
+      datasets: [rest as unknown as DatasetCatalogEntry],
+    })
+    expect(v.ok).toBe(false)
+    expect(v.errors.some((e) => e.includes('materialize descriptor is required'))).toBe(true)
+  })
+
+  it('rejects a canonical-zip entry without a url', () => {
+    const bad = structuredClone(entry('speech-commands-v2'))
+    bad.materialize = { type: 'canonical-zip', url: '' }
+    const v = validateDatasetCatalog({ schemaVersion: 1, datasets: [bad] })
+    expect(v.ok).toBe(false)
+    expect(v.errors.some((e) => e.includes('requires a non-empty url'))).toBe(true)
+  })
+
+  it('rejects an empty catalog', () => {
+    const v = validateDatasetCatalog({ schemaVersion: 1, datasets: [] })
+    expect(v.ok).toBe(false)
+  })
+})

--- a/scripts/build-dataset-catalog.mjs
+++ b/scripts/build-dataset-catalog.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Generate apps/web/public/datasets.json from the curated built-in catalog.
+ *
+ * Built-ins (ADR-044 §7, #207) are immutable references (`kind: builtin`):
+ * the curated source of truth lives at
+ * `packages/modules/data/dataset/catalog/builtins.json` (a `DatasetBuiltinCatalog`),
+ * and this script emits the runtime catalog the Datasets console + the
+ * Training wizard's `datasets[]` picker consume. The generated file is
+ * committed (reviewable diffs, lockfile-style); --check fails CI when stale
+ * (mirrors build-model-registry.mjs / build-dataset-engines.mjs).
+ *
+ * Usage:
+ *   node scripts/build-dataset-catalog.mjs            # print the catalog
+ *   node scripts/build-dataset-catalog.mjs --update   # write the file
+ *   node scripts/build-dataset-catalog.mjs --check    # exit 1 when stale
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dirname, '..')
+const SOURCE = 'packages/modules/data/dataset/catalog/builtins.json'
+const CATALOG_FILE = 'apps/web/public/datasets.json'
+
+const MATERIALIZE_TYPES = ['canonical-zip', 'speech-commands-v2', 'pending-host']
+
+function readSource() {
+  return JSON.parse(readFileSync(resolve(repoRoot, SOURCE), 'utf8'))
+}
+
+function validate(catalog) {
+  const errors = []
+  if (catalog.schemaVersion !== 1) {
+    errors.push(`schemaVersion must be 1 (got ${String(catalog.schemaVersion)})`)
+  }
+  if (!Array.isArray(catalog.datasets) || catalog.datasets.length === 0) {
+    return ['datasets must be a non-empty array']
+  }
+  const seen = new Set()
+  for (const entry of catalog.datasets) {
+    const id = entry.id ?? '(no id)'
+    if (seen.has(id)) errors.push(`duplicate dataset id: ${id}`)
+    seen.add(id)
+    if (entry.kind !== 'builtin') errors.push(`${id}: kind must be "builtin"`)
+    if (!entry.materialize || typeof entry.materialize !== 'object') {
+      errors.push(`${id}: materialize descriptor is required`)
+    } else if (!MATERIALIZE_TYPES.includes(entry.materialize.type)) {
+      errors.push(`${id}: materialize.type must be one of ${MATERIALIZE_TYPES.join(', ')}`)
+    } else if (
+      entry.materialize.type === 'canonical-zip' &&
+      !(typeof entry.materialize.url === 'string' && entry.materialize.url.length > 0)
+    ) {
+      errors.push(`${id}: canonical-zip materialize requires a non-empty url`)
+    }
+    if (!Array.isArray(entry.provenance) || entry.provenance.length === 0) {
+      errors.push(`${id}: provenance must be non-empty`)
+    }
+  }
+  return errors
+}
+
+function serialize(catalog) {
+  return JSON.stringify(catalog, null, 2) + '\n'
+}
+
+function isStaleFile(file, content) {
+  if (!existsSync(resolve(repoRoot, file))) return true
+  return readFileSync(resolve(repoRoot, file), 'utf8') !== content
+}
+
+function main() {
+  const mode = process.argv[2] ?? ''
+  const catalog = readSource()
+  const errors = validate(catalog)
+
+  if (mode === '--check') {
+    let ok = true
+    for (const e of errors) {
+      console.error(`[build-dataset-catalog] INVALID: ${e}`)
+      ok = false
+    }
+    if (isStaleFile(CATALOG_FILE, serialize(catalog))) {
+      console.error(
+        `[build-dataset-catalog] STALE: ${CATALOG_FILE} does not match ${SOURCE}.\n` +
+          `  Run 'node scripts/build-dataset-catalog.mjs --update' and commit the result.`,
+      )
+      ok = false
+    }
+    if (ok) {
+      console.log(
+        `[build-dataset-catalog] OK: ${CATALOG_FILE} matches the ${catalog.datasets.length} built-in datasets`,
+      )
+    } else {
+      process.exit(1)
+    }
+  } else if (mode === '--update') {
+    for (const e of errors) console.error(`[build-dataset-catalog] INVALID: ${e}`)
+    if (errors.length > 0) process.exit(1)
+    writeFileSync(resolve(repoRoot, CATALOG_FILE), serialize(catalog))
+    console.log(
+      `[build-dataset-catalog] wrote ${CATALOG_FILE} (${catalog.datasets.length} built-in datasets)`,
+    )
+  } else {
+    for (const e of errors) console.error(`[build-dataset-catalog] INVALID: ${e}`)
+    if (errors.length > 0) process.exit(1)
+    process.stdout.write(serialize(catalog))
+  }
+}
+
+main()


### PR DESCRIPTION
Closes #207

Spec-driven built-in dataset catalog (`datasets.json`, like `train-modules.json`)
of immutable references (`kind: builtin`), materialized on first use (ADR-044 §7).

### What's in this PR

- **Curated source of truth** — `packages/modules/data/dataset/catalog/builtins.json`:
  a `DatasetBuiltinCatalog` where every entry is a full `DatasetManifest` +
  a `materialize` descriptor. Entries: Speech Commands V2 (CC BY 4.0), Google
  Speech Commands (CC BY 4.0), Common Voice (CC0), AudioSet/FMA noise
  (**`commercialUse: false`** — blocks commercial exports via the gate, #210).
- **Build script** — `scripts/build-dataset-catalog.mjs` generates
  `apps/web/public/datasets.json`; `pnpm gen:catalog` / `gen:catalog:check` +
  a CI freshness check (mirrors the engines/registry pattern).
- **`core/catalog.ts`** — `DatasetBuiltinCatalog` types, `validateDatasetCatalog`,
  `BuiltinMaterialize` (`canonical-zip` | `speech-commands-v2` | `pending-host`),
  `isBuiltinAvailable`.
- **Backend `wake_train_kit/builtin_catalog.py`** — `ensure_builtin` materializes
  on first use into the `datasets/` store: SC2 via the existing ADR-022
  converter (packed to a canonical zip, contentHash-verified), `canonical-zip`
  by fetch+import, `pending-host` raises a clear "declared but not yet hosted"
  error. `materialize.extract_dataset` resolves built-in ids so a picked
  built-in trains like any stored dataset. Wheel-packaged copy for generic
  runtimes.
- **Wizard `DatasetPicker`** — lists built-ins (static catalog) alongside store
  datasets; `pending-host` entries shown disabled, non-commercial flagged; the
  selection is still validated against `spec.train.dataset`.
- **Docs** — `docs/modules/data-sources.md` §7 + change log.

### Tests

- 8 backend tests (fake SC2 source via monkeypatch — **no network**, ADR-026 L1).
- 9 TS catalog tests (shipped catalog + validation edge cases).
- `pnpm -r test:unit` ✅ · `pnpm -r typecheck` ✅ · backend pytest 133 ✅ ·
  lint (0 errors) ✅ · web `pnpm build` ✅ · `gen:catalog:check` ✅.

### Note

SC2 is the only built-in that is fully materializable today
(`speech-commands-v2`); the other three are declared with license/provenance
(`pending-host`) and become trainable once a canonical zip is hosted (flagged
in the entries + docs).
