### PR TITLE
feat(train): dataset quality gate & reproducibility (check/split jobs, dedup, #209)

### DIFF
--- a/apps/studio-backend/registry.json
+++ b/apps/studio-backend/registry.json
@@ -86,6 +86,7 @@
    "GEN_SAMPLE_RATE": "{params.sampleRate}",
    "GEN_NAME": "{params.name}",
    "GEN_DATASET_ID": "{params.datasetId}",
+   "GEN_SEED": "{params.seed}",
    "GEN_BACKEND": "self-hosted"
   }
  },
@@ -99,6 +100,28 @@
    "STORAGE_SRC": "{params.src}",
    "STORAGE_DEST": "{params.dest}",
    "STORAGE_PREFIX": "{params.prefix}",
+   "GEN_BACKEND": "self-hosted"
+  }
+ },
+ "dataset-check": {
+  "cwd": "src/wake_train_kit",
+  "engine": "direct",
+  "entry": "check_runner.py",
+  "env": {
+   "CHECK_DATASET_ID": "{params.datasetId}",
+   "CHECK_SRC": "{params.src}",
+   "GEN_BACKEND": "self-hosted"
+  }
+ },
+ "dataset-split": {
+  "cwd": "src/wake_train_kit",
+  "engine": "direct",
+  "entry": "split_runner.py",
+  "env": {
+   "SPLIT_DATASET_ID": "{params.datasetId}",
+   "SPLIT_SRC": "{params.src}",
+   "SPLIT_SEED": "{params.seed}",
+   "SPLIT_RATIOS": "{params.ratios}",
    "GEN_BACKEND": "self-hosted"
   }
  }

--- a/apps/studio-backend/src/wake_train_kit/check_runner.py
+++ b/apps/studio-backend/src/wake_train_kit/check_runner.py
@@ -1,0 +1,162 @@
+"""wake_train_kit.check_runner — dataset-check job entry (ADR-044 §9, #209).
+
+Registry entry (engine "direct") for the studio-backend job manager (ADR-036).
+Reads job params from CHECK_* env vars + WAKE_PARAMS JSON (the registry
+convention), loads a dataset (by store id or by direct zip path), runs the
+quality gate (`wake_train_kit.quality.check_dataset`) and reports:
+
+- a ``health`` NDJSON event with the FULL health report (the Datasets console
+  parses it from the job log for live display),
+- a ``wake-studio-dataset-health.json`` artifact (durable copy),
+- a quality-annotated ``wake-studio-dataset.zip``: the manifest gains
+  ``quality`` = verdict + warnings (AC: warnings travel in the manifest);
+  any silent change bumps the dataset ``version`` (reproducibility rule).
+
+The job exits 0 whenever the check RAN (a ``fail`` verdict is a report, not a
+job failure); the console/UI decides what to block.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from wake_train_kit.dataset import import_dataset_zip, pack_dataset_zip
+from wake_train_kit.quality import QualityError, check_dataset, quality_summary
+
+try:
+    from wake_train_kit.report import Reporter
+except ImportError:  # standalone fallback: plain NDJSON prints
+    class Reporter:  # type: ignore[no-redef]
+        def emit(self, event: str, **fields: Any) -> None:
+            print(json.dumps({"event": event, **fields}), flush=True)
+
+
+DEFAULTS: dict[str, Any] = {
+    "datasetId": "",   # dataset from the durable datasets/ store
+    "src": "",         # direct path to a wake-studio-dataset.zip (dev/tests)
+}
+
+ENV_MAP: dict[str, str] = {
+    "CHECK_DATASET_ID": "datasetId",
+    "CHECK_SRC": "src",
+}
+
+
+def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
+    env = env if env is not None else os.environ
+    params: dict[str, Any] = dict(DEFAULTS)
+
+    raw_json = env.get("WAKE_PARAMS", "")
+    if raw_json:
+        try:
+            for key, value in json.loads(raw_json).items():
+                if key in DEFAULTS:
+                    params[key] = value
+        except (ValueError, TypeError):
+            pass
+
+    for var, key in ENV_MAP.items():
+        raw = env.get(var, "")
+        if raw != "":
+            params[key] = raw
+    return params
+
+
+def resolve_dataset_zip(
+    params: dict[str, Any],
+    work_dir: Path,
+) -> Path:
+    """The canonical zip path for the job target (store id or direct src)."""
+    src = params.get("src")
+    if src:
+        path = Path(src)
+        if not path.is_absolute():
+            path = (work_dir / path).resolve()
+        return path
+
+    dataset_id = params.get("datasetId")
+    if not dataset_id:
+        raise QualityError("dataset-check requires a datasetId or src")
+
+    from wake_train_kit.materialize import open_dataset_store
+
+    record = open_dataset_store().get(dataset_id)
+    if record is None:
+        raise QualityError(
+            f"dataset '{dataset_id}' is not in the backend store "
+            "(run a dataset-generate job first)"
+        )
+    return Path(record["stored_path"])
+
+
+def extract_zip(zip_path: Path, dest: Path) -> Path:
+    """Safe zip extraction (zip-slip guarded) -> the canonical `audio/` root."""
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        for member in zf.namelist():
+            target = (dest / member).resolve()
+            if not str(target).startswith(str(dest.resolve())):
+                raise QualityError(f"dataset zip contains an unsafe path: {member}")
+        zf.extractall(dest)
+    return dest / "audio"
+
+
+def main(argv: list[str] | None = None) -> int:
+    reporter = Reporter()
+    params = read_params()
+    work_dir = Path(os.environ.get("WORK_DIR", ".")).resolve()
+
+    reporter.emit(
+        "log", level="info",
+        message=f"dataset-check: datasetId={params['datasetId'] or '-'} "
+                f"src={params['src'] or '-'}",
+    )
+
+    try:
+        zip_path = resolve_dataset_zip(params, work_dir)
+        if not zip_path.is_file():
+            raise QualityError(f"dataset zip not found: {zip_path}")
+
+        manifest, _clips = import_dataset_zip(zip_path)
+        extract_root = work_dir / "check-extract"
+        if extract_root.exists():
+            shutil.rmtree(extract_root)
+        audio_root = extract_zip(zip_path, extract_root)
+
+        report = check_dataset(audio_root, manifest)
+        reporter.emit("health", report=report)
+
+        # durable full report artifact
+        report_path = work_dir / "wake-studio-dataset-health.json"
+        report_path.write_text(json.dumps(report, ensure_ascii=False), encoding="utf-8")
+        reporter.emit("artifact", path=str(report_path))
+
+        # quality-annotated dataset zip (manifest.quality + version bump)
+        annotated = dict(manifest)
+        annotated["quality"] = quality_summary(report)
+        annotated["version"] = int(manifest.get("version", 1)) + 1
+        out_zip = work_dir / "wake-studio-dataset.zip"
+        pack_dataset_zip(audio_root, annotated, out_zip)
+        reporter.emit("artifact", path=str(out_zip))
+
+        reporter.emit(
+            "log", level="info",
+            message=f"dataset-check: verdict={report['verdict']} "
+                    f"warnings={len(report['warnings'])}",
+        )
+        reporter.emit("done", exitCode=0)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        reporter.emit("error", message=f"dataset-check failed: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/studio-backend/src/wake_train_kit/data_sources.py
+++ b/apps/studio-backend/src/wake_train_kit/data_sources.py
@@ -268,6 +268,7 @@ def build_edge_tts_kws_dataset(
     sample_rate: int = 16000,
     voices: dict[str, list[str]] | None = None,
     reporter: Any = None,
+    voices_used: dict[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     """Build a multi-language `label/*.wav` tree for kws_streaming.
 
@@ -275,6 +276,12 @@ def build_edge_tts_kws_dataset(
     ``unknown_words`` become the "unknown" negatives (their folders are not in
     ``--wanted_words``, so upstream folds them into ``_unknown_``); a few
     silence clips are written to ``_background_noise_``.
+
+    ``voices_used`` (optional caller-owned dict) is filled with the DISTINCT
+    voices actually synthesized per label (name -> ordered list) — the
+    synthetic-to-real gap data the manifest records for the voice-count
+    warning (#209). The return value keeps the provenance-dict contract so
+    the kws-streaming train adapters (web/public copies) stay untouched.
     """
     try:
         import edge_tts  # noqa: F401  (fail fast with a clear error)
@@ -310,6 +317,10 @@ def build_edge_tts_kws_dataset(
                 mp3_to_wav(mp3, label_dir / f"{lang}_{i}.wav", sample_rate)
                 mp3.unlink(missing_ok=True)
                 total += 1
+                if voices_used is not None:
+                    seen = voices_used.setdefault(label, [])
+                    if voice not in seen:
+                        seen.append(voice)
                 if reporter is not None and hasattr(reporter, "progress"):
                     reporter.progress(
                         step=total, total=None, message=f"tts {label}/{lang} clip {i + 1}"
@@ -330,6 +341,10 @@ def build_edge_tts_kws_dataset(
             mp3_to_wav(mp3, label_dir / f"{lang}_0.wav", sample_rate)
             mp3.unlink(missing_ok=True)
             total += 1
+            if voices_used is not None:
+                seen = voices_used.setdefault(label, [])
+                if lang_voices[0] not in seen:
+                    seen.append(lang_voices[0])
             _log(reporter, "info", f"tts negative {label}/{lang}")
 
     # background noise: a couple of silent clips keep augmentation happy

--- a/apps/studio-backend/src/wake_train_kit/dataset.py
+++ b/apps/studio-backend/src/wake_train_kit/dataset.py
@@ -67,6 +67,8 @@ class DatasetManifest(TypedDict):
     recipe: dict[str, Any] | None
     contentHash: str | None
     storage: dict[str, Any] | None
+    quality: dict[str, Any] | None      # health-report summary (check-dataset, #209)
+    split: dict[str, Any] | None        # fixed train/val/test partition (split op, #209)
     createdAtMs: int | None
 
 
@@ -160,6 +162,54 @@ def validate_dataset_manifest(raw: Any) -> tuple[bool, list[str]]:
 
     if m.get("contentHash") is not None and not _is_nonempty_str(m.get("contentHash")):
         errors.append("contentHash, when present, must be a non-empty string")
+
+    quality = m.get("quality")
+    if quality is not None:
+        if not _is_plain_record(quality):
+            errors.append("quality must be an object")
+        else:
+            if quality.get("verdict") not in ("pass", "warn", "fail"):
+                errors.append('quality.verdict must be one of: pass, warn, fail')
+            if not isinstance(quality.get("warnings"), list):
+                errors.append("quality.warnings must be an array")
+            else:
+                for i, warning in enumerate(quality["warnings"]):
+                    if not _is_plain_record(warning):
+                        errors.append(f"quality.warnings[{i}] must be an object")
+                        continue
+                    if not _is_nonempty_str(warning.get("code")):
+                        errors.append(f"quality.warnings[{i}].code must be a non-empty string")
+                    if warning.get("severity") not in ("info", "warn", "fail"):
+                        errors.append(
+                            f"quality.warnings[{i}].severity must be one of: info, warn, fail"
+                        )
+
+    split = m.get("split")
+    if split is not None:
+        if not _is_plain_record(split):
+            errors.append("split must be an object")
+        else:
+            if not isinstance(split.get("seed"), int):
+                errors.append("split.seed must be an integer")
+            ratios = split.get("ratios")
+            if (
+                not isinstance(ratios, list)
+                or len(ratios) != 3
+                or not all(isinstance(r, (int, float)) and 0 <= r <= 1 for r in ratios)
+            ):
+                errors.append("split.ratios must be three numbers between 0 and 1")
+            seen_refs: dict[str, str] = {}
+            for part in ("train", "val", "test"):
+                refs = split.get(part)
+                if not isinstance(refs, list) or not all(
+                    _is_nonempty_str(r) and r.startswith("audio/") for r in refs
+                ):
+                    errors.append(f"split.{part} must be an array of audio/<label>/<clip> refs")
+                    continue
+                for ref in refs:
+                    if ref in seen_refs:
+                        errors.append(f"split ref \"{ref}\" appears in both {seen_refs[ref]} and {part}")
+                    seen_refs[ref] = part
 
     return len(errors) == 0, errors
 

--- a/apps/studio-backend/src/wake_train_kit/generation.py
+++ b/apps/studio-backend/src/wake_train_kit/generation.py
@@ -95,8 +95,14 @@ def build_manifest(
     audio_root: Path,
     provenance: dict[str, Any],
     labels: list[dict[str, Any]],
+    tool_versions: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Assemble the ``dataset.json`` manifest for a generated dataset."""
+    """Assemble the ``dataset.json`` manifest for a generated dataset.
+
+    Reproducibility (#209): ``recipe.seed`` (from params) + ``recipe.toolVersions``
+    (engine toolchain, e.g. edge-tts version) make "regenerate" byte-reproducible
+    — same params + same tool versions → same ``contentHash``.
+    """
     clips = 0
     for label_dir in audio_root.iterdir():
         if label_dir.is_dir():
@@ -127,8 +133,8 @@ def build_manifest(
             "engine": params.get("engine") or "edge-tts",
             "phrases": phrases,
             "languages": languages,
-            "seed": 0,
-            "toolVersions": {},
+            "seed": int(params.get("seed") or 0),
+            "toolVersions": dict(tool_versions or {}),
         },
         "storage": {"backend": f"datasets/{dataset_id}/"},
         "createdAtMs": int(time.time() * 1000),
@@ -174,6 +180,12 @@ def generate_dataset(
 
     if reporter is not None and hasattr(reporter, "progress"):
         reporter.progress(step=3, total=3, progress=1.0, message="assemble")
-    manifest = build_manifest(params, audio_root, provenance, labels)
+    manifest = build_manifest(
+        params,
+        audio_root,
+        provenance,
+        labels,
+        tool_versions=result.get("toolVersions"),
+    )
     zip_path = pack_dataset_zip(audio_root, manifest, work / "wake-studio-dataset.zip")
     return zip_path

--- a/apps/studio-backend/src/wake_train_kit/generation_runner.py
+++ b/apps/studio-backend/src/wake_train_kit/generation_runner.py
@@ -40,6 +40,7 @@ DEFAULTS: dict[str, Any] = {
     "sampleRate": 16000,
     "name": "",
     "datasetId": "",
+    "seed": "0",
 }
 
 ENV_MAP: dict[str, str] = {
@@ -57,6 +58,7 @@ ENV_MAP: dict[str, str] = {
     "GEN_SAMPLE_RATE": "sampleRate",
     "GEN_NAME": "name",
     "GEN_DATASET_ID": "datasetId",
+    "GEN_SEED": "seed",
 }
 
 

--- a/apps/studio-backend/src/wake_train_kit/materialize.py
+++ b/apps/studio-backend/src/wake_train_kit/materialize.py
@@ -388,6 +388,35 @@ def _merge_dataset_trees(base: Path, tree: Path, out_dir: Path) -> Path:
     return out_dir
 
 
+def _scan_duplicate_warnings(clip_root: Path) -> list[str]:
+    """Warn LOUDLY (never silently drop) about mix-time duplicates (#209).
+
+    Exact duplicates (sha256) and near-duplicate clusters (perceptual
+    features) both signal train/eval leakage risk; the reproducible split
+    keeps each near-dup cluster in ONE partition. Called on the merged data
+    root (kws-streaming) or the materialized pools (openwakeword — the
+    `positives/` / `background/` dirs double as label folders for the scan).
+    """
+    from .quality import exact_duplicate_groups, near_duplicate_clusters
+
+    warnings: list[str] = []
+    exact = exact_duplicate_groups(clip_root)
+    dup_clips = sum(len(g) for groups in exact.values() for g in groups)
+    if dup_clips:
+        warnings.append(
+            f"{dup_clips} exact-duplicate clip(s) detected in the mixed data - "
+            "dedup before splitting so evaluation never sees training data (#209)."
+        )
+    near = near_duplicate_clusters(clip_root)
+    if near:
+        warnings.append(
+            f"{len(near)} near-duplicate cluster(s) detected in the mixed data "
+            "(train/eval leakage risk) - the split keeps each cluster in one "
+            "partition (#209)."
+        )
+    return warnings
+
+
 #: kws-streaming's canonical requirements (mirrors the module spec.train.dataset).
 KWS_STREAMING_REQUIREMENTS: dict[str, Any] = {
     "sampleRate": 16000,
@@ -489,6 +518,9 @@ def materialize_kws_streaming(
     for i, tree in enumerate(trees[1:], start=1):
         _log(reporter, "info", f"merging dataset tree {i + 1} into the data root")
         merged = _merge_dataset_trees(merged, tree, out / f"merged_{i}")
+
+    # mix-time quality scan: warn loudly on exact/near duplicates (#209)
+    warnings.extend(_scan_duplicate_warnings(merged))
 
     wanted: list[str] = []
     for manifest in manifests:
@@ -650,6 +682,10 @@ def materialize_openwakeword(
         )
 
     feature_data_files: dict[str, str] = {}
+
+    # mix-time quality scan: warn loudly on exact/near duplicates (#209). The
+    # materialized pools (positives/ + background/) are scanned as labels.
+    warnings.extend(_scan_duplicate_warnings(out))
     for label, wavs in unknown_features.items():
         if not wavs:
             continue

--- a/apps/studio-backend/src/wake_train_kit/quality.py
+++ b/apps/studio-backend/src/wake_train_kit/quality.py
@@ -1,0 +1,705 @@
+"""wake_train_kit.quality — dataset quality gate + reproducibility (ADR-044 §9, #209).
+
+Implements the v1 priorities from `docs/modules/data-sources.md` §9:
+
+1. **Quality gate** — `check_dataset()` produces a health report: per-label
+   clip counts, duration distribution, silence/empty clips, exact duplicates
+   (sha256), near duplicates (perceptual fingerprint), clipping, sample-rate
+   drift, label imbalance, voice counts + real-vs-synthetic (from the
+   manifest). Every finding is a structured warning (code + severity) and the
+   overall verdict is ``pass | warn | fail`` so trainers and the Datasets
+   console can act on it. The ``check-dataset`` job records the verdict +
+   warnings into the dataset manifest as ``quality`` (a silent content
+   change bumps the dataset ``version`` — reproducibility rule).
+2. **Synthetic-to-real gap** — per-label voice count + ``source`` come from
+   the manifest; warnings fire on too-few voices and on 100%-synthetic
+   wake-word datasets (TTS overfit risk at inference).
+3. **Dedup + reproducible splits** — exact duplicates are removable when
+   mixing datasets (``deduplicate_clips``); near-duplicate clips are
+   clustered (perceptual fingerprint, union-find) so a seeded
+   ``split_dataset`` assigns an entire cluster to ONE partition — a train
+   sample never leaks into val/test. The partition is recorded in the
+   manifest as ``split`` (web `core/spec.ts` mirror).
+4. **Reproducibility** — ``recipe.seed`` + ``recipe.toolVersions`` +
+   ``contentHash``: same root + seed + ratios → identical split; regenerate
+   is byte-reproducible and any silent change bumps ``version``/``contentHash``.
+
+Pure stdlib (no numpy/ffmpeg): WAV parsing + PCM decoding are deliberate v1
+simplifications for the canonical 16 kHz mono s16le form.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import struct
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+CANONICAL_SAMPLE_RATE = 16000
+
+#: |sample| below this (≈ −63 dBFS) marks a clip as silent/empty.
+SILENCE_PEAK_THRESHOLD = 24
+#: |sample| at/above this (within 1 LSB of full scale) marks clipping.
+CLIPPING_SAMPLE = 32766
+#: silence ratio above which the dataset is flagged.
+SILENCE_WARN_RATIO = 0.02
+#: cosine similarity at/above which two clips' envelopes are near-duplicates.
+NEAR_DUP_SIMILARITY = 0.99
+#: relative mean-zero-crossing-rate (pitch) tolerance for near-duplicates.
+NEAR_DUP_PITCH_TOLERANCE = 0.10
+#: near-duplicate candidates must also fall within this relative duration window.
+NEAR_DUP_DURATION_TOLERANCE = 0.15
+#: label-imbalance (max/min clip count) above which mixing is flagged.
+IMBALANCE_WARN_RATIO = 8.0
+#: positive labels with fewer distinct voices are flagged (TTS overfit risk).
+MIN_POSITIVE_VOICES = 2
+
+WARNING_CODES = {
+    "empty-label",
+    "silence",
+    "clipping",
+    "sample-rate-drift",
+    "exact-duplicates",
+    "near-duplicates",
+    "label-imbalance",
+    "too-few-voices",
+    "all-synthetic-positive",
+    "missing-voices-metadata",
+}
+SEVERITIES = {"info", "warn", "fail"}
+
+#: partition ratios parity with the web split mirrors (train/val/test).
+DEFAULT_SPLIT_RATIOS = (0.8, 0.1, 0.1)
+
+
+class QualityError(RuntimeError):
+    """Raised when a dataset root cannot be quality-checked (missing audio/, no clips)."""
+
+
+# ---------------------------------------------------------------------------
+# WAV probing (canonical 16 kHz mono s16le; tolerant of drift)
+# ---------------------------------------------------------------------------
+
+class WavMeta:
+    """Probed header + decoded samples of one canonical PCM clip."""
+
+    __slots__ = ("sample_rate", "channels", "bits", "frames", "samples")
+
+    def __init__(self, sample_rate: int, channels: int, bits: int,
+                 frames: int, samples: list[int]) -> None:
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.bits = bits
+        self.frames = frames
+        self.samples = samples
+
+    @property
+    def duration_sec(self) -> float:
+        return self.frames / self.sample_rate if self.sample_rate else 0.0
+
+    @property
+    def peak(self) -> int:
+        return max((abs(s) for s in self.samples), default=0)
+
+    @property
+    def silent(self) -> bool:
+        return self.frames == 0 or self.peak < SILENCE_PEAK_THRESHOLD
+
+    @property
+    def clipping(self) -> bool:
+        return any(abs(s) >= CLIPPING_SAMPLE for s in self.samples)
+
+
+def parse_wav(buffer: bytes) -> WavMeta | None:
+    """Parse a RIFF/WAVE buffer into a :class:`WavMeta` (None when not a WAV).
+
+    Reads the ``fmt `` + ``data`` chunks (enough for canonical PCM WAVs; no
+    decoding for compressed codecs — those are not canonical dataset clips).
+    """
+    try:
+        if buffer[:4] != b"RIFF" or buffer[8:12] != b"WAVE":
+            return None
+        offset = 12
+        fmt: dict[str, int] = {}
+        data_start = 0
+        data_size = 0
+        while offset + 8 <= len(buffer):
+            chunk_id = buffer[offset:offset + 4]
+            chunk_size = struct.unpack("<I", buffer[offset + 4:offset + 8])[0]
+            payload = buffer[offset + 8:offset + 8 + chunk_size]
+            if chunk_id == b"fmt " and len(payload) >= 16:
+                audio_format, channels, rate, _, _, bits = struct.unpack(
+                    "<HHIIHH", payload[:16]
+                )
+                if audio_format != 1:  # PCM only (canonical form)
+                    return None
+                fmt = {"channels": channels, "rate": rate, "bits": bits}
+            elif chunk_id == b"data":
+                data_start = offset + 8
+                data_size = chunk_size
+            offset += 8 + chunk_size + (chunk_size & 1)  # word-aligned
+            if chunk_id == b"data":
+                break
+        if not fmt:
+            return None
+        samples: list[int] = []
+        if fmt["bits"] == 16:
+            available = min(data_size, max(0, len(buffer) - data_start))
+            samples = [
+                struct.unpack("<h", buffer[j:j + 2])[0]
+                for j in range(data_start, data_start + available - 1, 2)
+            ]
+        if fmt["channels"] != 1:
+            samples = samples[:: fmt["channels"]]  # keep only the first channel
+        return WavMeta(
+            sample_rate=fmt["rate"],
+            channels=fmt["channels"],
+            bits=fmt["bits"],
+            frames=len(samples),
+            samples=samples,
+        )
+    except (struct.error, IndexError, ValueError):
+        return None
+
+
+def _read_clip(path: Path) -> WavMeta | None:
+    try:
+        return parse_wav(path.read_bytes())
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Perceptual features (dependency-free)
+# ---------------------------------------------------------------------------
+
+#: number of windowed mean-|amplitude| values in the envelope feature.
+AMPLITUDE_WINDOWS = 16
+
+
+def amplitude_envelope(samples: list[int]) -> list[float]:
+    """Unit-normalized windowed mean-|amplitude| envelope of a clip (16 dims).
+
+    Deterministic and robust to small sample noise (a re-synth of the same
+    phrase jitters by a few LSB, which barely moves the means). All-zero / tiny
+    clips get a zero vector (never confusable with speech).
+    """
+    n = len(samples)
+    if n < 8:
+        return [0.0] * AMPLITUDE_WINDOWS
+    amp: list[float] = []
+    for i in range(AMPLITUDE_WINDOWS):
+        win = samples[(i * n) // AMPLITUDE_WINDOWS:((i + 1) * n) // AMPLITUDE_WINDOWS]
+        amp.append(sum(abs(s) for s in win) / max(1, len(win)))
+    scale = max(amp) or 1.0
+    vec = [a / scale for a in amp]
+    norm = sum(v * v for v in vec) ** 0.5 or 1.0
+    return [v / norm for v in vec]
+
+
+def mean_zero_crossing_rate(samples: list[int]) -> float:
+    """Mean fraction of adjacent-sample sign changes (0..1) — a pitch cue.
+
+    Tone pitch scales this ~linearly (harmonics too), so a relative tolerance
+    separates a re-synth (same pitch) from a different phrase/pitch.
+    """
+    n = len(samples)
+    if n < 2:
+        return 0.0
+    crossings = 0
+    for a, b in zip(samples, samples[1:]):
+        if (a < 0) != (b < 0):
+            crossings += 1
+    return crossings / (n - 1)
+
+
+def audio_feature(samples: list[int]) -> tuple[list[float], float]:
+    """(amplitude envelope, mean zero-crossing rate) — the perceptual pair.
+
+    ``audio_similarity`` compares envelopes; the pitch tolerance check runs on
+    the zcr component inside :func:`near_duplicate_clusters`.
+    """
+    return amplitude_envelope(samples), mean_zero_crossing_rate(samples)
+
+
+def audio_similarity(a: Iterable[float], b: Iterable[float]) -> float:
+    """Cosine similarity of two unit-normalized envelope vectors (0..1)."""
+    return sum(x * y for x, y in zip(a, b))
+
+
+# ---------------------------------------------------------------------------
+# Duplicate scanning
+# ---------------------------------------------------------------------------
+
+def _clip_entries(clip_root: Path) -> list[tuple[str, Path]]:
+    """Sorted ``(label, path)`` list for every wav under a canonical audio/ root."""
+    root = Path(clip_root)
+    if not root.is_dir():
+        return []
+    entries: list[tuple[str, Path]] = []
+    for label_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        for wav in sorted(label_dir.glob("*.wav")):
+            entries.append((label_dir.name, wav))
+    return entries
+
+
+def exact_duplicate_groups(clip_root: Path) -> dict[str, list[list[str]]]:
+    """label → groups of byte-identical clip names (sha256), groups of size > 1."""
+    groups: dict[str, list[list[str]]] = {}
+    by_hash: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for label, path in _clip_entries(clip_root):
+        try:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            continue
+        by_hash[digest].append((label, path.name))
+    for members in by_hash.values():
+        if len(members) < 2:
+            continue
+        label = members[0][0]
+        if any(l != label for l, _ in members):
+            continue  # exclude cross-label collisions from exact-dup reporting
+        groups.setdefault(label, []).append([name for _, name in members])
+    return groups
+
+
+def near_duplicate_clusters(clip_root: Path) -> list[list[Path]]:
+    """Union-find clusters of near-duplicate clips (perceptual fingerprint).
+
+    Same label + same sample rate + duration within NEAR_DUP_DURATION_TOLERANCE
+    + Hamming distance ≤ NEAR_DUP_HAMMING → one cluster. Clusters are the
+    unit of the reproducible split: assigning a whole cluster to ONE partition
+    guarantees no train↔eval leakage.
+    """
+    entries = _clip_entries(clip_root)
+    metas: list[WavMeta | None] = [_read_clip(p) for _, p in entries]
+    features: list[tuple[list[float], float]] = [
+        audio_feature(m.samples) if m is not None else ([0.0] * AMPLITUDE_WINDOWS, 0.0)
+        for m in metas
+    ]
+    rates = [m.sample_rate if m else 0 for m in metas]
+    durations = [m.duration_sec if m else 0.0 for m in metas]
+
+    parent = list(range(len(entries)))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for i in range(len(entries)):
+        for j in range(i + 1, len(entries)):
+            if entries[i][0] != entries[j][0]:
+                continue
+            if rates[i] != rates[j] or rates[i] == 0:
+                continue
+            dur_a, dur_b = durations[i], durations[j]
+            if dur_a == 0 and dur_b == 0:
+                dur_a = dur_b = 1.0  # silent clips compare by feature only
+            if abs(dur_a - dur_b) > NEAR_DUP_DURATION_TOLERANCE * max(dur_a, dur_b):
+                continue
+            env_a, zcr_a = features[i]
+            env_b, zcr_b = features[j]
+            if audio_similarity(env_a, env_b) < NEAR_DUP_SIMILARITY:
+                continue
+            zcr_peak = max(zcr_a, zcr_b)
+            if zcr_peak > 0 and abs(zcr_a - zcr_b) / zcr_peak > NEAR_DUP_PITCH_TOLERANCE:
+                continue
+            union(i, j)
+
+    clusters: dict[int, list[Path]] = defaultdict(list)
+    for i, (label, path) in enumerate(entries):
+        clusters[find(i)].append(path)
+    return [sorted(c, key=lambda p: str(p)) for c in clusters.values() if len(c) > 1]
+
+
+def near_duplicate_pairs(clip_root: Path) -> list[tuple[Path, Path]]:
+    """Representative first pair per near-duplicate cluster (for warnings)."""
+    pairs: list[tuple[Path, Path]] = []
+    for cluster in near_duplicate_clusters(clip_root):
+        pairs.append((cluster[0], cluster[1]))
+    return pairs
+
+
+def deduplicate_clips(clip_root: Path, reporter: Any = None) -> dict[str, Any]:
+    """Remove exact-duplicate wavs in-place (keep the first by sorted name).
+
+    Called when MIXING datasets so the merged tree never contains a
+    byte-identical copy of a clip (evaluation would otherwise see training
+    data). Returns stats::
+
+        {"removed": N, "groups": {label: group_count}}
+
+    Near-duplicates are NOT removed silently — they surface as warnings
+    (`near-duplicates`) and the reproducible split keeps them out of leakage.
+    """
+    removed = 0
+    groups: dict[str, int] = defaultdict(int)
+    for label, paths in exact_duplicate_groups(clip_root).items():
+        for group in paths:
+            keep = sorted(group)[0]
+            for name in group:
+                if name == keep:
+                    continue
+                try:
+                    (Path(clip_root) / label / name).unlink()
+                    removed += 1
+                except OSError:
+                    continue
+            groups[label] += 1
+    if reporter is not None and hasattr(reporter, "emit"):
+        reporter.emit("log", level="info", message=f"dedup: removed {removed} exact-duplicate clips")
+    elif reporter is not None and hasattr(reporter, "log"):
+        reporter.log(level="info", message=f"dedup: removed {removed} exact-duplicate clips")
+    return {"removed": removed, "groups": dict(groups)}
+
+
+# ---------------------------------------------------------------------------
+# Health report
+# ---------------------------------------------------------------------------
+
+def _label_stats(clip_root: Path, label: str) -> dict[str, Any]:
+    """Aggregate metrics for one label folder (duration stats, silence, clipping...)."""
+    folder = Path(clip_root) / label
+    durations: list[float] = []
+    silent = 0
+    clipping = 0
+    non_standard_rate = 0
+    fingerprint_pairs: list[tuple[Path, Path]] = []
+    for wav in sorted(folder.glob("*.wav")):
+        meta = _read_clip(wav)
+        if meta is None:
+            continue
+        durations.append(meta.duration_sec)
+        if meta.silent:
+            silent += 1
+        if meta.clipping:
+            clipping += 1
+        if meta.sample_rate != CANONICAL_SAMPLE_RATE:
+            non_standard_rate += 1
+
+    def _durations() -> dict[str, float]:
+        if not durations:
+            return {"clips": 0, "minSec": 0, "maxSec": 0, "meanSec": 0, "totalSec": 0}
+        return {
+            "clips": len(durations),
+            "minSec": round(min(durations), 3),
+            "maxSec": round(max(durations), 3),
+            "meanSec": round(sum(durations) / len(durations), 3),
+            "totalSec": round(sum(durations), 3),
+        }
+
+    return {
+        "clips": len(durations),
+        "duration": _durations(),
+        "silent": silent,
+        "clipping": clipping,
+        "nonStandardSampleRate": non_standard_rate,
+    }
+
+
+def _manifest_voice_info(manifest: dict[str, Any] | None, label: str) -> tuple[list[str] | None, str | None]:
+    """(voices list, source) for a label from the manifest (None when absent)."""
+    if not manifest:
+        return None, None
+    for entry in manifest.get("labels") or []:
+        if entry.get("name") == label:
+            voices = entry.get("voices")
+            return list(voices) if isinstance(voices, list) else None, entry.get("source")
+    return None, None
+
+
+def check_dataset(clip_root: Path | str, manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Run the full quality gate over a canonical ``audio/`` clip root.
+
+    Returns the health report (JSON-serializable): ``verdict``
+    (``pass|warn|fail``), per-label metrics, exact/near-duplicate stats,
+    voice + source coverage from the manifest, and a structured
+    ``warnings[]`` list (code + severity + message). Raises ``QualityError``
+    when the root has no clips at all (nothing to check).
+    """
+    root = Path(clip_root)
+    if not root.is_dir():
+        raise QualityError(f"no label folders found under {root}")
+    labels = sorted(p.name for p in root.iterdir() if p.is_dir())
+    if not labels or labels == ["audio"]:
+        # label folders may sit directly under the root (pure tree) or under
+        # audio/ (extracted dataset zip) — be lenient about the wrapper dir.
+        audio_dir = root / "audio"
+        if audio_dir.is_dir():
+            return check_dataset(audio_dir, manifest)
+        raise QualityError(f"no label folders found under {root}")
+
+    report_labels: dict[str, Any] = {}
+    warnings: list[dict[str, str]] = []
+    totals = {
+        "clips": 0, "silent": 0, "clipping": 0, "nonStandardSampleRate": 0,
+        "exactDuplicateGroups": 0, "nearDuplicateClusters": 0,
+    }
+
+    exact_by_label = exact_duplicate_groups(root)
+    near_by_label: dict[str, int] = defaultdict(int)
+    for cluster in near_duplicate_clusters(root):
+        near_by_label[cluster[0].parent.name] += 1
+
+    for label in labels:
+        stats = _label_stats(root, label)
+        if stats["clips"] == 0:
+            warnings.append({
+                "code": "empty-label",
+                "severity": "fail",
+                "message": f'label "{label}" has no WAV clips (this label cannot be trained on)',
+            })
+        exact = exact_by_label.get(label, [])
+        near = near_by_label.get(label, 0)
+
+        voices, source = _manifest_voice_info(manifest, label)
+        entry = {
+            "clips": stats["clips"],
+            "duration": stats["duration"],
+            "silent": stats["silent"],
+            "clipping": stats["clipping"],
+            "nonStandardSampleRate": stats["nonStandardSampleRate"],
+            "exactDuplicateGroups": len(exact),
+            "nearDuplicateClusters": near,
+            "voices": len(voices) if voices is not None else None,
+            "source": source,
+        }
+        report_labels[label] = entry
+        totals["clips"] += stats["clips"]
+        totals["silent"] += stats["silent"]
+        totals["clipping"] += stats["clipping"]
+        totals["nonStandardSampleRate"] += stats["nonStandardSampleRate"]
+        totals["exactDuplicateGroups"] += len(exact)
+        totals["nearDuplicateClusters"] += near
+
+    # --- voice coverage + synthetic-to-real gap -------------------------------
+    for label in labels:
+        voices, source = _manifest_voice_info(manifest, label)
+        role = None
+        if manifest:
+            role = next((l.get("role") for l in manifest.get("labels") or [] if l.get("name") == label), None)
+        if role == "positive" and voices is None:
+            warnings.append({
+                "code": "missing-voices-metadata",
+                "severity": "info",
+                "message": f'positive label "{label}" has no voice metadata (voices[]) — '
+                           "voice-count warnings cannot be computed",
+            })
+        elif role == "positive" and len(voices) < MIN_POSITIVE_VOICES:
+            warnings.append({
+                "code": "too-few-voices",
+                "severity": "warn",
+                "message": f'positive label "{label}" uses {len(voices)} distinct voice(s) '
+                           "(< 2): TTS-overfit risk at inference, consider more voices",
+            })
+
+    if manifest:
+        positives = [l.get("name") for l in manifest.get("labels") or [] if l.get("role") == "positive"]
+        if positives and all(
+            _manifest_voice_info(manifest, l)[1] == "synthetic" for l in positives
+        ):
+            warnings.append({
+                "code": "all-synthetic-positive",
+                "severity": "warn",
+                "message": "every wake-word (positive) label is 100% synthetic — verify "
+                           "real-voice recognition before relying on it in production",
+            })
+
+    # --- content checks -------------------------------------------------------
+
+    # silence/clipping/imbalance ignore role:noise labels (background noise is
+    # legitimately low-energy); they only flag synthesis glitches in speech.
+    noise_roles = set()
+    if manifest:
+        noise_roles = {l.get("name") for l in manifest.get("labels") or []
+                       if l.get("role") == "noise"}
+    content_clips = totals["clips"] - sum(
+        report_labels[l]["clips"] for l in report_labels if l in noise_roles
+    )
+    content_silent = totals["silent"] - sum(
+        report_labels[l]["silent"] for l in report_labels if l in noise_roles
+    )
+
+    if content_clips > 0 and content_silent / content_clips > SILENCE_WARN_RATIO:
+        warnings.append({
+            "code": "silence",
+            "severity": "warn",
+            "message": f"{content_silent} of {content_clips} speech clips are silent/empty "
+                       "— check the TTS output and postprocess step",
+        })
+    if totals["clipping"] > 0:
+        warnings.append({
+            "code": "clipping",
+            "severity": "warn",
+            "message": f"{totals['clipping']} clip(s) hit full scale (clipping/distortion)",
+        })
+    if totals["nonStandardSampleRate"] > 0:
+        warnings.append({
+            "code": "sample-rate-drift",
+            "severity": "warn",
+            "message": f"{totals['nonStandardSampleRate']} clip(s) are not 16 kHz — "
+                       "materializers/trainers may reject them",
+        })
+    if totals["exactDuplicateGroups"] > 0:
+        warnings.append({
+            "code": "exact-duplicates",
+            "severity": "warn",
+            "message": f"{totals['exactDuplicateGroups']} exact-duplicate group(s) found "
+                       "- run dedup when mixing to keep eval clean",
+        })
+    if totals["nearDuplicateClusters"] > 0:
+        warnings.append({
+            "code": "near-duplicates",
+            "severity": "warn",
+            "message": f"{totals['nearDuplicateClusters']} near-duplicate cluster(s) for "
+                       "leakage risk - the reproducible split keeps each cluster in one partition",
+        })
+    if totals["clips"] > 0:
+        counts = [report_labels[l]["clips"] for l in report_labels if report_labels[l]["clips"] > 0]
+        if counts and max(counts) / min(counts) > IMBALANCE_WARN_RATIO:
+            warnings.append({
+                "code": "label-imbalance",
+                "severity": "warn",
+                "message": f"label clip counts are imbalanced (max {max(counts)} vs min {min(counts)} "
+                           f"clips, ratio > {IMBALANCE_WARN_RATIO:.0f}x) - thin labels underfit",
+            })
+
+    verdict = "fail" if any(w["severity"] == "fail" for w in warnings) else (
+        "warn" if any(w["severity"] == "warn" for w in warnings) else "pass"
+    )
+
+    import time
+    return {
+        "schemaVersion": 1,
+        "verdict": verdict,
+        "checkedAtSec": int(time.time()),
+        "totals": totals,
+        "labels": report_labels,
+        "warnings": warnings,
+    }
+
+
+def quality_summary(report: dict[str, Any]) -> dict[str, Any]:
+    """The durable manifest slice of a health report (AC: warnings in manifest).
+
+    ``quality`` is recorded into ``dataset.json`` by the check job (a silent
+    content change bumps the dataset ``version``).
+    """
+    return {
+        "checkedAtSec": report.get("checkedAtSec"),
+        "verdict": report.get("verdict"),
+        "warnings": report.get("warnings", []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reproducible split
+# ---------------------------------------------------------------------------
+
+def _clip_refs(clip_root: Path) -> list[str]:
+    """Sorted canonical refs ``audio/<label>/<name>`` for every wav in the tree."""
+    refs: list[str] = []
+    for label, path in _clip_entries(clip_root):
+        refs.append(f"audio/{label}/{path.name}")
+    return refs
+
+
+def distribute_clusters(
+    clusters: list[list[Path]],
+    ratios: tuple[float, float, float],
+    seed: int,
+) -> tuple[list[list[Path]], list[list[Path]], list[list[Path]]]:
+    """Deterministically assign near-duplicate clusters to train/val/test.
+
+    Seeded shuffle of the sorted clusters, then greedy fill toward the ratio
+    targets. Cluster = unit of assignment, so duplicates never straddle
+    partitions (no leakage). Deterministic: same clusters + seed + ratios →
+    the same partitions.
+    """
+    rng = random.Random(seed)
+    ordered = sorted(clusters, key=lambda c: str(c[0]))
+    rng.shuffle(ordered)
+    if not ordered:
+        return [], [], []
+    total = sum(len(c) for c in ordered)
+    targets = [r * total for r in ratios]
+    buckets: list[list[list[Path]]] = [[], [], []]
+    sizes = [0, 0, 0]
+    for cluster in ordered:
+        # pick the partition whose current fill is farthest below its target
+        deficit = [targets[i] - sizes[i] for i in range(3)]
+        chosen = max(range(3), key=lambda i: deficit[i])
+        buckets[chosen].append(cluster)
+        sizes[chosen] += len(cluster)
+    # every partition non-empty when the tree is big enough (deterministic:
+    # move one cluster out of the largest partition into each empty one)
+    empty = [i for i in range(3) if not buckets[i]]
+    while empty and len(ordered) >= 3:
+        src = max(range(3), key=lambda i: sizes[i])
+        if not buckets[src] or sizes[src] <= 1:
+            break
+        moved = buckets[src].pop()
+        sizes[src] -= len(moved)
+        target = empty.pop(0)
+        buckets[target] = [moved]
+        sizes[target] += len(moved)
+    return buckets[0], buckets[1], buckets[2]
+
+
+def split_dataset(
+    clip_root: Path | str,
+    manifest: dict[str, Any],
+    *,
+    seed: int = 0,
+    ratios: tuple[float, float, float] = DEFAULT_SPLIT_RATIOS,
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
+    """Compute a reproducible train/val/test partition; returns
+    ``(manifest_with_split, partitions)``.
+
+    ``partitions`` = ``{"train": [...refs], "val": [...], "test": [...]}`` where
+    refs are canonical ``audio/<label>/<name>`` paths. The manifest copy gains
+    ``split`` = ``{"seed", "ratios", train/val/test}`` (the web
+    ``core/spec.ts`` ``DatasetSplit`` mirror). ``manifest`` is never mutated.
+
+    The caller decides how to persist the split dataset (a new artifact with a
+    new id/version, or an in-place version bump) — the partition record itself
+    is the contract every backend trains on (docs/modules/data-sources.md §9.3).
+    """
+    root = Path(clip_root)
+    clusters = near_duplicate_clusters(root)
+    singletons = [Path(p) for (_, p) in _clip_entries(root)]
+    clustered: set[Path] = {p for c in clusters for p in c}
+    singles = [p for p in singletons if p not in clustered]
+
+    # clusters (duplicates must travel as one unit) then individual singles,
+    # both with the same seeded, deterministic logic
+    train_c, val_c, test_c = distribute_clusters(clusters, ratios, seed)
+    train_s, val_s, test_s = distribute_clusters([[s] for s in singles], ratios, seed)
+
+    def _refs(cluster_groups: Iterable[list[Path]]) -> list[str]:
+        refs = sorted(f"audio/{p.parent.name}/{p.name}" for g in cluster_groups for p in g)
+        return refs
+
+    partitions = {
+        "train": _refs([*train_c, *train_s]),
+        "val": _refs([*val_c, *val_s]),
+        "test": _refs([*test_c, *test_s]),
+    }
+    out = dict(manifest)
+    out["split"] = {
+        "seed": seed,
+        "ratios": list(ratios),
+        "train": partitions["train"],
+        "val": partitions["val"],
+        "test": partitions["test"],
+    }
+    return out, partitions

--- a/apps/studio-backend/src/wake_train_kit/split_runner.py
+++ b/apps/studio-backend/src/wake_train_kit/split_runner.py
@@ -1,0 +1,189 @@
+"""wake_train_kit.split_runner — dataset-split job entry (ADR-044 §9, #209).
+
+Registry entry (engine "direct") for the studio-backend job manager (ADR-036).
+Reads job params from SPLIT_* env vars + WAKE_PARAMS JSON (the registry
+convention), loads a dataset (store id or direct zip), computes a
+REPRODUCIBLE train/val/test partition and emits a NEW canonical dataset zip
+whose manifest records the partition:
+
+    split: {"seed": N, "ratios": [r_train, r_val, r_test],
+            "train": ["audio/<label>/<clip>", ...], "val": [...], "test": [...]}
+
+Every backend materializes the same split (docs/modules/data-sources.md §9.3);
+near-duplicate clips stay in ONE partition, so train/eval cannot leak
+(quality.py `split_dataset`). The split dataset is a new first-class dataset:
+new id, ``recipe.split.parentId`` pointing at the source dataset. The manager
+persists the emitted ``wake-studio-dataset.zip`` into the durable store
+automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from wake_train_kit.dataset import pack_dataset_zip
+from wake_train_kit.quality import QualityError, split_dataset
+
+try:
+    from wake_train_kit.report import Reporter
+except ImportError:  # standalone fallback: plain NDJSON prints
+    class Reporter:  # type: ignore[no-redef]
+        def emit(self, event: str, **fields: Any) -> None:
+            print(json.dumps({"event": event, **fields}), flush=True)
+
+
+DEFAULTS: dict[str, Any] = {
+    "datasetId": "",               # source dataset from the durable store
+    "src": "",                     # direct path to a wake-studio-dataset.zip
+    "seed": "0",                   # reproducibility seed (recipe.seed parity)
+    "ratios": "0.8,0.1,0.1",       # train,val,test
+}
+
+ENV_MAP: dict[str, str] = {
+    "SPLIT_DATASET_ID": "datasetId",
+    "SPLIT_SRC": "src",
+    "SPLIT_SEED": "seed",
+    "SPLIT_RATIOS": "ratios",
+}
+
+
+def read_params(env: dict[str, str] | None = None) -> dict[str, Any]:
+    env = env if env is not None else os.environ
+    params: dict[str, Any] = dict(DEFAULTS)
+
+    raw_json = env.get("WAKE_PARAMS", "")
+    if raw_json:
+        try:
+            for key, value in json.loads(raw_json).items():
+                if key in DEFAULTS:
+                    params[key] = value
+        except (ValueError, TypeError):
+            pass
+
+    for var, key in ENV_MAP.items():
+        raw = env.get(var, "")
+        if raw != "":
+            params[key] = raw
+    return params
+
+
+def _parse_ratios(raw: str) -> tuple[float, float, float]:
+    parts = [float(p.strip()) for p in raw.split(",") if p.strip()]
+    if len(parts) != 3 or any(p < 0 for p in parts) or not any(parts):
+        raise QualityError(
+            f"split ratios must be train,val,test numbers (got {raw!r})"
+        )
+    total = sum(parts)
+    return (parts[0] / total, parts[1] / total, parts[2] / total)
+
+
+def resolve_dataset_zip(params: dict[str, Any], work_dir: Path) -> Path:
+    src = params.get("src")
+    if src:
+        path = Path(src)
+        if not path.is_absolute():
+            path = (work_dir / path).resolve()
+        return path
+    dataset_id = params.get("datasetId")
+    if not dataset_id:
+        raise QualityError("dataset-split requires a datasetId or src")
+    from wake_train_kit.materialize import open_dataset_store
+
+    record = open_dataset_store().get(dataset_id)
+    if record is None:
+        raise QualityError(
+            f"dataset '{dataset_id}' is not in the backend store "
+            "(run a dataset-generate job first)"
+        )
+    return Path(record["stored_path"])
+
+
+def extract_zip(zip_path: Path, dest: Path) -> Path:
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        for member in zf.namelist():
+            target = (dest / member).resolve()
+            if not str(target).startswith(str(dest.resolve())):
+                raise QualityError(f"dataset zip contains an unsafe path: {member}")
+        zf.extractall(dest)
+    return dest / "audio"
+
+
+def main(argv: list[str] | None = None) -> int:
+    reporter = Reporter()
+    params = read_params()
+    work_dir = Path(os.environ.get("WORK_DIR", ".")).resolve()
+
+    try:
+        ratios = _parse_ratios(str(params.get("ratios") or "0.8,0.1,0.1"))
+        seed = int(params.get("seed") or 0)
+    except (TypeError, ValueError, QualityError) as exc:
+        reporter.emit("error", message=f"dataset-split failed: {exc}")
+        return 1
+    reporter.emit(
+        "log", level="info",
+        message=f"dataset-split: datasetId={params['datasetId'] or '-'} "
+                f"seed={seed} ratios={ratios}",
+    )
+
+    try:
+        zip_path = resolve_dataset_zip(params, work_dir)
+        if not zip_path.is_file():
+            raise QualityError(f"dataset zip not found: {zip_path}")
+
+        from wake_train_kit.dataset import import_dataset_zip
+
+        manifest, _clips = import_dataset_zip(zip_path)
+        extract_root = work_dir / "split-extract"
+        if extract_root.exists():
+            shutil.rmtree(extract_root)
+        audio_root = extract_zip(zip_path, extract_root)
+
+        split_manifest, partitions = split_dataset(
+            audio_root, manifest, seed=seed, ratios=ratios
+        )
+
+        # a split dataset is a NEW first-class dataset: new id, version 1,
+        # recipe.split records the parent + seed for provenance.
+        parent_id = str(manifest.get("id"))
+        split_manifest = dict(split_manifest)
+        split_manifest["id"] = str(uuid.uuid4())
+        split_manifest["version"] = 1
+        split_manifest["name"] = f"{manifest.get('name', 'dataset')} (split)"
+        split_manifest["storage"] = {
+            "backend": f"datasets/{split_manifest['id']}/",
+        }
+        recipe = dict(split_manifest.get("recipe") or {})
+        recipe["split"] = {
+            "parentId": parent_id,
+            "seed": seed,
+        }
+        split_manifest["recipe"] = recipe
+
+        out_zip = work_dir / "wake-studio-dataset.zip"
+        pack_dataset_zip(audio_root, split_manifest, out_zip)
+
+        counts = {k: len(v) for k, v in partitions.items()}
+        reporter.emit(
+            "log", level="info",
+            message=f"dataset-split: train={counts['train']} val={counts['val']} "
+                    f"test={counts['test']} seed={seed}",
+        )
+        reporter.emit("artifact", path=str(out_zip))
+        reporter.emit("done", exitCode=0, split=counts)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        reporter.emit("error", message=f"dataset-split failed: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/studio-backend/src/wake_training_service/manager.py
+++ b/apps/studio-backend/src/wake_training_service/manager.py
@@ -249,6 +249,9 @@ class JobManager:
         if job.checkpoint:
             env["WAKE_RESUME"] = "1"
             env["WAKE_CHECKPOINT"] = job.checkpoint
+        if self.datasets_dir is not None:
+            # dataset-* runners resolve the durable store via DATASETS_DIR
+            env["DATASETS_DIR"] = str(self.datasets_dir)
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,

--- a/apps/studio-backend/src/wake_training_service/ndjson.py
+++ b/apps/studio-backend/src/wake_training_service/ndjson.py
@@ -7,7 +7,7 @@ from typing import Any
 
 KNOWN_EVENTS = {
     "progress", "metrics", "log", "heartbeat", "checkpoint",
-    "artifact", "error", "done",
+    "artifact", "error", "done", "health",
 }
 
 

--- a/apps/studio-backend/tests/test_check_split_runners.py
+++ b/apps/studio-backend/tests/test_check_split_runners.py
@@ -1,0 +1,232 @@
+"""check-dataset / dataset-split job runner tests (#209).
+
+End-to-end-ish: build a canonical dataset zip in tmp, run the runner entry
+(`main()`) with env vars like the job manager would, and assert the NDJSON
+events + artifacts (health report, quality-annotated zip, split zip).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import os
+import struct
+import wave
+from pathlib import Path
+
+from wake_train_kit import check_runner, dataset as ds, split_runner
+
+
+def phrase(freq: float, mod: float, rate: int = 16000) -> list[int]:
+    out: list[int] = []
+    for i in range(rate):
+        t = i / rate
+        env = 0.6 + 0.4 * math.sin(2 * math.pi * mod * t)
+        s = env * (8000 * math.sin(2 * math.pi * freq * t)
+                   + 0.4 * 8000 * math.sin(2 * math.pi * 2 * freq * t))
+        out.append(int(s))
+    return out
+
+
+def make_wav(path: Path, samples: list[int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"".join(struct.pack("<h", min(32767, max(-32768, int(s)))) for s in samples))
+
+
+def build_test_zip(tmp_path: Path, name: str = "wake-studio-dataset.zip") -> Path:
+    """A 3-label canonical dataset zip (2 distinct positives + silence noise)."""
+    root = tmp_path / "src-tree"
+    make_wav(root / "hey_studio" / "a.wav", phrase(440, 3.0))
+    make_wav(root / "hey_studio" / "b.wav", phrase(880, 5.0))
+    make_wav(root / "goodbye" / "x.wav", phrase(220, 2.0))
+    make_wav(root / "_background_noise_" / "n1.wav", [0] * 16000)
+    manifest = {
+        "schemaVersion": ds.DATASET_MANIFEST_SCHEMA_VERSION,
+        "id": "ds-run-1",
+        "name": "run-test",
+        "version": 1,
+        "kind": "generated",
+        "role": "mixed",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": ds.CANONICAL_ENCODING,
+                  "clips": 4, "durationSec": 4},
+        "labels": [
+            {"name": "hey_studio", "role": "positive", "source": "synthetic", "voices": ["en-US-1"]},
+            {"name": "goodbye", "role": "unknown", "source": "synthetic"},
+            {"name": "_background_noise_", "role": "noise", "source": "synthetic"},
+        ],
+        "provenance": [{"name": "test", "license": "user-owned", "commercialUse": True}],
+        "recipe": {"engine": "edge-tts", "seed": 0, "toolVersions": {"edge-tts": "9.9.9"}},
+        "contentHash": None,
+        "storage": None,
+        "quality": None,
+        "split": None,
+        "createdAtMs": 1,
+    }
+    zip_path = tmp_path / name
+    ds.pack_dataset_zip(root, manifest, zip_path)
+    return zip_path
+
+
+def run_main(runner_module: str, env: dict[str, str], work_dir: Path) -> tuple[int, list[dict]]:
+    """Run a runner's ``main()`` with patched env + in-memory Reporter.
+
+    Returns ``(exit_code, captured NDJSON events)``.
+    """
+    mod = importlib.import_module(runner_module)
+    captured: list[dict] = []
+
+    class FakeReporter:
+        def emit(self, event: str, **fields: object) -> None:
+            captured.append({"event": event, **fields})
+
+    old_reporter = mod.Reporter
+    old_environ = dict(os.environ)
+    try:
+        mod.Reporter = FakeReporter  # type: ignore[assignment]
+        os.environ.clear()
+        os.environ.update(env)
+        os.environ["WORK_DIR"] = str(work_dir)
+        rc = mod.main([])
+    finally:
+        mod.Reporter = old_reporter
+        os.environ.clear()
+        os.environ.update(old_environ)
+    return rc, captured
+
+
+# ---------------------------------------------------------------------------
+# manifest validation: quality + split (mirror of the web spec)
+# ---------------------------------------------------------------------------
+
+def test_manifest_quality_and_split_validation():
+    manifest = {
+        "schemaVersion": 1, "id": "d", "name": "n", "version": 1,
+        "kind": "generated", "role": "mixed",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": ds.CANONICAL_ENCODING,
+                  "clips": 1, "durationSec": 1},
+        "labels": [{"name": "pos", "role": "positive"}],
+        "provenance": [{"name": "p", "license": "l", "commercialUse": True}],
+        "quality": {"checkedAtSec": 1, "verdict": "warn",
+                    "warnings": [{"code": "silence", "severity": "warn", "message": "x"}]},
+        "split": {"seed": 0, "ratios": [0.8, 0.1, 0.1],
+                  "train": ["audio/pos/a.wav"], "val": [], "test": []},
+    }
+    ok, errors = ds.validate_dataset_manifest(manifest)
+    assert ok, errors
+
+    bad_verdict = dict(manifest)
+    bad_verdict["quality"] = {"verdict": "nope", "warnings": []}
+    assert not ds.validate_dataset_manifest(bad_verdict)[0]
+
+    bad_ratios = dict(manifest)
+    bad_ratios["split"] = {"seed": "0", "ratios": [0.8, 0.1],
+                           "train": ["audio/pos/a.wav"], "val": [], "test": []}
+    assert not ds.validate_dataset_manifest(bad_ratios)[0]
+
+    overlap = dict(manifest)
+    overlap["split"] = {"seed": 0, "ratios": [0.8, 0.1, 0.1],
+                        "train": ["audio/pos/a.wav"], "val": ["audio/pos/a.wav"], "test": []}
+    assert not ds.validate_dataset_manifest(overlap)[0]
+
+
+# ---------------------------------------------------------------------------
+# check-dataset runner
+# ---------------------------------------------------------------------------
+
+def test_check_runner_emits_health_and_quality_annotated_zip(tmp_path):
+    zip_path = build_test_zip(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    rc, events = run_main("wake_train_kit.check_runner", {"CHECK_SRC": str(zip_path)}, work)
+    assert rc == 0
+
+    health = next(e for e in events if e["event"] == "health")
+    report = health["report"]
+    assert report["verdict"] in ("pass", "warn", "fail")
+    assert report["labels"]["hey_studio"]["clips"] == 2
+    assert report["labels"]["hey_studio"]["voices"] == 1  # manifest voice metadata
+
+    # full report artifact
+    assert (work / "wake-studio-dataset-health.json").is_file()
+
+    # quality-annotated zip: manifest.quality + version bumped
+    annotated_zip = work / "wake-studio-dataset.zip"
+    assert annotated_zip.is_file()
+    annotated_manifest, _ = ds.import_dataset_zip(annotated_zip)
+    assert annotated_manifest["version"] == 2
+    assert annotated_manifest["quality"]["verdict"] == report["verdict"]
+    assert annotated_manifest["quality"]["warnings"] == report["warnings"]
+    assert annotated_manifest["contentHash"]  # recomputed on the annotated payload
+
+
+def test_check_runner_without_target_fails_cleanly(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    rc, events = run_main("wake_train_kit.check_runner", {}, work)
+    assert rc == 1
+    assert any(e["event"] == "error" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# dataset-split runner
+# ---------------------------------------------------------------------------
+
+def test_split_runner_produces_split_dataset_zip(tmp_path):
+    zip_path = build_test_zip(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    rc, events = run_main(
+        "wake_train_kit.split_runner",
+        {"SPLIT_SRC": str(zip_path), "SPLIT_SEED": "7", "SPLIT_RATIOS": "0.8,0.1,0.1"},
+        work,
+    )
+    assert rc == 0
+
+    out_zip = work / "wake-studio-dataset.zip"
+    assert out_zip.is_file()
+    manifest, _ = ds.import_dataset_zip(out_zip)
+
+    split = manifest["split"]
+    assert split["seed"] == 7
+    assert split["ratios"] == [0.8, 0.1, 0.1]
+    partitions = {"train": set(split["train"]), "val": set(split["val"]), "test": set(split["test"])}
+    assert sum(len(v) for v in partitions.values()) == 4  # every clip in exactly one partition
+    assert manifest["id"] != "ds-run-1"  # split = a new dataset
+    assert manifest["recipe"]["split"]["parentId"] == "ds-run-1"
+    assert manifest["name"].endswith("(split)")
+
+    done = next(e for e in events if e["event"] == "done")
+    assert sum(done.get("split", {}).values()) == 4
+
+
+def test_split_runner_rejects_bad_ratios(tmp_path):
+    zip_path = build_test_zip(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+    rc, events = run_main(
+        "wake_train_kit.split_runner",
+        {"SPLIT_SRC": str(zip_path), "SPLIT_SEED": "0", "SPLIT_RATIOS": "1,2"},
+        work,
+    )
+    assert rc == 1
+    assert any(e["event"] == "error" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# registry wiring
+# ---------------------------------------------------------------------------
+
+def test_registry_has_check_and_split_entries():
+    registry_path = Path(__file__).resolve().parents[1] / "registry.json"
+    entries = json.loads(registry_path.read_text())
+    assert entries["dataset-check"]["entry"] == "check_runner.py"
+    assert entries["dataset-split"]["entry"] == "split_runner.py"
+    assert entries["dataset-check"]["env"]["CHECK_DATASET_ID"] == "{params.datasetId}"
+    assert entries["dataset-split"]["env"]["SPLIT_SEED"] == "{params.seed}"

--- a/apps/studio-backend/tests/test_quality.py
+++ b/apps/studio-backend/tests/test_quality.py
@@ -1,0 +1,290 @@
+"""wake_train_kit.quality tests — quality gate + dedup + reproducible split (#209).
+
+No network / no GPU: clips are tiny synthetic WAVs written with the stdlib
+`wave` module. Covers the health report (per-label stats, silence/clipping/
+sample-rate drift), exact + near-duplicate detection, in-place dedup, and the
+seeded train/val/test split (no near-dup leakage, byte-reproducible).
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+
+from wake_train_kit import quality as q
+
+
+def make_wav(path: Path, samples: list[int], rate: int = 16000) -> Path:
+    """Write a canonical 16 kHz mono s16le WAV clip."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(
+            b"".join(struct.pack("<h", min(32767, max(-32768, int(s)))) for s in samples)
+        )
+    return path
+
+
+def sine(duration: float = 1.0, freq: float = 440.0, rate: int = 16000) -> list[int]:
+    return [int(8000 * math.sin(2 * math.pi * freq * i / rate)) for i in range(int(duration * rate))]
+
+
+def phrase(freq: float, mod: float, duration: float = 1.0, rate: int = 16000) -> list[int]:
+    """Speech-like clip: amplitude-modulated harmonic (distinct envelope + pitch)."""
+    out: list[int] = []
+    for i in range(int(duration * rate)):
+        t = i / rate
+        env = 0.6 + 0.4 * math.sin(2 * math.pi * mod * t)
+        s = env * (8000 * math.sin(2 * math.pi * freq * t) + 0.4 * 8000 * math.sin(2 * math.pi * 2 * freq * t))
+        out.append(int(s))
+    return out
+
+
+def _tree(tmp_path: Path) -> Path:
+    """A small canonical audio/<label>/*.wav tree with 2 real labels + noise."""
+    root = tmp_path / "audio"
+    make_wav(root / "hey_studio" / "a.wav", phrase(440, 3.0))
+    make_wav(root / "hey_studio" / "b.wav", phrase(880, 5.0))
+    make_wav(root / "goodbye" / "x.wav", phrase(220, 2.0))
+    make_wav(root / "_background_noise_" / "n1.wav", [0] * 16000)
+    return root
+
+
+def _manifest(labels: list[dict]) -> dict:
+    return {
+        "schemaVersion": 1,
+        "id": "ds-t",
+        "name": "test-ds",
+        "version": 1,
+        "kind": "generated",
+        "role": "mixed",
+        "audio": {"sampleRate": 16000, "channels": 1, "encoding": "pcm_s16le",
+                  "clips": 4, "durationSec": 4},
+        "labels": labels,
+        "provenance": [{"name": "test", "license": "user-owned", "commercialUse": True}],
+        "contentHash": None,
+        "storage": None,
+        "quality": None,
+        "split": None,
+        "createdAtMs": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# WAV probing
+# ---------------------------------------------------------------------------
+
+def test_parse_wav_probes_canonical_clip(tmp_path):
+    wav = make_wav(tmp_path / "c.wav", sine())
+    meta = q.parse_wav(wav.read_bytes())
+    assert meta is not None
+    assert meta.sample_rate == 16000
+    assert meta.channels == 1
+    assert meta.bits == 16
+    assert meta.frames == 16000
+    assert abs(meta.duration_sec - 1.0) < 1e-6
+    assert not meta.silent
+    assert not meta.clipping
+
+
+def test_parse_wav_handles_garbage_and_non_pcm():
+    assert q.parse_wav(b"not a wav at all") is None
+    assert q.parse_wav(b"RIFF\x10\x00\x00\x00WAVE") is None  # no fmt chunk
+
+
+def test_parse_wav_silence_and_clipping(tmp_path):
+    silent = make_wav(tmp_path / "s.wav", [0] * 16000)
+    clipped = make_wav(tmp_path / "c.wav", [32767] * 16000)
+    assert q.parse_wav(silent.read_bytes()).silent
+    assert q.parse_wav(clipped.read_bytes()).clipping
+
+
+# ---------------------------------------------------------------------------
+# Health report
+# ---------------------------------------------------------------------------
+
+def test_check_dataset_clean_tree_passes(tmp_path):
+    root = _tree(tmp_path)
+    manifest = _manifest([
+        {"name": "hey_studio", "role": "positive", "source": "real", "voices": ["v1", "v2"]},
+        {"name": "goodbye", "role": "unknown", "source": "synthetic"},
+        {"name": "_background_noise_", "role": "noise", "source": "real"},
+    ])
+    report = q.check_dataset(root, manifest)
+    assert report["verdict"] == "pass"
+    assert report["totals"]["clips"] == 4
+    assert report["labels"]["hey_studio"]["clips"] == 2
+    assert report["labels"]["hey_studio"]["voices"] == 2
+    assert report["warnings"] == []
+    # manifest tags only carry into the manifest summary
+    summary = q.quality_summary(report)
+    assert summary["verdict"] == "pass"
+    assert summary["warnings"] == []
+
+
+def test_check_dataset_empty_label_fails(tmp_path):
+    root = tmp_path / "audio"
+    make_wav(root / "hey_studio" / "a.wav", sine())
+    (root / "empty_label").mkdir(parents=True)
+    report = q.check_dataset(root)
+    assert report["verdict"] == "fail"
+    assert any(w["code"] == "empty-label" for w in report["warnings"])
+
+
+def test_check_dataset_silence_and_clipping_warn(tmp_path):
+    root = tmp_path / "audio"
+    make_wav(root / "pos" / "a.wav", sine())
+    make_wav(root / "pos" / "b.wav", [0] * 16000)      # silent
+    make_wav(root / "pos" / "c.wav", [32767] * 16000)  # clipped
+    report = q.check_dataset(root)
+    codes = {w["code"] for w in report["warnings"]}
+    assert {"silence", "clipping"} <= codes
+    assert report["verdict"] == "warn"
+
+
+def test_check_dataset_sample_rate_drift_warns(tmp_path):
+    root = tmp_path / "audio"
+    make_wav(root / "pos" / "a.wav", sine())
+    make_wav(root / "pos" / "off.wav", sine(), rate=8000)
+    report = q.check_dataset(root)
+    assert report["totals"]["nonStandardSampleRate"] == 1
+    assert any(w["code"] == "sample-rate-drift" for w in report["warnings"])
+
+
+def test_check_dataset_too_few_voices_and_synthetic_warn(tmp_path):
+    root = tmp_path / "audio"
+    make_wav(root / "hey_studio" / "a.wav", sine())
+    manifest = _manifest([
+        {"name": "hey_studio", "role": "positive", "source": "synthetic", "voices": ["v1"]},
+    ])
+    report = q.check_dataset(root, manifest)
+    codes = {w["code"] for w in report["warnings"]}
+    assert "too-few-voices" in codes
+    assert "all-synthetic-positive" in codes
+
+
+def test_check_dataset_accepts_extracted_audio_wrapper(tmp_path):
+    # some tooling extracts the zip with an `audio/` wrapper dir
+    outer = tmp_path / "extract"
+    make_wav(outer / "audio" / "pos" / "a.wav", sine())
+    report = q.check_dataset(outer)
+    assert report["verdict"] == "pass"
+
+
+def test_check_dataset_no_clips_raises(tmp_path):
+    with pytest.raises(q.QualityError):
+        q.check_dataset(tmp_path / "nothing-here")
+
+
+# ---------------------------------------------------------------------------
+# Exact duplicates + dedup
+# ---------------------------------------------------------------------------
+
+def test_exact_duplicate_groups(tmp_path):
+    root = tmp_path / "audio"
+    base = sine()
+    make_wav(root / "pos" / "a.wav", base)
+    make_wav(root / "pos" / "b.wav", base)             # byte-identical
+    make_wav(root / "pos" / "c.wav", sine(freq=500.0))
+    groups = q.exact_duplicate_groups(root)
+    assert len(groups["pos"]) == 1
+    assert sorted(groups["pos"][0]) == ["a.wav", "b.wav"]
+
+
+def test_deduplicate_clips_removes_exact_duplicates(tmp_path):
+    root = tmp_path / "audio"
+    make_wav(root / "pos" / "a.wav", sine())
+    make_wav(root / "pos" / "b.wav", sine())           # byte-identical
+    stats = q.deduplicate_clips(root)
+    assert stats["removed"] == 1
+    assert (root / "pos" / "a.wav").exists()
+    assert not (root / "pos" / "b.wav").exists()
+
+
+# ---------------------------------------------------------------------------
+# Near duplicates + reproducible split
+# ---------------------------------------------------------------------------
+
+def test_near_duplicate_clusters_group_similar_clips(tmp_path):
+    root = tmp_path / "audio"
+    base = sine()
+    copy = list(base)
+    for i in range(0, len(copy), 133):  # tiny LSB jitter: same perceptual features
+        copy[i] = min(32767, copy[i] + 1)
+    make_wav(root / "pos" / "a.wav", base)
+    make_wav(root / "pos" / "b.wav", copy)
+    make_wav(root / "pos" / "c.wav", phrase(1800, 5.0))  # clearly different
+    env_a, _ = q.audio_feature(base)
+    assert q.audio_similarity(env_a, q.amplitude_envelope(copy)) >= q.NEAR_DUP_SIMILARITY
+    assert q.audio_similarity(env_a, q.amplitude_envelope(phrase(1800, 5.0))) < q.NEAR_DUP_SIMILARITY
+    clusters = q.near_duplicate_clusters(root)
+    assert len(clusters) == 1
+    assert {p.name for p in clusters[0]} == {"a.wav", "b.wav"}
+
+
+def test_near_duplicate_detection_cross_label_ignored(tmp_path):
+    root = tmp_path / "audio"
+    base = sine()
+    make_wav(root / "pos" / "a.wav", base)
+    make_wav(root / "pos2" / "b.wav", base)
+    assert q.near_duplicate_clusters(root) == []
+
+
+def test_split_records_partition_and_is_deterministic(tmp_path):
+    root = tmp_path / "audio"
+    for i in range(12):
+        make_wav(root / "pos" / f"c{i:02d}.wav", phrase(400.0 + i * 40, 3.0 + (i % 3)))
+    manifest = _manifest([{"name": "pos", "role": "positive"}])
+
+    split_a, parts_a = q.split_dataset(root, manifest, seed=7)
+    split_b, parts_b = q.split_dataset(root, manifest, seed=7)
+    assert split_a["split"] == split_b["split"]  # byte-reproducible
+
+    split_field = split_a["split"]
+    assert split_field["seed"] == 7
+    assert list(split_field["ratios"]) == [0.8, 0.1, 0.1]
+    all_refs = sorted(split_field["train"] + split_field["val"] + split_field["test"])
+    expected = sorted(
+        [f"audio/pos/c{i:02d}.wav" for i in range(12)]
+    )
+    assert all_refs == expected  # every clip in exactly one partition
+    assert len(parts_a["train"]) == len(split_field["train"])
+
+    # different seed -> different partition (clips are distinct singles)
+    split_c, _ = q.split_dataset(root, manifest, seed=8)
+    assert split_c["split"]["train"] != split_a["split"]["train"]
+
+
+def test_split_keeps_near_duplicates_in_one_partition(tmp_path):
+    root = tmp_path / "audio"
+    base = sine()
+    dup = list(base)
+    for i in range(0, len(dup), 97):
+        dup[i] = min(32767, dup[i] + 1)
+    # 6 pairs of near-duplicates + 6 unique clips
+    for i in range(6):
+        make_wav(root / "pos" / f"p{i}.wav", base)          # duplicates of base
+    for i in range(6):
+        make_wav(root / "pos" / f"u{i}.wav", sine(freq=300.0 + i * 120))
+    make_wav(root / "pos" / "dup.wav", dup)                 # near-dup of base
+
+    manifest = _manifest([{"name": "pos", "role": "positive"}])
+    split, _ = q.split_dataset(root, manifest, seed=3)
+    partitions = {k: set(v) for k, v in split["split"].items() if k in ("train", "val", "test")}
+    same = {p for p in partitions if "audio/pos/p0.wav" in partitions[p]}
+    assert same == {p for p in partitions if "audio/pos/dup.wav" in partitions[p]}
+
+
+def test_split_manifest_never_mutates_input(tmp_path):
+    root = tmp_path / "audio"
+    make_wav(root / "pos" / "a.wav", sine())
+    manifest = _manifest([{"name": "pos", "role": "positive"}])
+    before = dict(manifest)
+    q.split_dataset(root, manifest, seed=1)
+    assert manifest == before

--- a/apps/web/src/datasets/console/DatasetActions.tsx
+++ b/apps/web/src/datasets/console/DatasetActions.tsx
@@ -26,6 +26,8 @@ export interface DatasetActionsProps {
   client: StudioClient | null
   onNew: () => void
   onTrain: (id: string) => void
+  onCheck: (id: string) => void
+  onSplit: (id: string, seed: number) => void
   onUpload: (dataset: ConsoleDataset, input: { target: CloudTarget; repoId: string }) => Promise<void>
   onDownload: (dataset: ConsoleDataset) => Promise<void>
   onDelete: (dataset: ConsoleDataset) => Promise<void>
@@ -36,6 +38,8 @@ export function DatasetActions({
   client,
   onNew,
   onTrain,
+  onCheck,
+  onSplit,
   onUpload,
   onDownload,
   onDelete,
@@ -45,6 +49,7 @@ export function DatasetActions({
     dataset.origin === 'local' ||
     (dataset.origin === 'backend' && !!client) ||
     dataset.origin === 'builtin'
+  const canRunBackendOps = !!client && dataset.origin === 'backend'
 
   const [uploadOpen, setUploadOpen] = useState(false)
   const [target, setTarget] = useState<CloudTarget>('hf')
@@ -88,6 +93,23 @@ export function DatasetActions({
           <Button type="button" size="1" variant="soft" onClick={() => setUploadOpen(true)}>
             Upload to cloud
           </Button>
+          <Button
+            type="button"
+            size="1"
+            variant="soft"
+            disabled={!canRunBackendOps}
+            onClick={() => onCheck(dataset.id)}
+            title={
+              canRunBackendOps
+                ? 'Run the check-dataset quality job (clip quality, silence/duplication, voice coverage) on the studio-backend'
+                : 'Requires a connected studio-backend (backend-stored dataset)'
+            }
+          >
+            Check
+          </Button>
+          {canRunBackendOps && (
+            <SplitButton dataset={dataset} onSplit={onSplit} />
+          )}
           <Button
             type="button"
             size="1"
@@ -226,6 +248,76 @@ export function DatasetActions({
               }}
             >
               Delete
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+/** Split action — the reproducible train/val/test op (#209).
+ *
+ * Prompts for the reproducibility seed (default 0 → recipe.seed parity), then
+ * runs the backend `dataset-split` job which emits a NEW dataset zip with the
+ * partition recorded in its manifest (`split { seed, ratios, train/val/test }`).
+ */
+function SplitButton({
+  dataset,
+  onSplit,
+}: {
+  dataset: ConsoleDataset
+  onSplit: (id: string, seed: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [seed, setSeed] = useState('0')
+  const seedNumber = Number.parseInt(seed, 10) || 0
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="1"
+        variant="soft"
+        onClick={() => setOpen(true)}
+        title="Split into a fixed train/val/test partition (reproducible, no leakage) and save it as a new dataset"
+      >
+        Split…
+      </Button>
+      <Dialog open={open} onOpenChange={(o) => !o && setOpen(false)}>
+        <DialogContent centered className="w-[min(92vw,24rem)] p-5">
+          <DialogTitle className="text-sm">Split “{dataset.name}”</DialogTitle>
+          <DialogDescription className="text-xs leading-relaxed text-ink-3">
+            Records a fixed train/val/test partition (80/10/10) in a new dataset’s manifest.
+            Near-duplicate clips stay in one partition — evaluation never sees training data.
+          </DialogDescription>
+          <label htmlFor="split-seed" className="mt-3 block text-xs font-medium text-ink-2">
+            Reproducibility seed
+          </label>
+          <input
+            id="split-seed"
+            inputMode="numeric"
+            value={seed}
+            onChange={(e) => setSeed(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-line bg-surface-1 px-3 py-2 font-mono text-xs text-ink-1 outline-none placeholder:text-ink-3 focus:border-brand-8"
+          />
+          <p className="mt-1 text-[11px] text-ink-3">
+            Same dataset + seed → identical partition every time (byte-reproducible).
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button type="button" onClick={() => setOpen(false)} variant="outline" size="2" className="text-xs">
+              Keep
+            </Button>
+            <Button
+              type="button"
+              size="2"
+              className="text-xs"
+              onClick={() => {
+                setOpen(false)
+                onSplit(dataset.id, seedNumber)
+              }}
+            >
+              Split
             </Button>
           </div>
         </DialogContent>

--- a/apps/web/src/datasets/console/DatasetDetails.tsx
+++ b/apps/web/src/datasets/console/DatasetDetails.tsx
@@ -116,6 +116,7 @@ export function DatasetDetails({ dataset }: DatasetDetailsProps) {
                   <th className="px-3 py-1.5 font-medium">Role</th>
                   <th className="px-3 py-1.5 font-medium">Language</th>
                   <th className="px-3 py-1.5 font-medium">Source</th>
+                  <th className="px-3 py-1.5 font-medium">Voices</th>
                   <th className="px-3 py-1.5 text-right font-medium">~Clips</th>
                 </tr>
               </thead>
@@ -126,6 +127,22 @@ export function DatasetDetails({ dataset }: DatasetDetailsProps) {
                     <td className="px-3 py-1.5 text-ink-2">{l.role}</td>
                     <td className="px-3 py-1.5 text-ink-2">{l.language ?? '—'}</td>
                     <td className="px-3 py-1.5 text-ink-2">{l.source ?? '—'}</td>
+                    <td className="px-3 py-1.5 text-ink-2">
+                      {l.voices?.length ? (
+                        <span
+                          title={l.voices.join(', ')}
+                          className={cn(
+                            l.role === 'positive' && l.voices.length < 2
+                              ? 'text-amber-700'
+                              : 'text-ink-2',
+                          )}
+                        >
+                          {l.voices.length}
+                        </span>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
                     <td className="px-3 py-1.5 text-right font-mono text-ink-2">
                       {perLabel || '—'}
                     </td>
@@ -227,41 +244,110 @@ export function DatasetDetails({ dataset }: DatasetDetailsProps) {
         </dl>
       </section>
 
-      {/* Quality report — what the manifest carries today; the health-check
-          job (clip quality, silence, duplication, balance) is #209. */}
+      {/* Quality report — the check-dataset health report (#209). The verdict
+          + warnings travel in the manifest (recorded by the check job); the
+          full report (per-label stats) is the job's health NDJSON + artifact. */}
       <section className="rounded-xl border border-line bg-surface-2 p-4">
         <h4 className="text-xs font-semibold uppercase tracking-wide text-ink-3">Quality report</h4>
-        <dl className="mt-2 grid gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
-          <div className="flex justify-between gap-3">
-            <dt className="text-ink-3">Role coverage</dt>
-            <dd className="font-mono text-ink-1">
-              {dataset.roles.length ? dataset.roles.join(' / ') : '—'}
-            </dd>
+
+        {m.quality ? (
+          <div className="mt-2 space-y-2.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={cn(
+                  'rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide',
+                  m.quality.verdict === 'pass'
+                    ? 'bg-emerald-500/10 text-emerald-600'
+                    : m.quality.verdict === 'warn'
+                      ? 'bg-amber-500/10 text-amber-700'
+                      : 'bg-red-500/10 text-red-600',
+                )}
+              >
+                {m.quality.verdict}
+              </span>
+              <span className="text-[11px] text-ink-3">
+                {m.quality.checkedAtSec
+                  ? `checked ${new Date(m.quality.checkedAtSec * 1000).toLocaleString()}`
+                  : 'checked on the studio-backend'}
+              </span>
+            </div>
+
+            {m.quality.warnings.length === 0 && (
+              <p className="text-[11px] text-ink-3">No quality warnings — the dataset looks clean.</p>
+            )}
+            {m.quality.warnings.length > 0 && (
+              <ul className="space-y-1.5">
+                {m.quality.warnings.map((w, i) => (
+                  <li
+                    key={`${w.code}-${i}`}
+                    className={cn(
+                      'rounded-lg border px-3 py-2 text-[11px] leading-relaxed',
+                      w.severity === 'fail'
+                        ? 'border-red-500/20 bg-red-500/5 text-red-600'
+                        : w.severity === 'warn'
+                          ? 'border-amber-500/20 bg-amber-500/5 text-amber-700'
+                          : 'border-line bg-surface-1 text-ink-3',
+                    )}
+                  >
+                    <span className="mr-1.5 font-mono text-[10px] uppercase tracking-wide opacity-70">
+                      {w.code}
+                    </span>
+                    {w.message}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-ink-3">Wake-word (positive) labels</dt>
-            <dd className="font-mono text-ink-1">
-              {dataset.roles.includes('positive') ? 'yes' : 'no'}
-            </dd>
+        ) : (
+          <>
+            <dl className="mt-2 grid gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
+              <div className="flex justify-between gap-3">
+                <dt className="text-ink-3">Role coverage</dt>
+                <dd className="font-mono text-ink-1">
+                  {dataset.roles.length ? dataset.roles.join(' / ') : '—'}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-ink-3">Wake-word (positive) labels</dt>
+                <dd className="font-mono text-ink-1">
+                  {dataset.roles.includes('positive') ? 'yes' : 'no'}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-ink-3">Unknowns / noise coverage</dt>
+                <dd className="font-mono text-ink-1">
+                  {[dataset.roles.includes('unknown') && 'unknowns', dataset.roles.includes('noise') && 'noise']
+                    .filter(Boolean)
+                    .join(' / ') || '—'}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-ink-3">Commercial use</dt>
+                <dd className="font-mono text-ink-1">{dataset.commercialUse ? 'yes' : 'no'}</dd>
+              </div>
+            </dl>
+            <p className="mt-3 text-[11px] leading-relaxed text-ink-3">
+              This manifest-level summary is rendered today. Run a <span className="font-medium text-ink-2">Check</span> on the
+              studio-backend (Actions) to produce the full health report — per-label clip quality,
+              silence/duplicate detection, sample-rate drift, label balance, voice coverage.
+            </p>
+          </>
+        )}
+
+        {/* Reproducible split (#209) — the fixed partition every backend trains on. */}
+        {m.split && (
+          <div className="mt-3 rounded-lg border border-line bg-surface-1 px-3 py-2.5">
+            <div className="flex items-center gap-2 text-[11px]">
+              <span className="font-medium text-ink-2">Reproducible split</span>
+              <span className="font-mono text-[10px] text-ink-3">seed {m.split.seed}</span>
+            </div>
+            <div className="mt-1.5 flex flex-wrap gap-3 text-[11px]">
+              <span className="text-ink-2">train <b className="font-mono text-ink-1">{m.split.train.length}</b></span>
+              <span className="text-ink-2">val <b className="font-mono text-ink-1">{m.split.val.length}</b></span>
+              <span className="text-ink-2">test <b className="font-mono text-ink-1">{m.split.test.length}</b></span>
+            </div>
           </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-ink-3">Unknowns / noise coverage</dt>
-            <dd className="font-mono text-ink-1">
-              {[dataset.roles.includes('unknown') && 'unknowns', dataset.roles.includes('noise') && 'noise']
-                .filter(Boolean)
-                .join(' / ') || '—'}
-            </dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-ink-3">Commercial use</dt>
-            <dd className="font-mono text-ink-1">{dataset.commercialUse ? 'yes' : 'no'}</dd>
-          </div>
-        </dl>
-        <p className="mt-3 text-[11px] leading-relaxed text-ink-3">
-          This manifest-level summary is rendered today. The full health check — per-label clip
-          quality, silence/duplicate detection, sample-rate drift, label balance — ships as a
-          dedicated job (issue #209).
-        </p>
+        )}
       </section>
     </div>
   )

--- a/apps/web/src/datasets/console/DatasetJobDetails.tsx
+++ b/apps/web/src/datasets/console/DatasetJobDetails.tsx
@@ -16,7 +16,14 @@ import { isActiveStatus, useStudioJob } from '../../training/useStudioJob'
 import type { StudioJob } from '../../training/studio-client'
 import { STATUS_STYLE } from '../../training/console/StatusChip'
 import { ConfirmDialog } from '../../training/console/ConfirmDialog'
-import type { DatasetJob } from '../jobs'
+import type { DatasetJob, DatasetJobKind } from '../jobs'
+
+export const JOB_KIND_TITLE: Record<DatasetJobKind, string> = {
+  generate: 'Generation job',
+  storage: 'Storage job',
+  check: 'Quality check job',
+  split: 'Split job',
+}
 
 export interface DatasetJobDetailsProps {
   job: DatasetJob
@@ -67,9 +74,7 @@ export function DatasetJobDetails({ job, onLiveUpdate, onDelete }: DatasetJobDet
     <div className="space-y-5">
       {/* Header. */}
       <div className="flex flex-wrap items-center gap-2">
-        <h3 className="text-base font-semibold text-ink-1">
-          {job.kind === 'generate' ? 'Generation job' : 'Storage job'}
-        </h3>
+        <h3 className="text-base font-semibold text-ink-1">{JOB_KIND_TITLE[job.kind]}</h3>
         <span
           className={cn(
             'rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',

--- a/apps/web/src/datasets/console/DatasetJobList.tsx
+++ b/apps/web/src/datasets/console/DatasetJobList.tsx
@@ -9,8 +9,15 @@
  */
 
 import { cn } from '../../components/cn'
-import { sortJobsNewestFirst, type DatasetJob } from '../jobs'
+import { sortJobsNewestFirst, type DatasetJob, type DatasetJobKind } from '../jobs'
 import { STATUS_STYLE } from '../../training/console/StatusChip'
+
+export const JOB_KIND_LABEL: Record<DatasetJobKind, string> = {
+  generate: 'Generate',
+  storage: 'Storage',
+  check: 'Check',
+  split: 'Split',
+}
 
 export interface DatasetJobListProps {
   jobs: DatasetJob[]
@@ -54,7 +61,7 @@ export function DatasetJobList({ jobs, selectedId, onSelect }: DatasetJobListPro
                 </span>
               </div>
               <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-ink-1">
-                <span>{job.kind === 'generate' ? 'Generate' : 'Storage'}</span>
+                <span>{JOB_KIND_LABEL[job.kind]}</span>
                 <span className="rounded-full bg-surface-3 px-1.5 py-0.5 font-mono text-[10px] text-ink-3">
                   {job.executor}
                 </span>

--- a/apps/web/src/datasets/console/DatasetsConsole.tsx
+++ b/apps/web/src/datasets/console/DatasetsConsole.tsx
@@ -49,7 +49,7 @@ export function DatasetsConsole() {
   // backend (same convention as the Training console's datasets[] picker).
   const backend = backends[0]
   const store = useDatasetsStore(backend?.baseUrl, backend?.token)
-  const { jobs, submitGenerate, applyLive, remove } = useDatasetJobs(store.client)
+  const { jobs, submitGenerate, submitQuality, applyLive, remove } = useDatasetJobs(store.client)
   const [view, setView] = useState<View>(() => {
     const last = rememberedSelection('datasets')
     return last ? { kind: 'details', id: last } : { kind: 'empty' }
@@ -127,6 +127,35 @@ export function DatasetsConsole() {
   // -------------------------------------------------------------------------
   // Dataset actions
   // -------------------------------------------------------------------------
+
+  /** Run the check-dataset quality job on a backend dataset (#209). The job
+   *  writes the health report + records the verdict/warnings in the manifest
+   *  (version bump); the store refresh picks up the annotated dataset. */
+  const handleCheck = useCallback(
+    (datasetId: string) => {
+      if (!backend) return
+      void submitQuality('check', { datasetId }).then((job) => {
+        if (!job) return
+        rememberSelection('datasets', null)
+        setView({ kind: 'job', jobId: job.id })
+      })
+    },
+    [backend, submitQuality],
+  )
+
+  /** Run the dataset-split op (#209): records the reproducible partition in a
+   *  NEW dataset's manifest; the store refresh picks it up. */
+  const handleSplit = useCallback(
+    (datasetId: string, seed: number) => {
+      if (!backend) return
+      void submitQuality('split', { datasetId, seed: String(seed) }).then((job) => {
+        if (!job) return
+        rememberSelection('datasets', null)
+        setView({ kind: 'job', jobId: job.id })
+      })
+    },
+    [backend, submitQuality],
+  )
 
   /** Fetch a dataset's canonical zip bytes regardless of origin. */
   const datasetZipBytes = useCallback(
@@ -294,6 +323,8 @@ export function DatasetsConsole() {
                   client={store.client}
                   onNew={() => setView({ kind: 'wizard' })}
                   onTrain={handleTrain}
+                  onCheck={handleCheck}
+                  onSplit={handleSplit}
                   onUpload={handleUpload}
                   onDownload={handleDownload}
                   onDelete={handleDelete}

--- a/apps/web/src/datasets/jobs.ts
+++ b/apps/web/src/datasets/jobs.ts
@@ -16,7 +16,7 @@
 
 import type { GenerationExecutor } from './executor'
 
-export type DatasetJobKind = 'generate' | 'storage'
+export type DatasetJobKind = 'generate' | 'storage' | 'check' | 'split'
 
 /** Lifecycle status — the same vocabulary as TrainingJob (ADR-013). */
 export type DatasetJobStatus =
@@ -30,7 +30,7 @@ export type DatasetJobStatus =
 export interface DatasetJob {
   id: string
   kind: DatasetJobKind
-  moduleId: 'dataset-generate' | 'dataset-storage'
+  moduleId: 'dataset-generate' | 'dataset-storage' | 'dataset-check' | 'dataset-split'
   status: DatasetJobStatus
   executor: GenerationExecutor
   /** Snapshot of the params the job ran with. */

--- a/apps/web/src/datasets/useDatasetJobs.ts
+++ b/apps/web/src/datasets/useDatasetJobs.ts
@@ -188,10 +188,46 @@ export function useDatasetJobs(client: StudioClient | null) {
     [patch],
   )
 
+  /** Submit a quality op (check-dataset / dataset-split) on the BACKEND ONLY.
+   *
+   * These ops analyze/mix real store bytes, so there is no browser executor
+   * in v1 (#209) — the action is hidden without a connected studio-backend.
+   * Returns the recorded job; the details pane live-tracks it. */
+  const submitQuality = useCallback(
+    async (op: 'check' | 'split', params: Record<string, string>): Promise<DatasetJob | null> => {
+      const moduleId = op === 'check' ? 'dataset-check' : 'dataset-split'
+      const kind = op
+      const id = `dataset-${Date.now()}`
+      if (!client) {
+        return null
+      }
+      const job = startedDatasetJob({
+        id,
+        kind,
+        moduleId,
+        executor: 'backend',
+        params,
+      })
+      record(job)
+      void client
+        .createJob(moduleId, params, id)
+        .then(() => patch(id, { status: 'queued' }))
+        .catch((err: unknown) =>
+          patch(id, {
+            status: 'failed',
+            error: err instanceof Error ? err.message : String(err),
+            finishedAtMs: Date.now(),
+          }),
+        )
+      return job
+    },
+    [client, record, patch],
+  )
+
   const remove = useCallback((id: string) => {
     setJobs((prev) => prev.filter((j) => j.id !== id))
     void deleteDatasetJob(id)
   }, [])
 
-  return { jobs, submitGenerate, applyLive, patch, remove, refresh: () => listDatasetJobs().then(setJobs) }
+  return { jobs, submitGenerate, submitQuality, applyLive, patch, remove, refresh: () => listDatasetJobs().then(setJobs) }
 }

--- a/docs/modules/data-sources.md
+++ b/docs/modules/data-sources.md
@@ -403,19 +403,37 @@ storage); a **per-clip audio player** is shown only where reading a single clip 
 Playback reads a single clip on demand and never requires unpacking the whole dataset. Full
 per-trainer materialization (unpack) runs only at train-prep time (§6).
 
-## 9. Quality & reproducibility (v1 priorities)
+## 9. Quality & reproducibility (v1 priorities) — implemented (#209, ADR-044)
 
-1. **Quality gate** - a `check-dataset` job produces a health report: clip counts per label,
-   duration distribution, silence/empty clips, exact duplicates, clipping/distortion, sample-rate
-   drift, label imbalance. Trainers refuse (or warn loudly) when a required label is empty.
-2. **Synthetic-to-real gap** - record distinct voice count per label and `source:
-   real | synthetic` per clip; warn on too-few voices or a 100% synthetic wake-word dataset (TTS
-   overfit risk at inference).
-3. **Dedup + reproducible splits** - exact/near-duplicate detection (perceptual hash) when mixing
-   datasets (no train/eval leakage); a "split dataset" op records a fixed train/val/test
-   partition in the manifest so every backend trains on the same split.
-4. **Reproducibility** - `recipe.seed`, tool versions, and `contentHash`; "regenerate" is
-   byte-reproducible; any silent change bumps `version`.
+1. **Quality gate** — a `dataset-check` job (`wake_train_kit/check_runner.py`, registry entry
+   `dataset-check`) produces a health report (`wake_train_kit/quality.py::check_dataset`): clip
+   counts per label, duration distribution, silence/empty clips, exact duplicates (sha256),
+   clipping, sample-rate drift, label imbalance + voice coverage. Every finding is a structured
+   warning (code + severity) and the verdict is `pass | warn | fail`. The job emits a `health`
+   NDJSON event (full report), writes `wake-studio-dataset-health.json` (artifact), and records
+   the **verdict + warnings into the manifest as `quality`** (a silent change — the dataset
+   `version` bumps, §9.4). The Datasets console renders the verdict/warnings from the manifest
+   (Actions → **Check**, backend-stored datasets). Trainers refuse (or warn loudly) when a
+   required label is empty — `validate_datasets` + the importer's empty-label rejection (SS6).
+2. **Synthetic-to-real gap** — labels carry distinct `voices[]` + `source: real|synthetic`
+   (generation adapters record the voices they used). The health check warns on positive labels
+   with < 2 voices (`too-few-voices`) and on 100%-synthetic wake-word datasets
+   (`all-synthetic-positive`); the console shows the voice counts per label.
+3. **Dedup + reproducible splits** — exact/near-duplicate detection (sha256 + perceptual
+   features: windowed amplitude envelope + zero-crossing-rate pitch cue, cosine ≥ 0.99 +
+   pitch tolerance ≤ 10%) when mixing datasets; materializers **warn loudly** (never silently
+   drop) via `_scan_duplicate_warnings`. A `dataset-split` job (registry entry `dataset-split`,
+   `split_runner.py`) records a fixed seeded train/val/test partition in the manifest as
+   `split {seed, ratios, train/val/test}` (canonical `audio/<label>/<clip>` refs). Near-duplicate
+   clips stay in ONE partition (union-find clustering) so evaluation never sees training data.
+   Every backend materializes the same split (SS6 consumers read `manifest.split`). Console:
+   Actions → **Split…** (seed picker).
+4. **Reproducibility** — `recipe.seed`, `recipe.toolVersions` (engine toolchain, e.g.
+   `edge-tts` version) and `contentHash`; regenerate is byte-reproducible (existing generation
+   is order-deterministic); any silent change bumps `version` + recomputes `contentHash`.
+
+The manifest contract (web `core/spec.ts` + backend `dataset.py`, byte-identical validation)
+adds the optional `quality` (`DatasetQuality`) and `split` (`DatasetSplit`) blocks.
 
 ## 10. Provenance chain to the export gate
 
@@ -506,3 +524,4 @@ license/provenance log shown in-app before export. The Datasets console shows th
 | 2026-08-20 | **#208 — Datasets console (web, ADR-044 §8):** top-level `Datasets` nav + `#/datasets` route; list-detail console (rail = built-ins + backend store + browser-local store; details = manifest/provenance/storage/quality-report); generation wizard with the **two-executor decision locked** (§8.1 — engine `runtime` + studio-backend connectivity picks browser vs backend executor); browser executor (fetch TTS → Web Audio → canonical zip → HF direct push) + backend executor (`dataset-generate` job with reused Training NDJSON job UI); actions New/Train-with/Upload/Download/Delete (`GET/DELETE /datasets/{id}` backend routes); Training `datasets[]` picker fed from the same consolidated store. Follow-up fix: `pyproject.toml` force-include path for `builtins.json` was relative to `apps/studio-backend` (broke the wheel build) — corrected to `../../packages/...`. | agent |
 | 2026-08-20 | **Storage & on-disk form (ADR-045, human discussion):** canonical form made HF-recognized — contents ARE the HF `AudioFolder` layout + **derived** `metadata.csv` / `README.md` exported from `dataset.json` (single source of truth, never drift). Two storage forms: **zip** (portable) and **unpacked directory** (live), a pure archive/unzip apart. **IndexedDB metadata-only** (no file bytes); browser-local bytes move to **OPFS**. **No eager auto-unpack on import** (large-dataset size concern); materialize stays deferred to train-prep. **Listenability = per-clip random access** (local dir / cloud dir / local zip via single-entry extract ✓; remote single zip blob ✗); console gains a gated per-clip player (spec §8.3). | agent |
 | 2026-08-25 | **#210 — provenance chain to the export gate:** dataset `commercialUse` flags **inherit** into trained bundles. `materialize.inherited_provenance` computes the bundle `provenance.json` (license flips `user-owned` → `research-only`, `commercialUse=false`, `restrictedBy` lists the restricting datasets); `materialize.dataset_refs_from_manifests` records per-dataset id/name/version + license flags in `metadata.datasetRefs` (both kws-streaming + openwakeword adapters, lazy materialize import on legacy paths). Web: bundle importer parses `commercialUse`/`restrictedBy` + `isCommerciallyExportable` (the Phase 4 export-gate input); colab-import surfaces the inherited restriction in-app. Tests: 5 backend inheritance + 4 adapter e2e (research-only dataset) + 5 TS. | agent |
+| 2026-08-25 | **#209 — quality gate & reproducibility (ADR-044 §9):** `wake_train_kit/quality.py` — health report (`check_dataset`: per-label counts/duration/silence/clipping/sample-rate drift/exact+near dups/voice coverage, structured warnings + `pass|warn|fail` verdict), dependency-free perceptual features (envelope cosine ≥ 0.99 + zcr pitch tolerance ≤ 10%), union-find near-dup clustering, in-place exact dedup, and the seeded `split_dataset` (near-dup clusters stay in ONE partition — no train/eval leakage). Jobs: `dataset-check` + `dataset-split` registry entries (`check_runner.py`/`split_runner.py`), `health` NDJSON event, `wake-studio-dataset-health.json` artifact, manifest `quality` block (verdict + warnings, version bump on silent change) + `split` block (seed/ratios/train/val/test refs); `DATASETS_DIR` injected into job env. Manifest contract web+backend gains optional `quality`/`split` (byte-identical validation). Reproducibility: generation records `recipe.seed` + `recipe.toolVersions` (edge-tts adapter emits engine version, voices per label). Materializers warn loudly on mix-time duplicates (`_scan_duplicate_warnings`). Console: Check/Split actions (backend jobs), quality panel renders verdict/warnings + split summary, job rail labels check/split. Tests: 17 quality + 6 runner/registry + manifest validation (backend + TS), dedup at mix time. | agent |

--- a/packages/modules/data/dataset/core/spec.ts
+++ b/packages/modules/data/dataset/core/spec.ts
@@ -99,6 +99,35 @@ export interface DatasetStorage {
   url?: string
 }
 
+/** Quality-gate verdicts (check-dataset job, #209). */
+export type QualityVerdict = 'pass' | 'warn' | 'fail'
+
+/** One quality warning: machine code + severity + human message (#209). */
+export interface DatasetQualityWarning {
+  code: string
+  severity: 'info' | 'warn' | 'fail'
+  message: string
+}
+
+/** Durable health-report summary recorded in the manifest by check-dataset (#209). */
+export interface DatasetQuality {
+  /** Unix seconds of the check (mirrors checkedAtSec in the full report). */
+  checkedAtSec?: number
+  verdict: QualityVerdict
+  warnings: DatasetQualityWarning[]
+}
+
+/** Fixed train/val/test partition recorded by the split op (#209). */
+export interface DatasetSplit {
+  /** Reproducibility seed - same root + seed + ratios → identical partition. */
+  seed: number
+  ratios: [number, number, number]
+  /** Canonical refs: "audio/<label>/<clip>" (one partition per clip, no overlap). */
+  train: string[]
+  val: string[]
+  test: string[]
+}
+
 /**
  * The `dataset.json` portability contract (docs/modules/data-sources.md §4.2).
  */
@@ -117,6 +146,10 @@ export interface DatasetManifest {
   /** sha256 over the canonical payload (manifest minus hash/storage + all clip bytes). */
   contentHash?: string
   storage?: DatasetStorage
+  /** Health-report verdict + warnings (check-dataset, #209). */
+  quality?: DatasetQuality
+  /** Reproducible train/val/test partition (split op, #209). */
+  split?: DatasetSplit
   createdAtMs?: number
 }
 
@@ -238,6 +271,72 @@ export function validateDatasetManifest(raw: unknown): ManifestValidation {
 
   if (m.contentHash !== undefined && !isNonEmptyString(m.contentHash)) {
     errors.push('contentHash, when present, must be a non-empty string')
+  }
+
+  // quality block - health-report summary (check-dataset, #209)
+  const quality = m.quality
+  if (quality !== undefined) {
+    if (!isPlainRecord(quality)) {
+      errors.push('quality must be an object')
+    } else {
+      if (
+        quality.verdict !== 'pass' &&
+        quality.verdict !== 'warn' &&
+        quality.verdict !== 'fail'
+      ) {
+        errors.push('quality.verdict must be one of: pass, warn, fail')
+      }
+      const warnings = quality.warnings
+      if (!Array.isArray(warnings)) {
+        errors.push('quality.warnings must be an array')
+      } else {
+        warnings.forEach((warning, i) => {
+        if (!isPlainRecord(warning)) {
+          errors.push(`quality.warnings[${i}] must be an object`)
+          return
+        }
+        if (!isNonEmptyString(warning.code)) {
+          errors.push(`quality.warnings[${i}].code must be a non-empty string`)
+        }
+        if (warning.severity !== 'info' && warning.severity !== 'warn' && warning.severity !== 'fail') {
+          errors.push(`quality.warnings[${i}].severity must be one of: info, warn, fail`)
+        }
+      })
+      }
+    }
+  }
+
+  // split block - reproducible partition (split op, #209)
+  const split = m.split
+  if (split !== undefined) {
+    if (!isPlainRecord(split)) {
+      errors.push('split must be an object')
+    } else {
+      if (typeof split.seed !== 'number' || !Number.isInteger(split.seed)) {
+        errors.push('split.seed must be an integer')
+      }
+      const ratios = split.ratios
+      if (
+        !Array.isArray(ratios) ||
+        ratios.length !== 3 ||
+        !ratios.every((r) => typeof r === 'number' && r >= 0 && r <= 1)
+      ) {
+        errors.push('split.ratios must be three numbers between 0 and 1')
+      }
+      const seen = new Map<string, string>()
+      for (const part of ['train', 'val', 'test'] as const) {
+        const refs = split[part]
+        if (!Array.isArray(refs) || !refs.every(isNonEmptyString)) {
+          errors.push(`split.${part} must be an array of audio/<label>/<clip> refs`)
+          continue
+        }
+        refs.forEach((ref) => {
+          const where = seen.get(ref)
+          if (where) errors.push(`split ref "${ref}" appears in both ${where} and ${part}`)
+          else seen.set(ref, part)
+        })
+      }
+    }
   }
 
   return { ok: errors.length === 0, errors }

--- a/packages/modules/data/dataset/tests/spec.test.ts
+++ b/packages/modules/data/dataset/tests/spec.test.ts
@@ -98,4 +98,61 @@ describe('dataset.json manifest contract (ADR-044 §4.2, task #203)', () => {
     expect(validateDatasetManifest(null).ok).toBe(false)
     expect(validateDatasetManifest('nope').ok).toBe(false)
   })
+
+  // ------------------------------------------------------------------------
+  // quality + split (#209) - mirrors the backend importer's rules
+  // ------------------------------------------------------------------------
+
+  it('accepts a manifest with a quality report + split partition', () => {
+    const m = {
+      ...validManifest(),
+      quality: {
+        checkedAtSec: 1756000000,
+        verdict: 'warn',
+        warnings: [{ code: 'silence', severity: 'warn', message: 'some clips are silent' }],
+      },
+      split: {
+        seed: 7,
+        ratios: [0.8, 0.1, 0.1],
+        train: ['audio/hey_studio/a.wav'],
+        val: [],
+        test: [],
+      },
+    }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(true)
+    expect(r.errors).toEqual([])
+  })
+
+  it('rejects a bad quality verdict', () => {
+    const m = { ...validManifest(), quality: { verdict: 'nope', warnings: [] } }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('quality.verdict')
+  })
+
+  it('rejects overlapping split partitions (leakage would be untracked)', () => {
+    const m = {
+      ...validManifest(),
+      split: {
+        seed: 0,
+        ratios: [0.8, 0.1, 0.1],
+        train: ['audio/hey_studio/a.wav'],
+        val: ['audio/hey_studio/a.wav'],
+        test: [],
+      },
+    }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toContain('appears in both')
+  })
+
+  it('rejects a malformed split block', () => {
+    const m = {
+      ...validManifest(),
+      split: { seed: 'zero', ratios: [0.8, 0.1], train: [], val: [], test: [] },
+    }
+    const r = validateDatasetManifest(m)
+    expect(r.ok).toBe(false)
+  })
 })

--- a/packages/modules/data/edge-tts/adapter.py
+++ b/packages/modules/data/edge-tts/adapter.py
@@ -31,6 +31,7 @@ class Engine:
         )
         samples = int(params.get("samplesPerPhrase", 3) or 3)
 
+        voices_used: dict[str, list[str]] = {}
         provenance = data_sources.build_edge_tts_kws_dataset(
             phrases,
             languages,
@@ -38,6 +39,7 @@ class Engine:
             samples_per_phrase=samples,
             unknown_words=unknown_words,
             reporter=reporter,
+            voices_used=voices_used,
         )
 
         labels: list[dict[str, Any]] = []
@@ -48,14 +50,33 @@ class Engine:
                     "role": "positive",
                     "language": languages[0] if languages else None,
                     "source": "synthetic",
+                    "voices": list(voices_used.get(data_sources._sanitize_label(phrase), [])),
                 }
             )
         for word in unknown_words:
             labels.append(
-                {"name": data_sources._sanitize_label(word), "role": "unknown", "source": "synthetic"}
+                {
+                    "name": data_sources._sanitize_label(word),
+                    "role": "unknown",
+                    "source": "synthetic",
+                    "voices": list(voices_used.get(data_sources._sanitize_label(word), [])),
+                }
             )
         labels.append({"name": "_background_noise_", "role": "noise", "source": "synthetic"})
-        return {"provenance": provenance, "labels": labels}
+        return {
+            "provenance": provenance,
+            "labels": labels,
+            "toolVersions": {"edge-tts": _edge_tts_version()},
+        }
+
+
+def _edge_tts_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("edge-tts")
+    except Exception:  # noqa: BLE001 - dev/test environments without the dist
+        return "unknown"
 
 
 def _as_list(value: Any) -> list[str]:


### PR DESCRIPTION
Closes #209 — the last open sub-issue of epic #202.

## What
- **Backend** `wake_train_kit/quality.py`: dataset health report (per-label counts/duration, silence/empty clips, clipping, sample-rate drift, exact + near duplicates, label imbalance, voice coverage) with structured warnings (code + severity) and a `pass|warn|fail` verdict; dependency-free perceptual features (amplitude envelope cosine + zero-crossing-rate pitch cue), union-find near-duplicate clustering, exact-dedup, and a seeded `split_dataset` that keeps near-dup clusters in **one** partition (no train/eval leakage).
- **Jobs**: `dataset-check` (`check_runner.py`) + `dataset-split` (`split_runner.py`) registry entries; `health` NDJSON event; full report artifact `wake-studio-dataset-health.json`; `DATASETS_DIR` now injected into job env.
- **Manifest contract** (web `core/spec.ts` + backend `dataset.py`, byte-identical validation): optional `quality` (verdict + warnings; a silent change bumps the dataset `version`) and `split` (seed/ratios/train/val/test canonical refs) blocks. Full report = job `health` event/artifact; durable summary travels in `dataset.json`.
- **Reproducibility**: generation records `recipe.seed` + `recipe.toolVersions` (edge-tts adapter emits engine version + per-label `voices[]`).
- **Mixing**: materializers warn loudly on mix-time exact/near duplicates (never silent drops).
- **Console**: Check / Split… actions (backend jobs), quality verdict + warnings + split summary in DatasetDetails, job rail supports `check`/`split` kinds.

## Tests
- Backend: 17 `test_quality.py` + 6 `test_check_split_runners.py` (+ manifest validation), existing suite green (162).
- Web: dataset module 76 tests (spec gains quality/split validation cases), app 292 unit tests; lint + typecheck green; all 4 generator checks pass.

## Docs
- `docs/modules/data-sources.md` §9 rewritten to the implemented reality + changelog row.